### PR TITLE
WIP: Let rust-analyzer complete checks before gathering diagnostics

### DIFF
--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -7,6 +7,7 @@ import { formatResponse } from "../../core/prompts/responses"
 import { DecorationController } from "./DecorationController"
 import * as diff from "diff"
 import { diagnosticsToProblemsString, getNewDiagnostics } from "../diagnostics"
+import delay from "delay"
 
 export const DIFF_VIEW_URI_SCHEME = "cline-diff"
 
@@ -156,6 +157,35 @@ export class DiffViewProvider {
 
 		await vscode.window.showTextDocument(vscode.Uri.file(absolutePath), { preview: false })
 		await this.closeAllDiffViews()
+
+		try {
+			// Wait for Rust Analyzer to catch up before fetching post-diagnostics
+			const rustAnalyzer = vscode.extensions.getExtension("rust-lang.rust-analyzer")
+			if (rustAnalyzer?.isActive && (absolutePath.endsWith(".rs") || absolutePath.endsWith(".toml"))) {
+				const startTime = Date.now()
+				const INITIAL_DELAY = 1000 // 1 second
+				const TIMEOUT = 30000 // 30 seconds
+
+				// Give rust-analyzer some time to detect changes
+				while (rustAnalyzer.exports?.lastStatus?.quiescent === true) {
+					if (Date.now() - startTime > INITIAL_DELAY) {
+						break
+					}
+					await delay(50)
+				}
+
+				while (rustAnalyzer.exports?.lastStatus?.quiescent === false) {
+					if (Date.now() - startTime > TIMEOUT) {
+						console.error("Timeout waiting for rust-analyzer to become quiescent")
+						console.dir(rustAnalyzer.exports?.lastStatus)
+						break
+					}
+					await delay(100)
+				}
+			}
+		} catch (err) {
+			// We don't mind if rust-analyzer isn't installed
+		}
 
 		/*
 		Getting diagnostics before and after the file edit is a better approach than


### PR DESCRIPTION
## Description

Need some feedback on this approach since I'm quite new to VSCode extension development and interoperability.

**Problem**: When Rust Analyzer runs its checks on save, it can take quite long on slower hardware. Agent often does not have diagnostics when proceeding.

**This PR**: If Rust Analyzer extension is running, we give it 1 second grace period to start up (show as busy) and wait maximum 30 seconds for it to complete before collecting diagnostics. Separate spin-up loop allows step to complete quickly on faster hardware. Currently usable.

**Minimum Changes**: Want to put this behind a configuration flag first and make timing values configurable.

**Questions**:
- Would the project be okay to accept this kind of tool-specific change?
- Are there other tools/extensions running on save that make it worth making this feature more generic?
- Is this the correct place to add the hook?
- Is there a better way to wait for changes? I could not identify a subscription mechanism.

## Type of change

<!-- Please ignore options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Ad-hoc usage on rust and non-rust projects

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation