### PR TITLE
Some renames around 'partialMessage' extension message

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -364,9 +364,9 @@ export class Cline extends EventEmitter<ClineEvents> {
 		await this.saveClineMessages()
 	}
 
-	private async updateClineMessage(partialMessage: ClineMessage) {
-		await this.providerRef.deref()?.postMessageToWebview({ type: "partialMessage", partialMessage })
-		this.emit("message", { action: "updated", message: partialMessage })
+	private async updateClineMessage(message: ClineMessage) {
+		await this.providerRef.deref()?.postMessageToWebview({ type: "updatePartialMessage", clineMessage: message })
+		this.emit("message", { action: "updated", message })
 	}
 
 	private getTokenUsage() {

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -39,7 +39,7 @@ export interface ExtensionMessage {
 		| "theme"
 		| "workspaceUpdated"
 		| "invoke"
-		| "partialMessage"
+		| "updatePartialMessage"
 		| "openRouterModels"
 		| "glamaModels"
 		| "unboundModels"
@@ -89,7 +89,7 @@ export interface ExtensionMessage {
 		isActive: boolean
 		path?: string
 	}>
-	partialMessage?: ClineMessage
+	clineMessage?: ClineMessage
 	openRouterModels?: Record<string, ModelInfo>
 	glamaModels?: Record<string, ModelInfo>
 	unboundModels?: Record<string, ModelInfo>

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -200,14 +200,14 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 					setOpenedTabs(tabs)
 					break
 				}
-				case "partialMessage": {
-					const partialMessage = message.partialMessage!
+				case "updatePartialMessage": {
+					const clineMessage = message.clineMessage!
 					setState((prevState) => {
 						// worth noting it will never be possible for a more up-to-date message to be sent here or in normal messages post since the presentAssistantContent function uses lock
-						const lastIndex = findLastIndex(prevState.clineMessages, (msg) => msg.ts === partialMessage.ts)
+						const lastIndex = findLastIndex(prevState.clineMessages, (msg) => msg.ts === clineMessage.ts)
 						if (lastIndex !== -1) {
 							const newClineMessages = [...prevState.clineMessages]
-							newClineMessages[lastIndex] = partialMessage
+							newClineMessages[lastIndex] = clineMessage
 							return { ...prevState, clineMessages: newClineMessages }
 						}
 						return prevState


### PR DESCRIPTION
## Context

When I read `Cline.updateClineMessage` the first time I was a little surprised, because it was called with `ClineMessage` that was `!partial`.
I hope this rename is reasonable and will improve readability of codebase.

I'm only unsure about `ExtensionMessage.partialMessage` → `ExtensionMessage.clineMessage` rename. If you have better ideas on naming this field, I'm open to changes to this PR.

## Implementation

Trivial.

## Screenshots

None.

## How to Test

Not tested.

## Get in Touch

Discord user: wkordalski

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Renames 'partialMessage' to 'clineMessage' and updates message type to 'updatePartialMessage' across `Cline.ts`, `ExtensionMessage.ts`, and `ExtensionStateContext.tsx` for improved readability.
> 
>   - **Renames**:
>     - `partialMessage` to `clineMessage` in `ExtensionMessage` and `ExtensionStateContext.tsx`.
>     - Message type `"partialMessage"` to `"updatePartialMessage"` in `ExtensionMessage` and `Cline.ts`.
>   - **Behavior**:
>     - `updateClineMessage()` in `Cline.ts` now uses `"updatePartialMessage"` type and `clineMessage` field.
>     - `handleMessage()` in `ExtensionStateContext.tsx` updated to handle `"updatePartialMessage"` with `clineMessage` field.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d021f0a9ad35d00138370319243fe25e540c0305. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->