### PR TITLE
Add Option to Disable PowerLevel10k Theme

### DIFF
--- a/.changeset/add-disable-powerlevel10k-theme-6ab6338.md
+++ b/.changeset/add-disable-powerlevel10k-theme-6ab6338.md
@@ -1,0 +1,9 @@
+---
+"version": "minor"
+---
+
+Disable PowerLevel10k Theme
+
+- **WHAT the change is:** Added an option to disable the PowerLevel10k theme in the terminal.
+- **WHY the change was made:** To provide users with more customization options for their terminal appearance.
+- **HOW a consumer should update their code:** Users can disable the PowerLevel10k theme via the settings UI in the extension.

--- a/.changeset/add-disable-powerlevel10k-theme-6ab6338.md
+++ b/.changeset/add-disable-powerlevel10k-theme-6ab6338.md
@@ -5,5 +5,5 @@
 Disable PowerLevel10k Theme
 
 - **WHAT the change is:** Added an option to disable the PowerLevel10k theme in the terminal.
-- **WHY the change was made:** To provide users with more customization options for their terminal appearance.
+- **WHY the change was made:** To provide users the ability to use the Roo-Code without having to remove the theme PowerLevel10k.
 - **HOW a consumer should update their code:** Users can disable the PowerLevel10k theme via the settings UI in the extension.

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -123,6 +123,7 @@ type GlobalStateKey =
 	| "customModes" // Array of custom modes
 	| "unboundModelId"
 	| "unboundModelInfo"
+	| "disablePowerLevel10k" // Disable Power Level 10k
 
 export const GlobalFileNames = {
 	apiConversationHistory: "api_conversation_history.json",
@@ -1472,6 +1473,10 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 							await this.postStateToWebview()
 						}
 						break
+					case "disablePowerLevel10k":
+						await this.updateGlobalState("disablePowerLevel10k", message.bool ?? false)
+						await this.postStateToWebview()
+						break
 					case "deleteCustomMode":
 						if (message.slug) {
 							const answer = await vscode.window.showInformationMessage(
@@ -2214,6 +2219,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			enhancementApiConfigId,
 			autoApprovalEnabled,
 			experiments,
+			disablePowerLevel10k,
 		} = await this.getState()
 
 		const allowedCommands = vscode.workspace.getConfiguration("roo-cline").get<string[]>("allowedCommands") || []
@@ -2260,6 +2266,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			customModes: await this.customModesManager.getCustomModes(),
 			experiments: experiments ?? experimentDefault,
 			mcpServers: this.mcpHub?.getServers() ?? [],
+			disablePowerLevel10k: disablePowerLevel10k ?? false,
 		}
 	}
 
@@ -2391,6 +2398,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			unboundApiKey,
 			unboundModelId,
 			unboundModelInfo,
+			disablePowerLevel10k,
 		] = await Promise.all([
 			this.getGlobalState("apiProvider") as Promise<ApiProvider | undefined>,
 			this.getGlobalState("apiModelId") as Promise<string | undefined>,
@@ -2467,6 +2475,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			this.getSecret("unboundApiKey") as Promise<string | undefined>,
 			this.getGlobalState("unboundModelId") as Promise<string | undefined>,
 			this.getGlobalState("unboundModelInfo") as Promise<ModelInfo | undefined>,
+			this.getGlobalState("disablePowerLevel10k") as Promise<boolean | undefined>,
 		])
 
 		let apiProvider: ApiProvider
@@ -2589,6 +2598,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			experiments: experiments ?? experimentDefault,
 			autoApprovalEnabled: autoApprovalEnabled ?? false,
 			customModes,
+			disablePowerLevel10k: disablePowerLevel10k ?? false,
 		}
 	}
 

