### PR TITLE
feat ui/ux: overflow button in header actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -230,27 +230,23 @@
 				},
 				{
 					"command": "roo-cline.mcpButtonClicked",
-					"group": "navigation@3",
 					"when": "view == roo-cline.SidebarProvider"
 				},
 				{
 					"command": "roo-cline.historyButtonClicked",
-					"group": "navigation@4",
 					"when": "view == roo-cline.SidebarProvider"
 				},
 				{
 					"command": "roo-cline.popoutButtonClicked",
-					"group": "navigation@5",
 					"when": "view == roo-cline.SidebarProvider"
 				},
 				{
 					"command": "roo-cline.settingsButtonClicked",
-					"group": "navigation@6",
+					"group": "navigation@3",
 					"when": "view == roo-cline.SidebarProvider"
 				},
 				{
 					"command": "roo-cline.helpButtonClicked",
-					"group": "navigation@7",
 					"when": "view == roo-cline.SidebarProvider"
 				}
 			],
@@ -267,27 +263,23 @@
 				},
 				{
 					"command": "roo-cline.mcpButtonClicked",
-					"group": "navigation@3",
 					"when": "activeWebviewPanelId == roo-cline.TabPanelProvider"
 				},
 				{
 					"command": "roo-cline.historyButtonClicked",
-					"group": "navigation@4",
 					"when": "activeWebviewPanelId == roo-cline.TabPanelProvider"
 				},
 				{
 					"command": "roo-cline.popoutButtonClicked",
-					"group": "navigation@5",
 					"when": "activeWebviewPanelId == roo-cline.TabPanelProvider"
 				},
 				{
 					"command": "roo-cline.settingsButtonClicked",
-					"group": "navigation@6",
+					"group": "navigation@3",
 					"when": "activeWebviewPanelId == roo-cline.TabPanelProvider"
 				},
 				{
 					"command": "roo-cline.helpButtonClicked",
-					"group": "navigation@7",
 					"when": "activeWebviewPanelId == roo-cline.TabPanelProvider"
 				}
 			]


### PR DESCRIPTION
## Context

**Overview:**

This PR cleans up the Roo Code view header by moving less frequently used actions into the standard VS Code overflow menu (`...`). This provides a less cluttered primary header focusing on core actions like 'New Task', 'Prompts', and 'Settings'.

**Before**

![image](https://github.com/user-attachments/assets/651d8ca6-cf94-4b2c-9585-0a746537bc31)

**After**

![image](https://github.com/user-attachments/assets/81288f83-03e3-43dc-b0d7-048b391a4b08)

Drop-down (note no styles, icons, etc. this is standard vs code overflow)

![image](https://github.com/user-attachments/assets/0edeb432-696b-4cba-a598-cd6e777999dd)

Pros:

- Helps mental burden a lot because those icons are always present
- Can guide user to important pages like Prompts

Cons:

Maybe frustrating if someone uses something in the overflow frequently. The one I'm least confident is open in editor if someone has this in their workflow to click it every time or something (I don't know). 

**Problem:**

The Roo Code view header previously displayed all action buttons directly (New Task, Prompts, MCP Servers, History, Open in Editor, Settings, Help). This leads to a cluttered UI, mental burden, especially in narrower view layouts. It also allows easier dev in the future as can easily add a new page without affecting layout.

**Solution:**

Leveraged the standard VS Code menu contribution mechanism (`contributes.menus`) to control item visibility. By modifying the `group` property for specific actions within the `view/title` and `editor/title` contexts in `package.json`, we can signal to VS Code which items are primary (`navigation@<number>`) and which are secondary (no `group` assigned). VS Code automatically places these secondary items into the built-in overflow menu (`...`).

**Changes Made:**

*   Modified `Roo-Code/package.json`:
    *   In `contributes.menus["view/title"]`:
        *   Kept `group: "navigation@1"` for `roo-cline.plusButtonClicked`.
        *   Kept `group: "navigation@2"` for `roo-cline.promptsButtonClicked`.
        *   Updated `group` to `navigation@3` for `roo-cline.settingsButtonClicked`.
        *   Removed the `group` property entirely for `roo-cline.mcpButtonClicked`, `roo-cline.historyButtonClicked`, `roo-cline.popoutButtonClicked`, and `roo-cline.helpButtonClicked`.
    *   Applied identical changes to `contributes.menus["editor/title"]` for consistency when the view is popped out.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Declutters Roo Code view header by moving less used actions to overflow menu, focusing on core actions.
> 
>   - **UI/UX Improvement**:
>     - Moves less frequently used actions to VS Code's overflow menu (`...`) in the Roo Code view header.
>     - Focuses primary header on core actions: 'New Task', 'Prompts', 'Settings'.
>   - **Implementation**:
>     - Utilizes `contributes.menus` in `package.json` to manage item visibility.
>     - Modifies `group` properties in `view/title` and `editor/title` contexts.
>     - Keeps `group` for `plusButtonClicked`, `promptsButtonClicked`, `settingsButtonClicked`.
>     - Removes `group` for `mcpButtonClicked`, `historyButtonClicked`, `popoutButtonClicked`, `helpButtonClicked`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0b48f76d522fca5b4d668f04b9fdad64cbaac373. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->