### PR TITLE
Roo environment details compression - WIP

### DIFF
--- a/src/core/sliding-window/__tests__/context-compression.test.ts
+++ b/src/core/sliding-window/__tests__/context-compression.test.ts
@@ -1,0 +1,340 @@
+import { describe, it } from "mocha"
+import "should"
+import cloneDeep from "clone-deep"
+import { Anthropic } from "@anthropic-ai/sdk"
+import { compressConversationHistory, compressEnvironmentDetails } from "../core/sliding-window/context-compression"
+
+// Helper function to get the last message with environment details
+function getLastEnvironmentMessage(messages: Anthropic.Messages.MessageParam[]): string {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const msg = messages[i]
+		if (Array.isArray(msg.content)) {
+			for (const block of msg.content) {
+				if (block.type === "text" && block.text.includes("<environment_details>")) {
+					return block.text
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// Helper function to get all non-last environment messages
+function getPriorEnvironmentMessages(messages: Anthropic.Messages.MessageParam[]): string[] {
+	const result: string[] = []
+	let lastEnvIndex = -1
+
+	// Find last environment message first
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const msg = messages[i]
+		if (Array.isArray(msg.content)) {
+			for (const block of msg.content) {
+				if (block.type === "text" && block.text.includes("<environment_details>")) {
+					lastEnvIndex = i
+					break
+				}
+			}
+		}
+		if (lastEnvIndex !== -1) {
+			break
+		}
+	}
+
+	// Collect all prior environment messages
+	for (let i = 0; i < lastEnvIndex; i++) {
+		const msg = messages[i]
+		if (Array.isArray(msg.content)) {
+			for (const block of msg.content) {
+				if (block.type === "text" && block.text.includes("<environment_details>")) {
+					result.push(block.text)
+				}
+			}
+		}
+	}
+
+	return result
+}
+
+// Helper function to verify environment details compression
+function verifyEnvironmentCompression(
+	beforeObj: Anthropic.Messages.MessageParam[],
+	afterObj: Anthropic.Messages.MessageParam[],
+): void {
+	// Get last and prior messages after compression
+	const lastMsg = getLastEnvironmentMessage(afterObj)
+	const priorMsgs = getPriorEnvironmentMessages(afterObj)
+
+	// Verify prior messages only have UTC UNIX timestamp
+	for (const msg of priorMsgs) {
+		should(msg).match(/UTC UNIX: \d+/)
+		should(msg).not.match(/VSCode Visible Files/)
+		should(msg).not.match(/VSCode Open Tabs/)
+		should(msg).not.match(/Current Working Directory/)
+	}
+
+	// Verify last message has full details
+	should(lastMsg).match(/\d+\/\d+\/\d+,\s*(?:\d+:\d+:\d+(?:\s*[AP]M)?|\d+:\d+:\d+)/)
+
+	// Verify original structure is preserved in before object
+	const lastBeforeMsg = getLastEnvironmentMessage(beforeObj)
+	const priorBeforeMsgs = getPriorEnvironmentMessages(beforeObj)
+
+	// Original messages should have their full content
+	for (const msg of priorBeforeMsgs) {
+		should(msg).match(/\d+\/\d+\/\d+,\s*(?:\d+:\d+:\d+(?:\s*[AP]M)?|\d+:\d+:\d+)/)
+	}
+	should(lastBeforeMsg).match(/\d+\/\d+\/\d+,\s*(?:\d+:\d+:\d+(?:\s*[AP]M)?|\d+:\d+:\d+)/)
+}
+
+describe("Context Compression", () => {
+	describe("Conversation History Compression", () => {
+		it("should compress conversation history correctly", () => {
+			// Create test messages with environment details
+			const messages: Anthropic.Messages.MessageParam[] = [
+				{
+					role: "user",
+					content: [
+						{
+							type: "text",
+							text: "message 1\n<environment_details>\n# VSCode Visible Files\nfile1.ts\n\n# Current Time\n2/14/2025, 6:33:59 PM (America/Los_Angeles, UTC-8:00)\n\n# Current Mode\nACT MODE\n</environment_details>",
+						} as Anthropic.Messages.TextBlockParam,
+					],
+				},
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "text",
+							text: "I'll help with that.",
+						} as Anthropic.Messages.TextBlockParam,
+					],
+				},
+				{
+					role: "user",
+					content: [
+						{
+							type: "text",
+							text: "message 2\n<environment_details>\n# VSCode Visible Files\nfile2.ts\n\n# Current Time\n2/14/2025, 6:34:00 PM (America/Los_Angeles, UTC-8:00)\n\n# Current Mode\nPLAN MODE\n</environment_details>",
+						} as Anthropic.Messages.TextBlockParam,
+					],
+				},
+			]
+
+			// Make a deep copy for comparison
+			const originalMessages = cloneDeep(messages)
+
+			// Compress and get serialized structures with debug files
+			const { before, after } = compressConversationHistory(
+				messages,
+				"test_task",
+				`conversation_before_compression_${Date.now()}_basic_compression.json`,
+				`conversation_after_compression_${Date.now()}_basic_compression.json`,
+			)
+
+			// Parse the structures
+			const beforeObj = JSON.parse(before)
+			const afterObj = JSON.parse(after)
+
+			// Verify compression using helper functions
+			verifyEnvironmentCompression(beforeObj, afterObj)
+
+			// Additional verification specific to this test
+			const lastMsg = getLastEnvironmentMessage(afterObj)
+			should(lastMsg).match(/VSCode Visible Files\s*file2\.ts/)
+			should(lastMsg).match(/Current Mode\s*PLAN MODE/)
+		})
+
+		it("should accumulate sections in last message", () => {
+			const messages: Anthropic.Messages.MessageParam[] = [
+				{
+					role: "user",
+					content: [
+						{
+							type: "text",
+							text: "message 1\n<environment_details>\n# Current Time\n2/14/2025, 6:33:59 PM (America/Los_Angeles, UTC-8:00)\n\n# VSCode Visible Files\nfile1.ts\n</environment_details>",
+						} as Anthropic.Messages.TextBlockParam,
+					],
+				},
+				{
+					role: "user",
+					content: [
+						{
+							type: "text",
+							text: "message 2\n<environment_details>\n# Current Time\n2/14/2025, 6:34:00 PM (America/Los_Angeles, UTC-8:00)\n\n# VSCode Open Tabs\ntab1.ts\n</environment_details>",
+						} as Anthropic.Messages.TextBlockParam,
+					],
+				},
+				{
+					role: "user",
+					content: [
+						{
+							type: "text",
+							text: "message 3\n<environment_details>\n# Current Time\n2/14/2025, 6:34:01 PM (America/Los_Angeles, UTC-8:00)\n</environment_details>",
+						} as Anthropic.Messages.TextBlockParam,
+					],
+				},
+			]
+
+			// Make a deep copy for comparison
+			const originalMessages = cloneDeep(messages)
+
+			// Compress and get serialized structures with debug files
+			const { before, after } = compressConversationHistory(
+				messages,
+				"test_task",
+				`conversation_before_compression_${Date.now()}_section_accumulation.json`,
+				`conversation_after_compression_${Date.now()}_section_accumulation.json`,
+			)
+
+			// Parse the structures
+			const beforeObj = JSON.parse(before)
+			const afterObj = JSON.parse(after)
+
+			// Verify compression using helper functions
+			verifyEnvironmentCompression(beforeObj, afterObj)
+
+			// Additional verification specific to this test
+			const lastMsg = getLastEnvironmentMessage(afterObj)
+			should(lastMsg).match(/VSCode Visible Files\s*file1\.ts/)
+			should(lastMsg).match(/VSCode Open Tabs\s*tab1\.ts/)
+		})
+
+		it("should handle 12-hour and 24-hour time formats", () => {
+			const messages: Anthropic.Messages.MessageParam[] = [
+				{
+					role: "user",
+					content: [
+						{
+							type: "text",
+							text: "message 1\n<environment_details>\n# Current Time\n2/14/2025, 6:33:59 PM (America/Los_Angeles, UTC-8:00)\n</environment_details>",
+						} as Anthropic.Messages.TextBlockParam,
+					],
+				},
+				{
+					role: "user",
+					content: [
+						{
+							type: "text",
+							text: "message 2\n<environment_details>\n# Current Time\n2/14/2025, 18:34:00 (America/Los_Angeles, UTC-8:00)\n</environment_details>",
+						} as Anthropic.Messages.TextBlockParam,
+					],
+				},
+			]
+
+			// Make a deep copy for comparison
+			const originalMessages = cloneDeep(messages)
+
+			// Compress and get serialized structures with debug files
+			const { before, after } = compressConversationHistory(
+				messages,
+				"test_task",
+				`conversation_before_compression_${Date.now()}_time_formats.json`,
+				`conversation_after_compression_${Date.now()}_time_formats.json`,
+			)
+
+			// Parse the structures
+			const beforeObj = JSON.parse(before)
+			const afterObj = JSON.parse(after)
+
+			// Verify compression using helper functions
+			verifyEnvironmentCompression(beforeObj, afterObj)
+
+			// Additional verification specific to this test
+			const lastMsg = getLastEnvironmentMessage(afterObj)
+			should(lastMsg).match(/2\/14\/2025,\s*18:34:00/)
+		})
+
+		it("should handle working directory content", () => {
+			const messages: Anthropic.Messages.MessageParam[] = [
+				{
+					role: "user",
+					content: [
+						{
+							type: "text",
+							text: "message 1\n<environment_details>\n# Current Time\n2/14/2025, 6:33:59 PM (America/Los_Angeles, UTC-8:00)\n\n# Current Working Directory (/path/to/dir) Files\nfile1.txt\ndir1/\n  subfile1.txt\n</environment_details>",
+						} as Anthropic.Messages.TextBlockParam,
+					],
+				},
+				{
+					role: "user",
+					content: [
+						{
+							type: "text",
+							text: "message 2\n<environment_details>\n# Current Time\n2/14/2025, 6:34:00 PM (America/Los_Angeles, UTC-8:00)\n\n# Current Working Directory (/path/to/dir) Files\nfile1.txt\ndir1/\n  subfile1.txt\n  subfile2.txt\n</environment_details>",
+						} as Anthropic.Messages.TextBlockParam,
+					],
+				},
+			]
+
+			// Make a deep copy for comparison
+			const originalMessages = cloneDeep(messages)
+
+			// Compress and get serialized structures with debug files
+			const { before, after } = compressConversationHistory(
+				messages,
+				"test_task",
+				`conversation_before_compression_${Date.now()}_working_directory.json`,
+				`conversation_after_compression_${Date.now()}_working_directory.json`,
+			)
+
+			// Parse the structures
+			const beforeObj = JSON.parse(before)
+			const afterObj = JSON.parse(after)
+
+			// Verify compression using helper functions
+			verifyEnvironmentCompression(beforeObj, afterObj)
+
+			// Additional verification specific to this test
+			const lastMsg = getLastEnvironmentMessage(afterObj)
+			should(lastMsg).match(/Current Working Directory/)
+			should(lastMsg).match(/file1\.txt/)
+			should(lastMsg).match(/dir1\/\s*subfile1\.txt\s*subfile2\.txt/)
+		})
+
+		it("should handle empty VSCode sections", () => {
+			const messages: Anthropic.Messages.MessageParam[] = [
+				{
+					role: "user",
+					content: [
+						{
+							type: "text",
+							text: "message 1\n<environment_details>\n# Current Time\n2/14/2025, 6:33:59 PM (America/Los_Angeles, UTC-8:00)\n\n# VSCode Visible Files\n(No visible files)\n\n# VSCode Open Tabs\n(No open tabs)\n\n# Current Mode\nACT MODE\n</environment_details>",
+						} as Anthropic.Messages.TextBlockParam,
+					],
+				},
+				{
+					role: "user",
+					content: [
+						{
+							type: "text",
+							text: "message 2\n<environment_details>\n# Current Time\n2/14/2025, 6:34:00 PM (America/Los_Angeles, UTC-8:00)\n\n# VSCode Visible Files\n(No visible files)\n\n# VSCode Open Tabs\n(No open tabs)\n</environment_details>",
+						} as Anthropic.Messages.TextBlockParam,
+					],
+				},
+			]
+
+			// Make a deep copy for comparison
+			const originalMessages = cloneDeep(messages)
+
+			// Compress and get serialized structures with debug files
+			const { before, after } = compressConversationHistory(
+				messages,
+				"test_task",
+				`conversation_before_compression_${Date.now()}_empty_vscode.json`,
+				`conversation_after_compression_${Date.now()}_empty_vscode.json`,
+			)
+
+			// Parse the structures
+			const beforeObj = JSON.parse(before)
+			const afterObj = JSON.parse(after)
+
+			// Verify compression using helper functions
+			verifyEnvironmentCompression(beforeObj, afterObj)
+
+			// Additional verification specific to this test
+			const lastMsg = getLastEnvironmentMessage(afterObj)
+			should(lastMsg).match(/VSCode Visible Files\s*\(No visible files\)/)
+			should(lastMsg).match(/VSCode Open Tabs\s*\(No open tabs\)/)
+		})
+	})
+})

