### PR TITLE
Improved handling of Text Area focus state

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -397,6 +397,8 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 				() => {
 					if (this.view?.visible) {
 						this.postMessageToWebview({ type: "action", action: "didBecomeVisible" })
+					} else {
+						this.postMessageToWebview({ type: "action", action: "didBecomeInvisible" })
 					}
 				},
 				null,
@@ -408,6 +410,8 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 				() => {
 					if (this.view?.visible) {
 						this.postMessageToWebview({ type: "action", action: "didBecomeVisible" })
+					} else {
+						this.postMessageToWebview({ type: "action", action: "didBecomeInvisible" })
 					}
 				},
 				null,

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -77,6 +77,7 @@ export interface ExtensionMessage {
 		| "historyButtonClicked"
 		| "promptsButtonClicked"
 		| "didBecomeVisible"
+		| "didBecomeInvisible"
 	invoke?: "newChat" | "sendMessage" | "primaryButtonClick" | "secondaryButtonClick" | "setChatBoxMessage"
 	state?: ExtensionState
 	images?: string[]

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -493,11 +493,9 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 				case "action":
 					switch (message.action!) {
 						case "didBecomeVisible":
-							console.log("Set view hidden = false")
 							setViewHidden(false)
 							break
 						case "didBecomeInvisible":
-							console.log("Set view hidden = true")
 							setViewHidden(true)
 							break
 					}

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -142,13 +142,9 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 						case "followup":
 							setTextAreaDisabled(isPartial)
 							setClineAsk("followup")
-							// setting enable buttons to `false` would trigger a focus grab when
-							// the text area is enabled which is undesirable.
-							// We have no buttons for this tool, so no problem having them "enabled"
-							// to workaround this issue.  See #1358.
-							setEnableButtons(true)
-							setPrimaryButtonText(undefined)
-							setSecondaryButtonText(undefined)
+							setEnableButtons(isPartial)
+							// setPrimaryButtonText(undefined)
+							// setSecondaryButtonText(undefined)
 							break
 						case "tool":
 							if (!isAutoApproved(lastMessage)) {

--- a/webview-ui/src/components/chat/__tests__/ChatView.test.tsx
+++ b/webview-ui/src/components/chat/__tests__/ChatView.test.tsx
@@ -1236,6 +1236,10 @@ describe("ChatView - Focus Grabbing Tests", () => {
 				/>
 			</ExtensionStateContextProvider>,
 		)
+		// when chat view is hidden, this triggers a "blur" event
+		if (textAreaElement) {
+			fireEvent.blur(textAreaElement)
+		}
 
 		expect(mockFocus).toHaveBeenCalledTimes(1)
 
@@ -1256,7 +1260,7 @@ describe("ChatView - Focus Grabbing Tests", () => {
 	})
 
 	it("does not grab focus when unhidden and not previously focused", async () => {
-		const { rerender } = render(
+		const { getByTestId, rerender } = render(
 			<ExtensionStateContextProvider>
 				<ChatView
 					isHidden={false}
@@ -1267,6 +1271,7 @@ describe("ChatView - Focus Grabbing Tests", () => {
 			</ExtensionStateContextProvider>,
 		)
 
+		const textAreaElement = getByTestId("chat-textarea").querySelector("input")
 		rerender(
 			<ExtensionStateContextProvider>
 				<ChatView
@@ -1277,6 +1282,10 @@ describe("ChatView - Focus Grabbing Tests", () => {
 				/>
 			</ExtensionStateContextProvider>,
 		)
+		// when chat view is hidden, this triggers a "blur" event
+		if (textAreaElement) {
+			fireEvent.blur(textAreaElement)
+		}
 
 		rerender(
 			<ExtensionStateContextProvider>
@@ -1326,6 +1335,10 @@ describe("ChatView - Focus Grabbing Tests", () => {
 			expect(mockFocus).toHaveBeenCalledTimes(1)
 		})
 
+		// when extension becomes invisible, this will trigger a blur event before the message is sent.
+		if (textAreaElement) {
+			fireEvent.blur(textAreaElement)
+		}
 		await sendActionMessage("didBecomeInvisible")
 		expect(mockFocus).toHaveBeenCalledTimes(1)
 
@@ -1339,7 +1352,7 @@ describe("ChatView - Focus Grabbing Tests", () => {
 	})
 
 	it("does not grab focus when unhidden and not previously focused", async () => {
-		render(
+		const { findByTestId } = render(
 			<ExtensionStateContextProvider>
 				<ChatView
 					isHidden={false}
@@ -1350,6 +1363,12 @@ describe("ChatView - Focus Grabbing Tests", () => {
 			</ExtensionStateContextProvider>,
 		)
 
+		const textAreaElement = (await findByTestId("chat-textarea")).querySelector("input")
+
+		// when extension becomes invisible, this will trigger a blur event before the message is sent.
+		if (textAreaElement) {
+			fireEvent.blur(textAreaElement)
+		}
 		await sendActionMessage("didBecomeInvisible")
 		expect(mockFocus).toHaveBeenCalledTimes(0)
 
@@ -1389,8 +1408,11 @@ describe("ChatView - Focus Grabbing Tests", () => {
 		if (textAreaElement) {
 			fireEvent.blur(textAreaElement)
 		}
-
 		expect(mockFocus).toHaveBeenCalledTimes(1)
+
+		// must wait for > 500msecs after blur before making panel invisible
+		// so that the blur is interpreted as a deliberate user action.
+		await sleep(550)
 
 		await sendActionMessage("didBecomeInvisible")
 

--- a/webview-ui/src/components/chat/hooks/useFocusPreservation.tsx
+++ b/webview-ui/src/components/chat/hooks/useFocusPreservation.tsx
@@ -26,14 +26,8 @@ export function useFocusPreservation(element: HTMLElement | null, isHidden: Bool
 	}, [isHidden])
 
 	useEffect(() => {
-		// unclear why timer is here, and whether it's still necessary.
-		const timer = setTimeout(() => {
-			if (!isHidden && isFocused) {
-				element?.focus()
-			}
-		}, 50)
-		return () => {
-			clearTimeout(timer)
+		if (!isHidden && isFocused) {
+			element?.focus()
 		}
 	}, [isHidden, element, isFocused])
 

--- a/webview-ui/src/components/chat/hooks/useFocusPreservation.tsx
+++ b/webview-ui/src/components/chat/hooks/useFocusPreservation.tsx
@@ -1,0 +1,48 @@
+import { useState, useEffect, useRef } from "react"
+import { useMount } from "react-use"
+
+export interface UseFocusPreservationProps {
+	element: HTMLElement | undefined
+	isHidden: Boolean
+}
+
+export function useFocusPreservation({ element, isHidden }: UseFocusPreservationProps) {
+	const [isFocused, setIsFocused] = useState(false)
+	const isHiddenRef = useRef(isHidden)
+
+	useEffect(() => {
+		isHiddenRef.current = isHidden
+	}, [isHidden])
+
+	useEffect(() => {
+		const timer = setTimeout(() => {
+			if (!isHidden && isFocused) {
+				element?.focus()
+			}
+		}, 50)
+		return () => {
+			clearTimeout(timer)
+		}
+	}, [isHidden, element, isFocused])
+
+	const onTextAreaFocus = (event: FocusEvent) => {
+		setIsFocused(true)
+	}
+
+	const onTextAreaBlur = (event: FocusEvent) => {
+		// We wil get blur events when the element is hidden
+		// don't count these as an intentional loss of focus.
+		if (!isHiddenRef.current) {
+			setIsFocused(false)
+		}
+	}
+
+	useMount(() => {
+		element?.addEventListener("focus", onTextAreaFocus)
+		element?.addEventListener("blur", onTextAreaBlur)
+		return () => {
+			element?.removeEventListener("focus", onTextAreaFocus)
+			element?.removeEventListener("blur", onTextAreaBlur)
+		}
+	})
+}

--- a/webview-ui/src/components/chat/hooks/useFocusPreservation.tsx
+++ b/webview-ui/src/components/chat/hooks/useFocusPreservation.tsx
@@ -15,7 +15,7 @@ import { useState, useEffect, useRef } from "react"
  * this hook will track the "focussed" state, and reinstate it once the element
  * is no longer hidden.
  */
-export function useFocusPreservation(element: HTMLElement | null, isHidden: Boolean) {
+export function useFocusPreservation(element: HTMLElement | null, isHidden: boolean) {
 	const [isFocused, setIsFocused] = useState(false)
 	const isHiddenRef = useRef(isHidden)
 	const isHiddenLastChangedRef = useRef(0)


### PR DESCRIPTION
## Context

After making a pragmatic fix under PR#2263, I came across #2189, and as per comments there, I realized that there were various further issues with how focus on the text box is managed.

As described [there](https://github.com/RooVetGit/Roo-Code/issues/2189#issuecomment-2776688437), when the Roo Chat tab becomes visible again (either by switching between Roo tabs) or by switching between VSCode extensions, there is no way to determine from existing state whether or not focus should be re-instated on the text panel.

This PR explicitly tracks whether there is focus on this panel, and then re-instates it when the panel comes back into view.

## Implementation

Basic approach is:
- track focus and blur events to keep track of whether the text area has focus.
- re-instate this when the chat view reappears.
- simplify ChatView by pulling this code into a custom hook.
- revert previous fix for #2263, which is no longer required.

A bit of complexity arose because of the various ways that the text area can "blur" that we don't want to count as blurring, in particular
- switching to a new Roo tab (Prompts, MCP Servers etc.)
- switching to a different VS Code extension.

To accommodate the last of these, I had to extend the ExtensionMessage API to add a new "didBecomeInvisible" message that fires when the VSCode extension is hidden.

I added a decent set of Unit Tests to cover these various flows as well.

## Screenshots

N/A

## How to Test

Key manual tests are:
- toggle focus on the text area by clicking on / off
- focus state should be preserved when switching to a different Roo tab (e.g. Prompts, MCP Servers) and back
- focus state should be preserved when switching to a different VSCode extension so that Roo is hidden (or hiding Roo) and then switching back to Roo.

## Get in Touch

diarmid/diarmidm on Discord
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves text area focus handling in `ChatView` by tracking focus state and reinstating it when the view becomes visible, using a new `useFocusPreservation` hook.
> 
>   - **Behavior**:
>     - Tracks focus and blur events in `ChatView.tsx` to manage text area focus state.
>     - Reinstates focus when the chat view becomes visible again.
>     - Introduces `useFocusPreservation` hook in `useFocusPreservation.tsx` to handle focus state management.
>     - Reverts previous fix for #2263 as it's no longer needed.
>   - **ExtensionMessage**:
>     - Adds `didBecomeInvisible` action to `ExtensionMessage` in `ExtensionMessage.ts`.
>   - **Tests**:
>     - Adds unit tests in `ChatView.test.tsx` to verify focus behavior when view visibility changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 86d9722b4ba9517a2ebfc759b969685a2455f820. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->