--- a/src/core/webview/__tests__/ClineProvider.test.ts
+++ b/src/core/webview/__tests__/ClineProvider.test.ts
@@ -351,6 +351,7 @@ describe("ClineProvider", () => {
 			mode: defaultModeSlug,
 			customModes: [],
 			experiments: experimentDefault,
+			disablePowerLevel10k: false,
 		}
 
 		const message: ExtensionMessage = {

--- a/src/integrations/terminal/TerminalManager.ts
+++ b/src/integrations/terminal/TerminalManager.ts
@@ -14,6 +14,7 @@ TerminalProcess extends EventEmitter and implements Promise:
 - Emits 'line' events with output while promise is pending
 - process.continue() resolves promise and stops event emission
 - Allows real-time output handling or background execution
+- Retrieve missed output later
 
 getUnretrievedOutput() fetches latest output for ongoing commands
 

--- a/src/integrations/terminal/TerminalProcess.ts
+++ b/src/integrations/terminal/TerminalProcess.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "events"
 import stripAnsi from "strip-ansi"
 import * as vscode from "vscode"
+import { ClineProvider } from "../../core/webview/ClineProvider"
 
 export interface TerminalProcessEvents {
 	line: [line: string]
@@ -27,8 +28,14 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 	// 	super()
 
 	async run(terminal: vscode.Terminal, command: string) {
+		const visibleProvider = await ClineProvider.getInstance()
+		const state = await visibleProvider?.getState()
+		const disablePowerLevel10k = state?.disablePowerLevel10k ?? false
 		if (terminal.shellIntegration && terminal.shellIntegration.executeCommand) {
-			const execution = terminal.shellIntegration.executeCommand(command)
+			const prefix = "prompt_powerlevel9k_teardown &&"
+			const execution = terminal.shellIntegration.executeCommand(
+				disablePowerLevel10k ? `${prefix} ${command}` : command,
+			)
 			const stream = execution.read()
 			// todo: need to handle errors
 			let isFirstChunk = true

--- a/src/integrations/terminal/__tests__/TerminalProcess.test.ts
+++ b/src/integrations/terminal/__tests__/TerminalProcess.test.ts
@@ -3,7 +3,13 @@ import * as vscode from "vscode"
 import { EventEmitter } from "events"
 
 // Mock vscode
-jest.mock("vscode")
+jest.mock("vscode", () => ({
+	...jest.requireActual("vscode"),
+	commands: {
+		...jest.requireActual("vscode").commands,
+		executeCommand: jest.fn().mockImplementation(() => Promise.resolve()),
+	},
+}))
 
 describe("TerminalProcess", () => {
 	let terminalProcess: TerminalProcess

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -126,7 +126,7 @@ export interface ExtensionState {
 	autoApprovalEnabled?: boolean
 	customModes: ModeConfig[]
 	toolRequirements?: Record<string, boolean> // Map of tool names to their requirements (e.g. {"apply_diff": true} if diffEnabled)
-	disablePowerLevel10k?: boolean // Whether to disable Powerlevel10k theme
+	disablePowerLevel10k: boolean // Whether to disable Powerlevel10k theme
 }
 
 export interface ClineMessage {

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -45,6 +45,7 @@ export interface ExtensionMessage {
 		| "unboundModels"
 		| "refreshUnboundModels"
 		| "currentCheckpointUpdated"
+		| "disablePowerLevel10k"
 	text?: string
 	action?:
 		| "chatButtonClicked"
@@ -125,6 +126,7 @@ export interface ExtensionState {
 	autoApprovalEnabled?: boolean
 	customModes: ModeConfig[]
 	toolRequirements?: Record<string, boolean> // Map of tool names to their requirements (e.g. {"apply_diff": true} if diffEnabled)
+	disablePowerLevel10k?: boolean // Whether to disable Powerlevel10k theme
 }
 
 export interface ClineMessage {

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -90,6 +90,7 @@ export interface WebviewMessage {
 		| "openCustomModesSettings"
 		| "checkpointDiff"
 		| "checkpointRestore"
+		| "disablePowerLevel10k"
 	text?: string
 	disabled?: boolean
 	askResponse?: ClineAskResponse

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -63,6 +63,8 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 		setExperimentEnabled,
 		alwaysAllowModeSwitch,
 		setAlwaysAllowModeSwitch,
+		disablePowerLevel10k,
+		setDisablePowerLevel10k,
 	} = useExtensionState()
 	const [apiErrorMessage, setApiErrorMessage] = useState<string | undefined>(undefined)
 	const [modelIdErrorMessage, setModelIdErrorMessage] = useState<string | undefined>(undefined)
@@ -111,6 +113,9 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 			})
 
 			vscode.postMessage({ type: "alwaysAllowModeSwitch", bool: alwaysAllowModeSwitch })
+
+			vscode.postMessage({ type: "disablePowerLevel10k", bool: disablePowerLevel10k })
+
 			onDone()
 		}
 	}
@@ -734,6 +739,24 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 									}
 								/>
 							))}
+					</div>
+				</div>
+				<div style={{ marginBottom: 40 }}>
+					<h3 style={{ color: "var(--vscode-foreground)", margin: "0 0 15px 0" }}>Terminal Settings</h3>
+					<div style={{ marginBottom: 15 }}>
+						<VSCodeCheckbox
+							checked={disablePowerLevel10k}
+							onChange={(e: any) => setDisablePowerLevel10k(e.target.checked)}>
+							<span style={{ fontWeight: "500" }}>Disable PowerLevel10k</span>
+						</VSCodeCheckbox>
+						<p
+							style={{
+								fontSize: "12px",
+								marginTop: "5px",
+								color: "var(--vscode-descriptionForeground)",
+							}}>
+							When enabled, Roo will disable the PowerLevel10k theme in the terminal.
+						</p>
 					</div>
 				</div>
 

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -293,6 +293,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		fuzzyMatchThreshold: state.fuzzyMatchThreshold,
 		writeDelayMs: state.writeDelayMs,
 		screenshotQuality: state.screenshotQuality,
+		disablePowerLevel10k: state.disablePowerLevel10k,
 		setExperimentEnabled: (id, enabled) =>
 			setState((prevState) => ({ ...prevState, experiments: { ...prevState.experiments, [id]: enabled } })),
 		setApiConfiguration: (value) =>

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -79,6 +79,8 @@ export interface ExtensionStateContextType extends ExtensionState {
 	handleInputChange: (field: keyof ApiConfiguration, softUpdate?: boolean) => (event: any) => void
 	customModes: ModeConfig[]
 	setCustomModes: (value: ModeConfig[]) => void
+	disablePowerLevel10k: boolean
+	setDisablePowerLevel10k: (value: boolean) => void
 }
 
 export const ExtensionStateContext = createContext<ExtensionStateContextType | undefined>(undefined)
@@ -114,6 +116,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		enhancementApiConfigId: "",
 		autoApprovalEnabled: false,
 		customModes: [],
+		disablePowerLevel10k: false,
 	})
 
 	const [didHydrateState, setDidHydrateState] = useState(false)
