### PR TITLE
feat: Add a way to limit the number of results from search_files tool

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -582,6 +582,14 @@ export class Cline extends EventEmitter<ClineEvents> {
 		return formatResponse.toolError(formatResponse.missingToolParameterError(paramName))
 	}
 
+	async sayAndCreateInvalidNumberParamError(toolName: ToolUseName, paramName: string) {
+		await this.say(
+			"error",
+			`Roo tried to use ${toolName} with invalid number value for parameter '${paramName}'. Retrying...`,
+		)
+		return formatResponse.toolError(formatResponse.invalidNumberParameterError(paramName))
+	}
+
 	// Task lifecycle
 
 	private async startTask(task?: string, images?: string[]): Promise<void> {

--- a/src/core/assistant-message/index.ts
+++ b/src/core/assistant-message/index.ts
@@ -38,6 +38,7 @@ export const toolParamNames = [
 	"line_count",
 	"regex",
 	"file_pattern",
+	"max_results",
 	"recursive",
 	"action",
 	"url",
@@ -100,7 +101,7 @@ export interface InsertCodeBlockToolUse extends ToolUse {
 
 export interface SearchFilesToolUse extends ToolUse {
 	name: "search_files"
-	params: Partial<Pick<Record<ToolParamName, string>, "path" | "regex" | "file_pattern">>
+	params: Partial<Pick<Record<ToolParamName, string>, "path" | "regex" | "file_pattern" | "max_results">>
 }
 
 export interface ListFilesToolUse extends ToolUse {

--- a/src/core/prompts/__tests__/__snapshots__/system.test.ts.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system.test.ts.snap
@@ -90,18 +90,21 @@ Parameters:
 - path: (required) The path of the directory to search in (relative to the current working directory /test/path). This directory will be recursively searched.
 - regex: (required) The regular expression pattern to search for. Uses Rust regex syntax.
 - file_pattern: (optional) Glob pattern to filter files (e.g., '*.ts' for TypeScript files). If not provided, it will search all files (*).
+- max_results: (optional) The maximum number of results to return. If not provided, a reasonable default is used.
 Usage:
 <search_files>
 <path>Directory path here</path>
 <regex>Your regex pattern here</regex>
 <file_pattern>file pattern here (optional)</file_pattern>
+<max_results>Maximum number of results to return (optional)</max_results>
 </search_files>
 
-Example: Requesting to search for all .ts files in the current directory
+Example: Requesting to search for all .ts files in the current directory and limit the result count to 100.
 <search_files>
 <path>.</path>
 <regex>.*</regex>
 <file_pattern>*.ts</file_pattern>
+<max_results>100</max_results>
 </search_files>
 
 ## list_files
@@ -487,18 +490,21 @@ Parameters:
 - path: (required) The path of the directory to search in (relative to the current working directory /test/path). This directory will be recursively searched.
 - regex: (required) The regular expression pattern to search for. Uses Rust regex syntax.
 - file_pattern: (optional) Glob pattern to filter files (e.g., '*.ts' for TypeScript files). If not provided, it will search all files (*).
+- max_results: (optional) The maximum number of results to return. If not provided, a reasonable default is used.
 Usage:
 <search_files>
 <path>Directory path here</path>
 <regex>Your regex pattern here</regex>
 <file_pattern>file pattern here (optional)</file_pattern>
+<max_results>Maximum number of results to return (optional)</max_results>
 </search_files>
 
-Example: Requesting to search for all .ts files in the current directory
+Example: Requesting to search for all .ts files in the current directory and limit the result count to 100.
 <search_files>
 <path>.</path>
 <regex>.*</regex>
 <file_pattern>*.ts</file_pattern>
+<max_results>100</max_results>
 </search_files>
 
 ## list_files
@@ -973,18 +979,21 @@ Parameters:
 - path: (required) The path of the directory to search in (relative to the current working directory /test/path). This directory will be recursively searched.
 - regex: (required) The regular expression pattern to search for. Uses Rust regex syntax.
 - file_pattern: (optional) Glob pattern to filter files (e.g., '*.ts' for TypeScript files). If not provided, it will search all files (*).
+- max_results: (optional) The maximum number of results to return. If not provided, a reasonable default is used.
 Usage:
 <search_files>
 <path>Directory path here</path>
 <regex>Your regex pattern here</regex>
 <file_pattern>file pattern here (optional)</file_pattern>
+<max_results>Maximum number of results to return (optional)</max_results>
 </search_files>
 
-Example: Requesting to search for all .ts files in the current directory
+Example: Requesting to search for all .ts files in the current directory and limit the result count to 100.
 <search_files>
 <path>.</path>
 <regex>.*</regex>
 <file_pattern>*.ts</file_pattern>
+<max_results>100</max_results>
 </search_files>
 
 ## list_files
@@ -1423,18 +1432,21 @@ Parameters:
 - path: (required) The path of the directory to search in (relative to the current working directory /test/path). This directory will be recursively searched.
 - regex: (required) The regular expression pattern to search for. Uses Rust regex syntax.
 - file_pattern: (optional) Glob pattern to filter files (e.g., '*.ts' for TypeScript files). If not provided, it will search all files (*).
+- max_results: (optional) The maximum number of results to return. If not provided, a reasonable default is used.
 Usage:
 <search_files>
 <path>Directory path here</path>
 <regex>Your regex pattern here</regex>
 <file_pattern>file pattern here (optional)</file_pattern>
+<max_results>Maximum number of results to return (optional)</max_results>
 </search_files>
 
-Example: Requesting to search for all .ts files in the current directory
+Example: Requesting to search for all .ts files in the current directory and limit the result count to 100.
 <search_files>
 <path>.</path>
 <regex>.*</regex>
 <file_pattern>*.ts</file_pattern>
+<max_results>100</max_results>
 </search_files>
 
 ## list_files
@@ -1820,18 +1832,21 @@ Parameters:
 - path: (required) The path of the directory to search in (relative to the current working directory /test/path). This directory will be recursively searched.
 - regex: (required) The regular expression pattern to search for. Uses Rust regex syntax.
 - file_pattern: (optional) Glob pattern to filter files (e.g., '*.ts' for TypeScript files). If not provided, it will search all files (*).
+- max_results: (optional) The maximum number of results to return. If not provided, a reasonable default is used.
 Usage:
 <search_files>
 <path>Directory path here</path>
 <regex>Your regex pattern here</regex>
 <file_pattern>file pattern here (optional)</file_pattern>
+<max_results>Maximum number of results to return (optional)</max_results>
 </search_files>
 
-Example: Requesting to search for all .ts files in the current directory
+Example: Requesting to search for all .ts files in the current directory and limit the result count to 100.
 <search_files>
 <path>.</path>
 <regex>.*</regex>
 <file_pattern>*.ts</file_pattern>
+<max_results>100</max_results>
 </search_files>
 
 ## list_files
@@ -2217,18 +2232,21 @@ Parameters:
 - path: (required) The path of the directory to search in (relative to the current working directory /test/path). This directory will be recursively searched.
 - regex: (required) The regular expression pattern to search for. Uses Rust regex syntax.
 - file_pattern: (optional) Glob pattern to filter files (e.g., '*.ts' for TypeScript files). If not provided, it will search all files (*).
+- max_results: (optional) The maximum number of results to return. If not provided, a reasonable default is used.
 Usage:
 <search_files>
 <path>Directory path here</path>
 <regex>Your regex pattern here</regex>
 <file_pattern>file pattern here (optional)</file_pattern>
+<max_results>Maximum number of results to return (optional)</max_results>
 </search_files>
 
-Example: Requesting to search for all .ts files in the current directory
+Example: Requesting to search for all .ts files in the current directory and limit the result count to 100.
 <search_files>
 <path>.</path>
 <regex>.*</regex>
 <file_pattern>*.ts</file_pattern>
+<max_results>100</max_results>
 </search_files>
 
 ## list_files
@@ -2614,18 +2632,21 @@ Parameters:
 - path: (required) The path of the directory to search in (relative to the current working directory /test/path). This directory will be recursively searched.
 - regex: (required) The regular expression pattern to search for. Uses Rust regex syntax.
 - file_pattern: (optional) Glob pattern to filter files (e.g., '*.ts' for TypeScript files). If not provided, it will search all files (*).
+- max_results: (optional) The maximum number of results to return. If not provided, a reasonable default is used.
 Usage:
 <search_files>
 <path>Directory path here</path>
 <regex>Your regex pattern here</regex>
 <file_pattern>file pattern here (optional)</file_pattern>
+<max_results>Maximum number of results to return (optional)</max_results>
 </search_files>
 
-Example: Requesting to search for all .ts files in the current directory
+Example: Requesting to search for all .ts files in the current directory and limit the result count to 100.
 <search_files>
 <path>.</path>
 <regex>.*</regex>
 <file_pattern>*.ts</file_pattern>
+<max_results>100</max_results>
 </search_files>
 
 ## list_files
@@ -3060,18 +3081,21 @@ Parameters:
 - path: (required) The path of the directory to search in (relative to the current working directory /test/path). This directory will be recursively searched.
 - regex: (required) The regular expression pattern to search for. Uses Rust regex syntax.
 - file_pattern: (optional) Glob pattern to filter files (e.g., '*.ts' for TypeScript files). If not provided, it will search all files (*).
+- max_results: (optional) The maximum number of results to return. If not provided, a reasonable default is used.
 Usage:
 <search_files>
 <path>Directory path here</path>
 <regex>Your regex pattern here</regex>
 <file_pattern>file pattern here (optional)</file_pattern>
+<max_results>Maximum number of results to return (optional)</max_results>
 </search_files>
 
-Example: Requesting to search for all .ts files in the current directory
+Example: Requesting to search for all .ts files in the current directory and limit the result count to 100.
 <search_files>
 <path>.</path>
 <regex>.*</regex>
 <file_pattern>*.ts</file_pattern>
+<max_results>100</max_results>
 </search_files>
 
 ## list_files
@@ -3525,18 +3549,21 @@ Parameters:
 - path: (required) The path of the directory to search in (relative to the current working directory /test/path). This directory will be recursively searched.
 - regex: (required) The regular expression pattern to search for. Uses Rust regex syntax.
 - file_pattern: (optional) Glob pattern to filter files (e.g., '*.ts' for TypeScript files). If not provided, it will search all files (*).
+- max_results: (optional) The maximum number of results to return. If not provided, a reasonable default is used.
 Usage:
 <search_files>
 <path>Directory path here</path>
 <regex>Your regex pattern here</regex>
 <file_pattern>file pattern here (optional)</file_pattern>
+<max_results>Maximum number of results to return (optional)</max_results>
 </search_files>
 
-Example: Requesting to search for all .ts files in the current directory
+Example: Requesting to search for all .ts files in the current directory and limit the result count to 100.
 <search_files>
 <path>.</path>
 <regex>.*</regex>
 <file_pattern>*.ts</file_pattern>
+<max_results>100</max_results>
 </search_files>
 
 ## list_files
@@ -3971,18 +3998,21 @@ Parameters:
 - path: (required) The path of the directory to search in (relative to the current working directory /test/path). This directory will be recursively searched.
 - regex: (required) The regular expression pattern to search for. Uses Rust regex syntax.
 - file_pattern: (optional) Glob pattern to filter files (e.g., '*.ts' for TypeScript files). If not provided, it will search all files (*).
+- max_results: (optional) The maximum number of results to return. If not provided, a reasonable default is used.
 Usage:
 <search_files>
 <path>Directory path here</path>
 <regex>Your regex pattern here</regex>
 <file_pattern>file pattern here (optional)</file_pattern>
+<max_results>Maximum number of results to return (optional)</max_results>
 </search_files>
 
-Example: Requesting to search for all .ts files in the current directory
+Example: Requesting to search for all .ts files in the current directory and limit the result count to 100.
 <search_files>
 <path>.</path>
 <regex>.*</regex>
 <file_pattern>*.ts</file_pattern>
+<max_results>100</max_results>
 </search_files>
 
 ## list_files
@@ -4464,18 +4494,21 @@ Parameters:
 - path: (required) The path of the directory to search in (relative to the current working directory /test/path). This directory will be recursively searched.
 - regex: (required) The regular expression pattern to search for. Uses Rust regex syntax.
 - file_pattern: (optional) Glob pattern to filter files (e.g., '*.ts' for TypeScript files). If not provided, it will search all files (*).
+- max_results: (optional) The maximum number of results to return. If not provided, a reasonable default is used.
 Usage:
 <search_files>
 <path>Directory path here</path>
 <regex>Your regex pattern here</regex>
 <file_pattern>file pattern here (optional)</file_pattern>
+<max_results>Maximum number of results to return (optional)</max_results>
 </search_files>
 
-Example: Requesting to search for all .ts files in the current directory
+Example: Requesting to search for all .ts files in the current directory and limit the result count to 100.
 <search_files>
 <path>.</path>
 <regex>.*</regex>
 <file_pattern>*.ts</file_pattern>
+<max_results>100</max_results>
 </search_files>
 
 ## list_files
@@ -4903,18 +4936,21 @@ Parameters:
 - path: (required) The path of the directory to search in (relative to the current working directory /test/path). This directory will be recursively searched.
 - regex: (required) The regular expression pattern to search for. Uses Rust regex syntax.
 - file_pattern: (optional) Glob pattern to filter files (e.g., '*.ts' for TypeScript files). If not provided, it will search all files (*).
+- max_results: (optional) The maximum number of results to return. If not provided, a reasonable default is used.
 Usage:
 <search_files>
 <path>Directory path here</path>
 <regex>Your regex pattern here</regex>
 <file_pattern>file pattern here (optional)</file_pattern>
+<max_results>Maximum number of results to return (optional)</max_results>
 </search_files>
 
-Example: Requesting to search for all .ts files in the current directory
+Example: Requesting to search for all .ts files in the current directory and limit the result count to 100.
 <search_files>
 <path>.</path>
 <regex>.*</regex>
 <file_pattern>*.ts</file_pattern>
+<max_results>100</max_results>
 </search_files>
 
 ## list_files
@@ -5462,18 +5498,21 @@ Parameters:
 - path: (required) The path of the directory to search in (relative to the current working directory /test/path). This directory will be recursively searched.
 - regex: (required) The regular expression pattern to search for. Uses Rust regex syntax.
 - file_pattern: (optional) Glob pattern to filter files (e.g., '*.ts' for TypeScript files). If not provided, it will search all files (*).
+- max_results: (optional) The maximum number of results to return. If not provided, a reasonable default is used.
 Usage:
 <search_files>
 <path>Directory path here</path>
 <regex>Your regex pattern here</regex>
 <file_pattern>file pattern here (optional)</file_pattern>
+<max_results>Maximum number of results to return (optional)</max_results>
 </search_files>
 
-Example: Requesting to search for all .ts files in the current directory
+Example: Requesting to search for all .ts files in the current directory and limit the result count to 100.
 <search_files>
 <path>.</path>
 <regex>.*</regex>
 <file_pattern>*.ts</file_pattern>
+<max_results>100</max_results>
 </search_files>
 
 ## list_files
@@ -5935,18 +5974,21 @@ Parameters:
 - path: (required) The path of the directory to search in (relative to the current working directory /test/path). This directory will be recursively searched.
 - regex: (required) The regular expression pattern to search for. Uses Rust regex syntax.
 - file_pattern: (optional) Glob pattern to filter files (e.g., '*.ts' for TypeScript files). If not provided, it will search all files (*).
+- max_results: (optional) The maximum number of results to return. If not provided, a reasonable default is used.
 Usage:
 <search_files>
 <path>Directory path here</path>
 <regex>Your regex pattern here</regex>
 <file_pattern>file pattern here (optional)</file_pattern>
+<max_results>Maximum number of results to return (optional)</max_results>
 </search_files>
 
-Example: Requesting to search for all .ts files in the current directory
+Example: Requesting to search for all .ts files in the current directory and limit the result count to 100.
 <search_files>
 <path>.</path>
 <regex>.*</regex>
 <file_pattern>*.ts</file_pattern>
+<max_results>100</max_results>
 </search_files>
 
 ## list_files
@@ -6306,18 +6348,21 @@ Parameters:
 - path: (required) The path of the directory to search in (relative to the current working directory /test/path). This directory will be recursively searched.
 - regex: (required) The regular expression pattern to search for. Uses Rust regex syntax.
 - file_pattern: (optional) Glob pattern to filter files (e.g., '*.ts' for TypeScript files). If not provided, it will search all files (*).
+- max_results: (optional) The maximum number of results to return. If not provided, a reasonable default is used.
 Usage:
 <search_files>
 <path>Directory path here</path>
 <regex>Your regex pattern here</regex>
 <file_pattern>file pattern here (optional)</file_pattern>
+<max_results>Maximum number of results to return (optional)</max_results>
 </search_files>
 
-Example: Requesting to search for all .ts files in the current directory
+Example: Requesting to search for all .ts files in the current directory and limit the result count to 100.
 <search_files>
 <path>.</path>
 <regex>.*</regex>
 <file_pattern>*.ts</file_pattern>
+<max_results>100</max_results>
 </search_files>
 
 ## list_files

--- a/src/core/prompts/responses.ts
+++ b/src/core/prompts/responses.ts
@@ -35,6 +35,9 @@ Otherwise, if you have not completed the task and do not need additional informa
 	missingToolParameterError: (paramName: string) =>
 		`Missing value for required parameter '${paramName}'. Please retry with complete response.\n\n${toolUseInstructionsReminder}`,
 
+	invalidNumberParameterError: (paramName: string) =>
+		`Incorrect number value for parameter '${paramName}'. Please retry and use a number.`,
+
 	invalidMcpToolArgumentError: (serverName: string, toolName: string) =>
 		`Invalid JSON argument used with ${serverName} for ${toolName}. Please retry with a properly formatted JSON argument.`,
 

--- a/src/core/prompts/tools/search-files.ts
+++ b/src/core/prompts/tools/search-files.ts
@@ -7,17 +7,20 @@ Parameters:
 - path: (required) The path of the directory to search in (relative to the current working directory ${args.cwd}). This directory will be recursively searched.
 - regex: (required) The regular expression pattern to search for. Uses Rust regex syntax.
 - file_pattern: (optional) Glob pattern to filter files (e.g., '*.ts' for TypeScript files). If not provided, it will search all files (*).
+- max_results: (optional) The maximum number of results to return. If not provided, a reasonable default is used.
 Usage:
 <search_files>
 <path>Directory path here</path>
 <regex>Your regex pattern here</regex>
 <file_pattern>file pattern here (optional)</file_pattern>
+<max_results>Maximum number of results to return (optional)</max_results>
 </search_files>
 
-Example: Requesting to search for all .ts files in the current directory
+Example: Requesting to search for all .ts files in the current directory and limit the result count to 100.
 <search_files>
 <path>.</path>
 <regex>.*</regex>
 <file_pattern>*.ts</file_pattern>
+<max_results>100</max_results>
 </search_files>`
 }

--- a/src/core/tools/searchFilesTool.ts
+++ b/src/core/tools/searchFilesTool.ts
@@ -17,11 +17,13 @@ export async function searchFilesTool(
 	const relDirPath: string | undefined = block.params.path
 	const regex: string | undefined = block.params.regex
 	const filePattern: string | undefined = block.params.file_pattern
+	const maxResults: string | undefined = block.params.max_results
 	const sharedMessageProps: ClineSayTool = {
 		tool: "searchFiles",
 		path: getReadablePath(cline.cwd, removeClosingTag("path", relDirPath)),
 		regex: removeClosingTag("regex", regex),
 		filePattern: removeClosingTag("file_pattern", filePattern),
+		maxResults: removeClosingTag("max_results", maxResults),
 	}
 	try {
 		if (block.partial) {
@@ -42,6 +44,12 @@ export async function searchFilesTool(
 				pushToolResult(await cline.sayAndCreateMissingParamError("search_files", "regex"))
 				return
 			}
+			const maxResultsNumber = parseInt(maxResults ?? "")
+			if (maxResults !== undefined && isNaN(maxResultsNumber)) {
+				cline.consecutiveMistakeCount++
+				pushToolResult(await cline.sayAndCreateInvalidNumberParamError("search_files", "max_results"))
+				return
+			}
 			cline.consecutiveMistakeCount = 0
 			const absolutePath = path.resolve(cline.cwd, relDirPath)
 			const results = await regexSearchFiles(
@@ -49,6 +57,7 @@ export async function searchFilesTool(
 				absolutePath,
 				regex,
 				filePattern,
+				maxResultsNumber,
 				cline.rooIgnoreController,
 			)
 			const completeMessage = JSON.stringify({

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -226,6 +226,7 @@ export interface ClineSayTool {
 	content?: string
 	regex?: string
 	filePattern?: string
+	maxResults?: string
 	mode?: string
 	reason?: string
 	isOutsideWorkspace?: boolean


### PR DESCRIPTION
## Context

Currently search_files will produce up to 300 results (an arbitrary number). In cortain cases this is too large number because only first few occurrences are wanted. Unfortunately if too generic search pattern is selected, lots of results will be returned to the LLM and this will reduce remaining context significantly and require more time to process than would be otherwise necessary.

## Implementation

To address this, an explicit optional max_results parameter has been added to the search_files tool. Its explanation is simple and it does not increase the Roo Code prompt size too much.

If the max_results parameter is not supplied, code works exactly as before.

## Screenshots

Not applicable.

## How to Test

Unfortunately there are no existing unit or integration tests for this functionality. The change has been tested manually.
