### PR TITLE
New Setting: Post Edit Delay

### DIFF
--- a/.changeset/kind-dogs-rescue.md
+++ b/.changeset/kind-dogs-rescue.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Added new setting: "Post Edit Delay" which allows a configurable amount of delay (in seconds) to occur after Roo edits any file during a task.

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -3149,8 +3149,9 @@ export class Cline {
 		}
 
 		details += "\n\n# VSCode Open Tabs"
-		const { maxOpenTabsContext } = (await this.providerRef.deref()?.getState()) ?? {}
+		const { maxOpenTabsContext, postEditDelaySeconds } = (await this.providerRef.deref()?.getState()) ?? {}
 		const maxTabs = maxOpenTabsContext ?? 20
+		const postEditDelay = postEditDelaySeconds ?? 0
 		const openTabs = vscode.window.tabGroups.all
 			.flatMap((group) => group.tabs)
 			.map((tab) => (tab.input as vscode.TabInputText)?.uri?.fsPath)
@@ -3167,6 +3168,11 @@ export class Cline {
 		const busyTerminals = this.terminalManager.getTerminals(true)
 		const inactiveTerminals = this.terminalManager.getTerminals(false)
 		// const allTerminals = [...busyTerminals, ...inactiveTerminals]
+	
+		if (postEditDelay > 0 && this.didEditFile)
+		{
+			await delay(postEditDelay * 1000)
+		}
 
 		if (busyTerminals.length > 0 && this.didEditFile) {
 			//  || this.didEditFile

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -111,6 +111,7 @@ type GlobalStateKey =
 	| "alwaysApproveResubmit"
 	| "requestDelaySeconds"
 	| "rateLimitSeconds"
+	| "postEditDelaySeconds"
 	| "currentApiConfigName"
 	| "listApiConfigMeta"
 	| "vsCodeLmModelSelector"
@@ -1046,6 +1047,9 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						await this.updateGlobalState("rateLimitSeconds", message.value ?? 0)
 						await this.postStateToWebview()
 						break
+					case "postEditDelaySeconds":
+						await this.updateGlobalState("postEditDelaySeconds", message.value ?? 0)
+						await this.postStateToWebview()
 					case "preferredLanguage":
 						await this.updateGlobalState("preferredLanguage", message.text)
 						await this.postStateToWebview()
@@ -2370,6 +2374,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			alwaysApproveResubmit,
 			requestDelaySeconds,
 			rateLimitSeconds,
+			postEditDelaySeconds,
 			currentApiConfigName,
 			listApiConfigMeta,
 			mode,
@@ -2418,6 +2423,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			alwaysApproveResubmit: alwaysApproveResubmit ?? false,
 			requestDelaySeconds: requestDelaySeconds ?? 10,
 			rateLimitSeconds: rateLimitSeconds ?? 0,
+			postEditDelaySeconds: postEditDelaySeconds ?? 0,
 			currentApiConfigName: currentApiConfigName ?? "default",
 			listApiConfigMeta: listApiConfigMeta ?? [],
 			mode: mode ?? defaultModeSlug,
@@ -2547,6 +2553,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			alwaysApproveResubmit,
 			requestDelaySeconds,
 			rateLimitSeconds,
+			postEditDelaySeconds,
 			currentApiConfigName,
 			listApiConfigMeta,
 			vsCodeLmModelSelector,
@@ -2629,6 +2636,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			this.getGlobalState("alwaysApproveResubmit") as Promise<boolean | undefined>,
 			this.getGlobalState("requestDelaySeconds") as Promise<number | undefined>,
 			this.getGlobalState("rateLimitSeconds") as Promise<number | undefined>,
+			this.getGlobalState("postEditDelaySeconds") as Promise<number | undefined>,
 			this.getGlobalState("currentApiConfigName") as Promise<string | undefined>,
 			this.getGlobalState("listApiConfigMeta") as Promise<ApiConfigMeta[] | undefined>,
 			this.getGlobalState("vsCodeLmModelSelector") as Promise<vscode.LanguageModelChatSelector | undefined>,
@@ -2768,6 +2776,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			alwaysApproveResubmit: alwaysApproveResubmit ?? false,
 			requestDelaySeconds: Math.max(5, requestDelaySeconds ?? 10),
 			rateLimitSeconds: rateLimitSeconds ?? 0,
+			postEditDelaySeconds: postEditDelaySeconds ?? 0,
 			currentApiConfigName: currentApiConfigName ?? "default",
 			listApiConfigMeta: listApiConfigMeta ?? [],
 			modeApiConfigs: modeApiConfigs ?? ({} as Record<Mode, string>),

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1050,6 +1050,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 					case "postEditDelaySeconds":
 						await this.updateGlobalState("postEditDelaySeconds", message.value ?? 0)
 						await this.postStateToWebview()
+						break
 					case "preferredLanguage":
 						await this.updateGlobalState("preferredLanguage", message.text)
 						await this.postStateToWebview()

--- a/src/core/webview/__tests__/ClineProvider.test.ts
+++ b/src/core/webview/__tests__/ClineProvider.test.ts
@@ -377,6 +377,7 @@ describe("ClineProvider", () => {
 			enableMcpServerCreation: false,
 			requestDelaySeconds: 5,
 			rateLimitSeconds: 0,
+			postEditDelaySeconds: 0,
 			mode: defaultModeSlug,
 			customModes: [],
 			experiments: experimentDefault,

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -106,6 +106,7 @@ export interface ExtensionState {
 	alwaysAllowModeSwitch?: boolean
 	requestDelaySeconds: number
 	rateLimitSeconds: number // Minimum time between successive requests (0 = disabled)
+	postEditDelaySeconds: number // Time to delay after any file edit (0 = disabled)
 	uriScheme?: string
 	currentTaskItem?: HistoryItem
 	allowedCommands?: string[]

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -75,6 +75,7 @@ export interface WebviewMessage {
 		| "alwaysApproveResubmit"
 		| "requestDelaySeconds"
 		| "rateLimitSeconds"
+		| "postEditDelaySeconds"
 		| "setApiConfigPassword"
 		| "requestVsCodeLmModels"
 		| "mode"

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -60,6 +60,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone },
 		maxOpenTabsContext,
 		mcpEnabled,
 		rateLimitSeconds,
+		postEditDelaySeconds,
 		requestDelaySeconds,
 		screenshotQuality,
 		soundEnabled,
@@ -160,6 +161,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone },
 			vscode.postMessage({ type: "alwaysApproveResubmit", bool: alwaysApproveResubmit })
 			vscode.postMessage({ type: "requestDelaySeconds", value: requestDelaySeconds })
 			vscode.postMessage({ type: "rateLimitSeconds", value: rateLimitSeconds })
+			vscode.postMessage({ type: "postEditDelaySeconds", value: postEditDelaySeconds})
 			vscode.postMessage({ type: "maxOpenTabsContext", value: maxOpenTabsContext })
 			vscode.postMessage({ type: "currentApiConfigName", text: currentApiConfigName })
 			vscode.postMessage({
@@ -696,6 +698,26 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone },
 						</div>
 						<p style={{ fontSize: "12px", marginTop: "5px", color: "var(--vscode-descriptionForeground)" }}>
 							Minimum time between API requests.
+						</p>
+					</div>
+					<div style={{ marginBottom: 15 }}>
+						<div style={{ display: "flex", flexDirection: "column", gap: "5px" }}>
+							<span style={{ fontWeight: "500" }}>Post Edit Delay</span>
+							<div style={{ display: "flex", alignItems: "center", gap: "5px" }}>
+								<input
+									type="range"
+									min="0"
+									max="60"
+									step="0.5"
+									value={postEditDelaySeconds}
+									onChange={(e) => setCachedStateField("postEditDelaySeconds", parseFloat(e.target.value))}
+									className="h-2 focus:outline-0 w-4/5 accent-vscode-button-background"
+								/>
+								<span style={{ ...sliderLabelStyle }}>{postEditDelaySeconds}s</span>
+							</div>
+						</div>
+						<p style={{ fontSize: "12px", marginTop: "5px", color: "var(--vscode-descriptionForeground)" }}>
+							Time to delay after any file edit.
 						</p>
 					</div>
 					<div style={{ marginBottom: 15 }}>

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -161,7 +161,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone },
 			vscode.postMessage({ type: "alwaysApproveResubmit", bool: alwaysApproveResubmit })
 			vscode.postMessage({ type: "requestDelaySeconds", value: requestDelaySeconds })
 			vscode.postMessage({ type: "rateLimitSeconds", value: rateLimitSeconds })
-			vscode.postMessage({ type: "postEditDelaySeconds", value: postEditDelaySeconds})
+			vscode.postMessage({ type: "postEditDelaySeconds", value: postEditDelaySeconds })
 			vscode.postMessage({ type: "maxOpenTabsContext", value: maxOpenTabsContext })
 			vscode.postMessage({ type: "currentApiConfigName", text: currentApiConfigName })
 			vscode.postMessage({
@@ -710,8 +710,11 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone },
 									max="60"
 									step="0.5"
 									value={postEditDelaySeconds}
-									onChange={(e) => setCachedStateField("postEditDelaySeconds", parseFloat(e.target.value))}
+									onChange={(e) =>
+										setCachedStateField("postEditDelaySeconds", parseFloat(e.target.value))
+									}
 									className="h-2 focus:outline-0 w-4/5 accent-vscode-button-background"
+									aria-label="Post edit delay in seconds"
 								/>
 								<span style={{ ...sliderLabelStyle }}>{postEditDelaySeconds}s</span>
 							</div>

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -68,6 +68,8 @@ export interface ExtensionStateContextType extends ExtensionState {
 	setRequestDelaySeconds: (value: number) => void
 	rateLimitSeconds: number
 	setRateLimitSeconds: (value: number) => void
+	postEditDelaySeconds: number
+	setPostEditDelaySeconds: (value: number) => void
 	setCurrentApiConfigName: (value: string) => void
 	setListApiConfigMeta: (value: ApiConfigMeta[]) => void
 	onUpdateApiConfig: (apiConfig: ApiConfiguration) => void
@@ -108,6 +110,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		alwaysApproveResubmit: false,
 		requestDelaySeconds: 5,
 		rateLimitSeconds: 0, // Minimum time between successive requests (0 = disabled)
+		postEditDelaySeconds: 0, // Time to delay after editing a file (0 = disabled)
 		currentApiConfigName: "default",
 		listApiConfigMeta: [],
 		mode: defaultModeSlug,
@@ -314,6 +317,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		setAlwaysApproveResubmit: (value) => setState((prevState) => ({ ...prevState, alwaysApproveResubmit: value })),
 		setRequestDelaySeconds: (value) => setState((prevState) => ({ ...prevState, requestDelaySeconds: value })),
 		setRateLimitSeconds: (value) => setState((prevState) => ({ ...prevState, rateLimitSeconds: value })),
+		setPostEditDelaySeconds: (value) => setState((prevState) => ({ ...prevState, postEditDelaySeconds: value })),
 		setCurrentApiConfigName: (value) => setState((prevState) => ({ ...prevState, currentApiConfigName: value })),
 		setListApiConfigMeta,
 		onUpdateApiConfig,


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

Add a new setting: Post Edit Delay.

This new setting will force Roo to wait some number of second after any file edit. This can be useful for a number of reasons, like giving the user time to see what was changed before Roo moves on (and give a chance to stop the task), or allow language servers time to catch up (which should happen automatically but some misbehave [I am looking at you C#]).

## Type of change

<!-- Please ignore options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Added the new setting and tested in VSCode validating the following:
- Setting is available in settings page
- Setting persists between sessions
- Delay is being triggered after file edits

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [x] (not needed) I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Additional context

N/A

## Related Issues

N/A

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->