@@ -335,6 +338,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		setAutoApprovalEnabled: (value) => setState((prevState) => ({ ...prevState, autoApprovalEnabled: value })),
 		handleInputChange,
 		setCustomModes: (value) => setState((prevState) => ({ ...prevState, customModes: value })),
+		setDisablePowerLevel10k: (value) => setState((prevState) => ({ ...prevState, disablePowerLevel10k: value })),
 	}
 
 	return <ExtensionStateContext.Provider value={contextValue}>{children}</ExtensionStateContext.Provider>


### PR DESCRIPTION
# Add Option to Disable PowerLevel10k Theme

### Motivation

When using zsh with the popular PowerLevel10k theme on Linux, some users encounter issues that force them to either disable the theme or switch shells. This PR introduces a new option that allows users to disable the PowerLevel10k theme without changing their shell, thereby providing a smoother experience and preserving user preferences.

### Summary of Changes

- **Global State Update:**  
  - Introduced a new global state key (`disablePowerLevel10k`) in `ClineProvider.ts` to manage the theme setting.
  - Enhanced state management methods to integrate this new option.

- **Terminal Process Adjustment:**  
  - Updated `TerminalProcess.ts` to check the `disablePowerLevel10k` state and conditionally prepend commands with `prompt_powerlevel9k_teardown` when the option is enabled.

- **UI Enhancements:**  
  - Modified `SettingsView.tsx` to include a checkbox for toggling the PowerLevel10k theme.
  - Provided user-friendly descriptive text explaining the effect of disabling the theme.

- **Message Interface Extensions:**  
  - Added `"disablePowerLevel10k"` as a new message type in both `ExtensionMessage.ts` and `WebviewMessage.ts` to facilitate proper communication between components.
  - Extended the `ExtensionState` and `ExtensionStateContextType` interfaces to support this new state.

### Related Issues

This PR is related to issues [#637](https://github.com/RooVetGit/Roo-Code/issues/637) and [#225](https://github.com/RooVetGit/Roo-Code/issues/225), where users discussed challenges with the PowerLevel10k theme on zsh.

### Testing

1. **UI Verification:**  
   - Navigate to the settings view and toggle the new checkbox.
   - Confirm that the checkbox correctly reflects and updates the `disablePowerLevel10k` state.

2. **Terminal Behavior:**  
   - With the option enabled, open a new terminal instance and verify that the command is prepended with `prompt_powerlevel9k_teardown`, thereby disabling the PowerLevel10k theme.
   - With the option disabled, confirm that the terminal launches without any alterations to the command.

### Additional Notes

This is my first contribution to the repository. I appreciate any further feedback or adjustments needed to align with the project's standard PR format. Thank you for reviewing this change!
