### PR TITLE
Set CWD of MCP server for single-root workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"@google-cloud/vertexai": "^1.9.3",
 				"@google/generative-ai": "^0.18.0",
 				"@mistralai/mistralai": "^1.3.6",
-				"@modelcontextprotocol/sdk": "^1.0.1",
+				"@modelcontextprotocol/sdk": "^1.5.0",
 				"@types/clone-deep": "^4.0.4",
 				"@types/pdf-parse": "^1.1.4",
 				"@types/tmp": "^0.2.6",
@@ -4080,13 +4080,37 @@
 			"integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="
 		},
 		"node_modules/@modelcontextprotocol/sdk": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.0.3.tgz",
-			"integrity": "sha512-2as3cX/VJ0YBHGmdv3GFyTpoM8q2gqE98zh3Vf1NwnsSY0h3mvoO07MUzfygCKkWsFjcZm4otIiqD6Xh7kiSBQ==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.5.0.tgz",
+			"integrity": "sha512-IJ+5iVVs8FCumIHxWqpwgkwOzyhtHVKy45s6Ug7Dv0MfRpaYisH8QQ87rIWeWdOzlk8sfhitZ7HCyQZk7d6b8w==",
+			"license": "MIT",
 			"dependencies": {
 				"content-type": "^1.0.5",
+				"eventsource": "^3.0.2",
 				"raw-body": "^3.0.0",
-				"zod": "^3.23.8"
+				"zod": "^3.23.8",
+				"zod-to-json-schema": "^3.24.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
+			"version": "3.24.2",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+			"integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
+			"version": "3.24.1",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.1.tgz",
+			"integrity": "sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w==",
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.24.1"
 			}
 		},
 		"node_modules/@noble/ciphers": {
@@ -8442,6 +8466,27 @@
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
 			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
 			"dev": true
+		},
+		"node_modules/eventsource": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.5.tgz",
+			"integrity": "sha512-LT/5J605bx5SNyE+ITBDiM3FxffBiq9un7Vx0EwMDM3vg8sWKx/tO2zC+LMqZ+smAM0F2hblaDZUVZF0te2pSw==",
+			"license": "MIT",
+			"dependencies": {
+				"eventsource-parser": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/eventsource-parser": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.0.tgz",
+			"integrity": "sha512-T1C0XCUimhxVQzW4zFipdx0SficT651NnkR0ZSH3yQwh+mFMdLfgjABVi4YtMTtaL4s168593DaoaRLMqryavA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			}
 		},
 		"node_modules/execa": {
 			"version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -268,7 +268,7 @@
 		"@google/generative-ai": "^0.18.0",
 		"@google-cloud/vertexai": "^1.9.3",
 		"@mistralai/mistralai": "^1.3.6",
-		"@modelcontextprotocol/sdk": "^1.0.1",
+		"@modelcontextprotocol/sdk": "^1.5.0",
 		"@types/clone-deep": "^4.0.4",
 		"@types/pdf-parse": "^1.1.4",
 		"@types/tmp": "^0.2.6",

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -270,8 +270,11 @@ export class McpHub {
 	private getDefaultCwd() {
 		const paths = vscode.workspace.workspaceFolders
 		if (paths?.length === 1) {
+			// In workspaces with a single folder, we can safely use it as the default CWD for MCP servers
 			return paths[0].uri.fsPath
 		}
+		// Otherwise we return undefined, which means the MCP process will be spawned with
+		// NodeJS default CWD, i.e. process.cwd()
 		return undefined
 	}
 

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -172,6 +172,7 @@ export class McpHub {
 					// ...(process.env.NODE_PATH ? { NODE_PATH: process.env.NODE_PATH } : {}),
 				},
 				stderr: "pipe", // necessary for stderr to be available
+				cwd: config.cwd ?? this.getDefaultCwd(),
 			})
 
 			transport.onerror = async (error) => {
@@ -264,6 +265,14 @@ export class McpHub {
 			}
 			throw error
 		}
+	}
+
+	private getDefaultCwd() {
+		const paths = vscode.workspace.workspaceFolders
+		if (paths?.length === 1) {
+			return paths[0].uri.fsPath
+		}
+		return undefined
 	}
 
 	private appendErrorMessage(connection: McpConnection, error: string) {


### PR DESCRIPTION
## Description
It's useful to have the MCP process started in the workspace directory, so the process can rely on local configuration files.

For example, I use [ASDF](https://asdf-vm.com/) to manage NodeJS version in a project. By setting the CWD to be the current workspace, an MCP that runs `npx` will use the node version defined for the project.

This is a very recent addition to the [@modelcontextprotocol/sdk](https://github.com/modelcontextprotocol/typescript-sdk) so I updated it to version 1.5.0.

When we do not specify the CWD, the MCP server is spawned at `process.cwd()`, which (in my machine at least) returns `/`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] ? **Breaking change (fix or feature that would cause existing functionality to not work as expected):**
  - This has the potential to change behaviour, if some MCP out there was relying on being run at the `/` path.
  - This seems unlikely, but if we want to be really strict about making this non-breaking, we could keep the current behaviour if `config.cwd` is undefined. We would then only apply the new behaviour if `config.cwd === <some_special_value>` e.g. `"{workspaceDir}"`.
- [ ] This change requires a documentation update

## How Has This Been Tested?
Tested the extension locally and found that it now starts an MCP with the correct CWD.

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Sets CWD for MCP servers to workspace directory in single-root workspaces and updates SDK to version 1.5.0.
> 
>   - **Behavior**:
>     - Sets CWD for MCP servers to workspace directory in single-root workspaces in `McpHub.ts`.
>     - Defaults to `process.cwd()` if no workspace or multiple workspaces.
>   - **Dependencies**:
>     - Updates `@modelcontextprotocol/sdk` to version 1.5.0 in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 00e9c7b9b32bf6aa2aaa7c16e8dcc3911d95d6ee. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->