### PR TITLE
Hack: remove line numbers from reads and diffs

### DIFF
--- a/src/core/diff/strategies/multi-search-replace.ts
+++ b/src/core/diff/strategies/multi-search-replace.ts
@@ -423,8 +423,10 @@ Only use a single line of '=======' between search and replacement content, beca
 			let searchStartIndex = 0
 			let searchEndIndex = resultLines.length
 
+			startLine = endLine = 0
+
 			// Validate and handle line range if provided
-			if (startLine) {
+			if (startLine && endLine) {
 				// Convert to 0-based index
 				const exactStartIndex = startLine - 1
 				const searchLen = searchLines.length
@@ -483,7 +485,7 @@ Only use a single line of '=======' between search and replacement content, beca
 				} else {
 					// No match found with either method
 					const originalContentSection =
-						startLine !== undefined && endLine !== undefined
+						startLine && endLine
 							? `\n\nOriginal Content:\n${addLineNumbers(
 									resultLines
 										.slice(

--- a/src/core/prompts/tools/index.ts
+++ b/src/core/prompts/tools/index.ts
@@ -37,7 +37,7 @@ const toolDescriptionMap: Record<string, (args: ToolArgs) => string | undefined>
 	access_mcp_resource: (args) => getAccessMcpResourceDescription(args),
 	switch_mode: () => getSwitchModeDescription(),
 	new_task: (args) => getNewTaskDescription(args),
-	// insert_content: (args) => getInsertContentDescription(args),
+	insert_content: (args) => getInsertContentDescription(args),
 	search_and_replace: (args) => getSearchAndReplaceDescription(args),
 	apply_diff: (args) =>
 		args.diffStrategy ? args.diffStrategy.getToolDescription({ cwd: args.cwd, toolOptions: args.toolOptions }) : "",

--- a/src/core/prompts/tools/index.ts
+++ b/src/core/prompts/tools/index.ts
@@ -37,7 +37,7 @@ const toolDescriptionMap: Record<string, (args: ToolArgs) => string | undefined>
 	access_mcp_resource: (args) => getAccessMcpResourceDescription(args),
 	switch_mode: () => getSwitchModeDescription(),
 	new_task: (args) => getNewTaskDescription(args),
-	insert_content: (args) => getInsertContentDescription(args),
+	// insert_content: (args) => getInsertContentDescription(args),
 	search_and_replace: (args) => getSearchAndReplaceDescription(args),
 	apply_diff: (args) =>
 		args.diffStrategy ? args.diffStrategy.getToolDescription({ cwd: args.cwd, toolOptions: args.toolOptions }) : "",

--- a/src/core/prompts/tools/insert-content.ts
+++ b/src/core/prompts/tools/insert-content.ts
@@ -29,5 +29,23 @@ Example for appending to the end of file:
 // This is the end of the file
 </content>
 </insert_content>
+
+Example for creating very large files that exceed output limits:
+<write_to_file>
+<path>src/large_file.txt</path>
+<content>
+// This is the beginning of a very large file but you must terminate prematurely in order for line_count to be produced:
+</content>
+<line_count>100</line_count>
+</write_to_file>
+
+Then use insert_content to append the rest of the content starting immediately where you left off; repeat as many times as necessary:
+<insert_content>
+<path>src/large_file.txt</path>
+<line>0</line>
+<content>
+// This is a continuation of very large file
+</content>
+</insert_content>
 `
 }

--- a/src/core/tools/insertContentTool.ts
+++ b/src/core/tools/insertContentTool.ts
@@ -78,6 +78,13 @@ export async function insertContentTool(
 			return
 		}
 
+		if (lineNumber !== 0) {
+			cline.consecutiveMistakeCount++
+			cline.recordToolError("insert_content")
+			pushToolResult(formatResponse.toolError("Invalid line number: only append is supported so line must be 0"))
+			return
+		}
+
 		cline.consecutiveMistakeCount = 0
 
 		// Read the file

--- a/src/core/tools/writeToFileTool.ts
+++ b/src/core/tools/writeToFileTool.ts
@@ -69,6 +69,15 @@ export async function writeToFileTool(
 	const fullPath = relPath ? path.resolve(cline.cwd, removeClosingTag("path", relPath)) : ""
 	const isOutsideWorkspace = isPathOutsideWorkspace(fullPath)
 
+	if (fileExists) {
+		pushToolResult(
+			formatResponse.toolError(
+				`File '${relPath}' already exists, write_to_file failed: You must use the 'apply_diff' tool to change an existing file.`,
+			),
+		)
+		return
+	}
+
 	const sharedMessageProps: ClineSayTool = {
 		tool: fileExists ? "editedExistingFile" : "newFileCreated",
 		path: getReadablePath(cline.cwd, removeClosingTag("path", relPath)),

--- a/src/integrations/misc/extract-text.ts
+++ b/src/integrations/misc/extract-text.ts
@@ -55,6 +55,8 @@ async function extractTextFromIPYNB(filePath: string): Promise<string> {
 }
 
 export function addLineNumbers(content: string, startLine: number = 1): string {
+	return content
+
 	// If content is empty, return empty string - empty files should not have line numbers
 	// If content is empty but startLine > 1, return "startLine | " because we know the file is not empty
 	// but the content is empty at that line offset


### PR DESCRIPTION
# Roo read_file/apply_diff Hackfest

Today @hannesrudolph and I we are troubleshooting strange Claude hallucinations related to line numbers and other issues.  While troubleshooting that, I hacked together these few commits.

**Do not merge this!** --- at least not yet. I am sharing this with the community for feedback and for others who may wish to test the behavior.

## what does it do?

This branch:

1. Absolutely forces the model to use `apply_diff` if a file exists (write_to_file is denied)
2. Prevents line numbers from being added to reads
3. Relaxes line number checking in multi-diff

## Background

While there are places where line numbers are useful, line numbers in file reads have a few issues:

- Line numbers increase context usage
- They can confuse the replacement algorithm, especially when a line legitimately starts with a `|` symbol because it interferes with the line number separator and confuses the model (just try to edit a markdown table, I dare you...)
- Modifying the file content (ie, line numbers) gives an alternate perception to the model vs. reality, and then we have to trust the model (!?) to exclude those line numbers later for operations...
- Line numbers can distract the model from the content (123 | Squirrel!):
     1. When trying to produce exact search content for replacement
     2. When trying to consider indentation, especially since our line number markers contains spaces: `123 | `

There _are_ places where line numbers are useful, here are a few:

- Search results
- Declaration details
- `read_file` start/end ranges

So, I have built this into my daily driver and will report my findings and continue to refine this. 

## Long term goals

- Configuration options to make this possible for use by others without breaking features 
- clean up the pr to make it not so hackish 
- others?