### PR TITLE
feat: Enable computer use support for gemini-2.5-pro-exp-03-25

### DIFF
--- a/.changeset/moody-gorillas-marry.md
+++ b/.changeset/moody-gorillas-marry.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": minor
+---
+
+Enable computer use support for gemini-2.5-pro-exp-03-25

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -468,6 +468,7 @@ export const vertexModels = {
 		maxTokens: 65_535,
 		contextWindow: 1_048_576,
 		supportsImages: true,
+		supportsComputerUse: true,
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,


### PR DESCRIPTION
## Context

Adds the `supportsComputerUse: true` flag for the `gemini-2.5-pro-exp-03-25` model.

This model has demonstrated browser interaction capabilities when used via an MCP server, so this change enables the corresponding built-in browser tool flag in Cline's settings.

## Implementation

Added `supportsComputerUse: true` to the model's definition in `src/shared/api.ts`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `supportsComputerUse: true` to `gemini-2.5-pro-exp-03-25` model in `api.ts`, enabling browser interaction.
> 
>   - **Behavior**:
>     - Adds `supportsComputerUse: true` to `gemini-2.5-pro-exp-03-25` model in `api.ts`, enabling browser interaction via MCP server.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5eec7fbd6e28be504dc9a311c92e981ce00a133e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->