--- a/src/core/sliding-window/__tests__/context-compression.test.ts
+++ b/src/core/sliding-window/__tests__/context-compression.test.ts
@@ -2,7 +2,22 @@ import { describe, it } from "mocha"
 import "should"
 import cloneDeep from "clone-deep"
 import { Anthropic } from "@anthropic-ai/sdk"
+import * as path from "path"
 import { compressConversationHistory, compressEnvironmentDetails } from "../core/sliding-window/context-compression"
+
+// Helper function to generate debug filenames
+function getDebugFilenames(testType: string): { before: string; after: string } {
+	const timestamp = Date.now()
+	const date = new Date(timestamp)
+	const dateStr = date.toISOString().split("T")[0].split("-").slice(1).join("-") // Get MM-DD format
+	const timeStr = date.toTimeString().split(" ")[0].replace(/:/g, "-") // Get HH-MM-SS format
+
+	const baseFilename = `${testType}_${timestamp}_${dateStr}--${timeStr}.json`
+	return {
+		before: path.join("debug", `conv_before_compression_${baseFilename}`),
+		after: path.join("debug", `conv_after_compression_${baseFilename}`),
+	}
+}
 
 // Helper function to get the last message with environment details
 function getLastEnvironmentMessage(messages: Anthropic.Messages.MessageParam[]): string {
@@ -124,12 +139,8 @@ describe("Context Compression", () => {
 			const originalMessages = cloneDeep(messages)
 
 			// Compress and get serialized structures with debug files
-			const { before, after } = compressConversationHistory(
-				messages,
-				"test_task",
-				`conversation_before_compression_${Date.now()}_basic_compression.json`,
-				`conversation_after_compression_${Date.now()}_basic_compression.json`,
-			)
+			const { before: beforeFile, after: afterFile } = getDebugFilenames("basic_compression")
+			const { before, after } = compressConversationHistory(messages, "test_task", beforeFile, afterFile)
 
 			// Parse the structures
 			const beforeObj = JSON.parse(before)
@@ -179,12 +190,8 @@ describe("Context Compression", () => {
 			const originalMessages = cloneDeep(messages)
 
 			// Compress and get serialized structures with debug files
-			const { before, after } = compressConversationHistory(
-				messages,
-				"test_task",
-				`conversation_before_compression_${Date.now()}_section_accumulation.json`,
-				`conversation_after_compression_${Date.now()}_section_accumulation.json`,
-			)
+			const { before: beforeFile, after: afterFile } = getDebugFilenames("section_accumulation")
+			const { before, after } = compressConversationHistory(messages, "test_task", beforeFile, afterFile)
 
 			// Parse the structures
 			const beforeObj = JSON.parse(before)
@@ -225,12 +232,8 @@ describe("Context Compression", () => {
 			const originalMessages = cloneDeep(messages)
 
 			// Compress and get serialized structures with debug files
-			const { before, after } = compressConversationHistory(
-				messages,
-				"test_task",
-				`conversation_before_compression_${Date.now()}_time_formats.json`,
-				`conversation_after_compression_${Date.now()}_time_formats.json`,
-			)
+			const { before: beforeFile, after: afterFile } = getDebugFilenames("time_formats")
+			const { before, after } = compressConversationHistory(messages, "test_task", beforeFile, afterFile)
 
 			// Parse the structures
 			const beforeObj = JSON.parse(before)
@@ -270,12 +273,8 @@ describe("Context Compression", () => {
 			const originalMessages = cloneDeep(messages)
 
 			// Compress and get serialized structures with debug files
-			const { before, after } = compressConversationHistory(
-				messages,
-				"test_task",
-				`conversation_before_compression_${Date.now()}_working_directory.json`,
-				`conversation_after_compression_${Date.now()}_working_directory.json`,
-			)
+			const { before: beforeFile, after: afterFile } = getDebugFilenames("working_directory")
+			const { before, after } = compressConversationHistory(messages, "test_task", beforeFile, afterFile)
 
 			// Parse the structures
 			const beforeObj = JSON.parse(before)
@@ -317,12 +316,8 @@ describe("Context Compression", () => {
 			const originalMessages = cloneDeep(messages)
 
 			// Compress and get serialized structures with debug files
-			const { before, after } = compressConversationHistory(
-				messages,
-				"test_task",
-				`conversation_before_compression_${Date.now()}_empty_vscode.json`,
-				`conversation_after_compression_${Date.now()}_empty_vscode.json`,
-			)
+			const { before: beforeFile, after: afterFile } = getDebugFilenames("empty_vscode")
+			const { before, after } = compressConversationHistory(messages, "test_task", beforeFile, afterFile)
 
 			// Parse the structures
 			const beforeObj = JSON.parse(before)
@@ -372,12 +367,8 @@ describe("Context Compression", () => {
 			const originalMessages = cloneDeep(messages)
 
 			// Compress and get serialized structures with debug files
-			const { before, after } = compressConversationHistory(
-				messages,
-				"test_task",
-				`conversation_before_compression_${Date.now()}_task_resumption.json`,
-				`conversation_after_compression_${Date.now()}_task_resumption.json`,
-			)
+			const { before: beforeFile, after: afterFile } = getDebugFilenames("task_resumption")
+			const { before, after } = compressConversationHistory(messages, "test_task", beforeFile, afterFile)
 
 			// Parse the structures
 			const beforeObj = JSON.parse(before)
@@ -450,12 +441,8 @@ describe("Context Compression", () => {
 			const originalMessages = cloneDeep(messages)
 
 			// Compress and get serialized structures with debug files
-			const { before, after } = compressConversationHistory(
-				messages,
-				"test_task",
-				`conversation_before_compression_${Date.now()}_task_resumption_non_last.json`,
-				`conversation_after_compression_${Date.now()}_task_resumption_non_last.json`,
-			)
+			const { before: beforeFile, after: afterFile } = getDebugFilenames("task_resumption_non_last")
+			const { before, after } = compressConversationHistory(messages, "test_task", beforeFile, afterFile)
 
 			// Parse the structures
 			const beforeObj = JSON.parse(before)

--- a/src/core/sliding-window/context-compression.ts
+++ b/src/core/sliding-window/context-compression.ts
@@ -1,0 +1,229 @@
+import { Anthropic } from "@anthropic-ai/sdk"
+import fs from "fs/promises"
+import * as path from "path"
+
+function parseTimeToUnix(timeStr: string): string {
+	// Match both formats:
+	// "2/14/2025, 6:33:59 PM (America/Los_Angeles, UTC-8:00)"  // 12-hour
+	// "2/14/2025, 18:33:59 (America/Los_Angeles, UTC-8:00)"    // 24-hour
+	const match = timeStr.match(/^(\d+)\/(\d+)\/(\d+),\s*(\d+):(\d+):(\d+)(?:\s*(AM|PM))?\s*\(/)
+	if (!match) {
+		return timeStr
+	}
+
+	const [_, month, day, year, hour, minute, second, period] = match
+
+	// Handle hours based on format
+	let hours = parseInt(hour)
+	if (period) {
+		// 12-hour format
+		if (period === "PM" && hours !== 12) {
+			hours += 12
+		}
+		if (period === "AM" && hours === 12) {
+			hours = 0
+		}
+	}
+	// else: 24-hour format, use hours as-is
+
+	try {
+		const date = new Date(
+			parseInt(year),
+			parseInt(month) - 1, // months are 0-based
+			parseInt(day),
+			hours,
+			parseInt(minute),
+			parseInt(second),
+		)
+		return `UTC UNIX: ${Math.floor(date.getTime() / 1000)}`
+	} catch (e) {
+		return timeStr
+	}
+}
+
+function hasEnvironmentDetails(message: Anthropic.Messages.MessageParam): boolean {
+	if (!Array.isArray(message.content)) {
+		return false
+	}
+
+	for (const block of message.content) {
+		if (block.type === "text" && block.text.includes("<environment_details>")) {
+			return true
+		}
+	}
+	return false
+}
+
+function findLastEnvironmentMessage(messages: Anthropic.Messages.MessageParam[]): number {
+	let lastIndex = -1
+	for (let i = 0; i < messages.length; i++) {
+		if (hasEnvironmentDetails(messages[i])) {
+			lastIndex = i
+		}
+	}
+	return lastIndex
+}
+
+function compressEnvironmentSection(
+	text: string,
+	isLastMessage: boolean,
+	accumulatedMatches: Map<string, string>,
+): string {
+	// Match the entire text structure using DOTALL mode
+	const fullMatch = text.match(/^(.*?)(<environment_details>\n)(.*?)(\n<\/environment_details>)(.*?)$/s)
+	if (!fullMatch) {
+		return text
+	}
+
+	const [_, beforeEnv, envStart, envContent, envEnd, afterEnv] = fullMatch
+
+	if (isLastMessage) {
+		console.log("Last Message Environment Details Before:", envContent)
+	}
+
+	function handleSection(heading: string, content: string, isLast: boolean): string {
+		if (!isLast) {
+			return ""
+		}
+		return `# ${heading}\n${content}\n`
+	}
+
+	function handleTimeSection(heading: string, content: string, isLast: boolean): string {
+		if (isLast) {
+			return `# ${heading}\n${content}\n`
+		}
+		return `# ${heading}\n${parseTimeToUnix(content.trim())}\n`
+	}
+
+	// Define sections with their headings
+	const sectionMatches = [
+		{ heading: "Current Working Directory \\([^)]+\\) Files", handle: handleSection },
+		{ heading: "VSCode Visible Files", handle: handleSection },
+		{ heading: "VSCode Open Tabs", handle: handleSection },
+		{ heading: "Current Mode", handle: handleSection },
+		{ heading: "Current Time", handle: handleTimeSection },
+	]
+
+	// Process each section
+	let processedContent = envContent
+	const patternEnd = "(?=\\n# |$)"
+
+	for (const section of sectionMatches) {
+		// Use DOTALL mode for section matching
+		const regex = new RegExp(`\\n*#\\s*${section.heading}\\s*?\\n(.*?)${patternEnd}`, "s")
+		const match = processedContent.match(regex)
+
+		console.log(`Processing section "${section.heading}":`)
+		console.log("- Regex pattern:", regex)
+		console.log("- Match found:", !!match)
+		if (match) {
+			console.log("- Matched content:", match[0])
+		}
+
+		if (match) {
+			// Found a match - accumulate it
+			accumulatedMatches.set(section.heading, match[0])
+			console.log(`- Added to accumulated matches: ${section.heading}\n  ${match[0]}`)
+
+			if (!isLastMessage) {
+				processedContent = processedContent.replace(regex, (match, content) =>
+					section.handle(section.heading, content, false),
+				)
+				console.log("- Processed for non-last message")
+			}
+		} else if (isLastMessage && accumulatedMatches.has(section.heading)) {
+			// No match in last message but we have accumulated content - append it
+			processedContent += accumulatedMatches.get(section.heading)
+		}
+	}
+
+	// Clean up newlines and reconstruct with regex
+	processedContent = processedContent.replace(/\n{2,}/g, "\n")
+	const result = beforeEnv + envStart + processedContent.trim() + envEnd + afterEnv
+
+	if (isLastMessage) {
+		console.log("Last Message Environment Details After:", result)
+		console.log("Accumulated Matches (last):", Object.fromEntries(accumulatedMatches))
+	}
+
+	return result
+}
+
+export function compressEnvironmentDetails(messages: Anthropic.Messages.MessageParam[]): void {
+	const lastEnvIndex = findLastEnvironmentMessage(messages)
+	if (lastEnvIndex === -1) {
+		console.warn("No <environment_details> were found in any message")
+		return
+	}
+
+	const accumulatedMatches = new Map<string, string>()
+
+	for (let i = 0; i < messages.length; i++) {
+		if (!Array.isArray(messages[i].content) || messages[i].role !== "user") {
+			continue
+		}
+
+		for (let j = 0; j < messages[i].content.length; j++) {
+			const content = messages[i].content[j]
+			if (typeof content === "string" || content.type !== "text") {
+				continue
+			}
+
+			content.text = compressEnvironmentSection(content.text, i === lastEnvIndex, accumulatedMatches)
+		}
+	}
+}
+
+/**
+ * Compresses conversation history by replacing duplicate content with references
+ * and converting tool operations to more compact formats. Modifies messages in place.
+ */
+/**
+ * Serializes message objects to pretty-printed JSON for debugging
+ */
+function serializeMessages(messages: Anthropic.Messages.MessageParam[]): string {
+	return JSON.stringify(messages, null, 2)
+}
+
+/**
+ * Compresses conversation history and returns the before/after message structures
+ */
+export function compressConversationHistory(
+	messages: Anthropic.Messages.MessageParam[],
+	taskId: string,
+	beforeName?: string,
+	afterName?: string,
+): { before: string; after: string } {
+	// Serialize messages BEFORE compression
+	const beforeJson = serializeMessages(messages)
+
+	// Compress environment details in place
+	compressEnvironmentDetails(messages)
+
+	// Serialize messages AFTER compression
+	const afterJson = serializeMessages(messages)
+
+	if (beforeName && afterName) {
+		// beforeName and afterName are absolute paths
+		const beforeDir = path.dirname(beforeName)
+		const afterDir = path.dirname(afterName)
+
+		// Create directories if they don't exist
+		fs.mkdir(beforeDir, { recursive: true })
+			.then(() => fs.mkdir(afterDir, { recursive: true }))
+			.then(() => {
+				fs.writeFile(beforeName, beforeJson)
+				fs.writeFile(afterName, afterJson)
+
+				console.log(`Compression debug files:
+Before: ${beforeName}
+After:  ${afterName}`)
+			})
+			.catch((err) => console.error("Error writing debug files:", err))
+	}
+
+	return {
+		before: beforeJson,
+		after: afterJson,
+	}
+}


### PR DESCRIPTION
## Context

Implementing environment details compression to reduce token usage while preserving full context. Environment details contain redundant information across messages that can be optimized without losing information.

## How to Test

This is not ready for public testing, I am putting it up to prevent duplicate effort.

## Implementation

The compression strategy:

1. Deduplicated into last message:
   - "Current Working Directory Files" 
   - "VSCode Visible Files"
   - "VSCode Open Tabs"
   - "Current Mode"
   - and others that I find along the way.
   
2. Kept in each message:
   - "Actively Running Terminals" (maintains command output)
   - "Inactive Terminals" (maintains command output)

3. Special handling - "Current Time":
   - Appears in all messages
       - In the future we might create a flag for time since not all users need time in their context history 
   - Prior messages: Convert to UTC UNIX timestamp
   - Last message: Keep human-readable format
   
4. Section cleanup:
   - Remove empty VSCode sections entirely
   - Strip redundant "(No visible files)" and "(No open tabs)" markers
      
## Screenshots

n/a

