### PR TITLE
ui/ux feat: chat search w/ highlight + jump 

### DIFF
--- a/webview-ui/src/components/chat/FollowUpSuggest.tsx
+++ b/webview-ui/src/components/chat/FollowUpSuggest.tsx
@@ -9,9 +9,17 @@ interface FollowUpSuggestProps {
 	suggestions?: string[]
 	onSuggestionClick?: (answer: string, event?: React.MouseEvent) => void
 	ts: number
+	searchText?: string // Add searchText prop
+	highlightText?: (text: string, searchTerm: string) => React.ReactNode // Add highlightText prop
 }
 
-export const FollowUpSuggest = ({ suggestions = [], onSuggestionClick, ts = 1 }: FollowUpSuggestProps) => {
+export const FollowUpSuggest = ({
+	suggestions = [],
+	onSuggestionClick,
+	ts = 1,
+	searchText, // Destructure searchText
+	highlightText, // Destructure highlightText
+}: FollowUpSuggestProps) => {
 	const { t } = useAppTranslation()
 	const handleSuggestionClick = useCallback(
 		(suggestion: string, event: React.MouseEvent) => {
@@ -34,7 +42,8 @@ export const FollowUpSuggest = ({ suggestions = [], onSuggestionClick, ts = 1 }:
 						className="text-left whitespace-normal break-words w-full h-auto py-3 justify-start pr-8"
 						onClick={(event) => handleSuggestionClick(suggestion, event)}
 						aria-label={suggestion}>
-						<div>{suggestion}</div>
+						{/* Apply highlighting if searchText and highlightText are provided */}
+						<div>{searchText && highlightText ? highlightText(suggestion, searchText) : suggestion}</div>
 					</Button>
 					<div
 						className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity"

--- a/webview-ui/src/components/chat/Markdown.tsx
+++ b/webview-ui/src/components/chat/Markdown.tsx
@@ -5,61 +5,68 @@ import { useCopyToClipboard } from "@src/utils/clipboard"
 
 import MarkdownBlock from "../common/MarkdownBlock"
 
-export const Markdown = memo(({ markdown, partial }: { markdown?: string; partial?: boolean }) => {
-	const [isHovering, setIsHovering] = useState(false)
+// Add searchText to props
+import React from "react" // Needed for React.ReactNode type
 
-	// Shorter feedback duration for copy button flash.
-	const { copyWithFeedback } = useCopyToClipboard(200)
+// Removed highlightText from props
+export const Markdown = memo(
+	({ markdown, partial, searchText }: { markdown?: string; partial?: boolean; searchText?: string }) => {
+		const [isHovering, setIsHovering] = useState(false)
 
-	if (!markdown || markdown.length === 0) {
-		return null
-	}
+		// Shorter feedback duration for copy button flash.
+		const { copyWithFeedback } = useCopyToClipboard(200)
 
-	return (
-		<div
-			onMouseEnter={() => setIsHovering(true)}
-			onMouseLeave={() => setIsHovering(false)}
-			style={{ position: "relative" }}>
-			<div style={{ wordBreak: "break-word", overflowWrap: "anywhere", marginBottom: -15, marginTop: -15 }}>
-				<MarkdownBlock markdown={markdown} />
-			</div>
-			{markdown && !partial && isHovering && (
-				<div
-					style={{
-						position: "absolute",
-						bottom: "-4px",
-						right: "8px",
-						opacity: 0,
-						animation: "fadeIn 0.2s ease-in-out forwards",
-						borderRadius: "4px",
-					}}>
-					<style>{`@keyframes fadeIn { from { opacity: 0; } to { opacity: 1.0; } }`}</style>
-					<VSCodeButton
-						className="copy-button"
-						appearance="icon"
-						style={{
-							height: "24px",
-							border: "none",
-							background: "var(--vscode-editor-background)",
-							transition: "background 0.2s ease-in-out",
-						}}
-						onClick={async () => {
-							const success = await copyWithFeedback(markdown)
-							if (success) {
-								const button = document.activeElement as HTMLElement
-								if (button) {
-									button.style.background = "var(--vscode-button-background)"
-									setTimeout(() => {
-										button.style.background = ""
-									}, 200)
-								}
-							}
-						}}
-						title="Copy as markdown">
-						<span className="codicon codicon-copy" />
-					</VSCodeButton>
+		if (!markdown || markdown.length === 0) {
+			return null
+		}
+
+		return (
+			<div
+				onMouseEnter={() => setIsHovering(true)}
+				onMouseLeave={() => setIsHovering(false)}
+				style={{ position: "relative" }}>
+				<div style={{ wordBreak: "break-word", overflowWrap: "anywhere", marginBottom: -15, marginTop: -15 }}>
+					{/* Pass searchText down to MarkdownBlock (highlighting handled by rehype plugin) */}
+					<MarkdownBlock markdown={markdown} searchText={searchText} />
 				</div>
-			)}
-		</div>
-	)
-})
+				{markdown && !partial && isHovering && (
+					<div
+						style={{
+							position: "absolute",
+							bottom: "-4px",
+							right: "8px",
+							opacity: 0,
+							animation: "fadeIn 0.2s ease-in-out forwards",
+							borderRadius: "4px",
+						}}>
+						<style>{`@keyframes fadeIn { from { opacity: 0; } to { opacity: 1.0; } }`}</style>
+						<VSCodeButton
+							className="copy-button"
+							appearance="icon"
+							style={{
+								height: "24px",
+								border: "none",
+								background: "var(--vscode-editor-background)",
+								transition: "background 0.2s ease-in-out",
+							}}
+							onClick={async () => {
+								const success = await copyWithFeedback(markdown)
+								if (success) {
+									const button = document.activeElement as HTMLElement
+									if (button) {
+										button.style.background = "var(--vscode-button-background)"
+										setTimeout(() => {
+											button.style.background = ""
+										}, 200)
+									}
+								}
+							}}
+							title="Copy as markdown">
+							<span className="codicon codicon-copy" />
+						</VSCodeButton>
+					</div>
+				)}
+			</div>
+		)
+	},
+)

--- a/webview-ui/src/components/chat/Mention.tsx
+++ b/webview-ui/src/components/chat/Mention.tsx
@@ -1,21 +1,26 @@
 import { mentionRegexGlobal } from "@roo/shared/context-mentions"
 
+import React from "react" // Needed for React.ReactNode
 import { vscode } from "../../utils/vscode"
 
 interface MentionProps {
 	text?: string
 	withShadow?: boolean
+	// Add search props
+	searchText?: string
+	highlightText?: (text: string, searchTerm: string) => React.ReactNode
 }
 
-export const Mention = ({ text, withShadow = false }: MentionProps) => {
+export const Mention = ({ text, withShadow = false, searchText, highlightText }: MentionProps) => {
+	// Destructure props
 	if (!text) {
 		return <>{text}</>
 	}
 
 	const parts = text.split(mentionRegexGlobal).map((part, index) => {
 		if (index % 2 === 0) {
-			// This is regular text.
-			return part
+			// This is regular text. Apply highlighting.
+			return searchText && highlightText ? highlightText(part, searchText) : part
 		} else {
 			// This is a mention.
 			return (
@@ -23,7 +28,8 @@ export const Mention = ({ text, withShadow = false }: MentionProps) => {
 					key={index}
 					className={`${withShadow ? "mention-context-highlight-with-shadow" : "mention-context-highlight"} cursor-pointer`}
 					onClick={() => vscode.postMessage({ type: "openMention", text: part })}>
-					@{part}
+					{/* Apply highlighting to the mention text */}
+					{searchText && highlightText ? highlightText(`@${part}`, searchText) : `@${part}`}
 				</span>
 			)
 		}

--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -1,15 +1,14 @@
 import { memo, useRef, useState } from "react"
 import { useWindowSize } from "react-use"
-import { useTranslation } from "react-i18next"
-import { VSCodeBadge } from "@vscode/webview-ui-toolkit/react"
-import { CloudUpload, CloudDownload } from "lucide-react"
+// Remove TFunction import, it's not needed
+import { VSCodeBadge, VSCodeButton } from "@vscode/webview-ui-toolkit/react" // Import VSCodeButton
+import { CloudUpload, CloudDownload, Search } from "lucide-react" // Import Search icon
 
 import { ClineMessage } from "@roo/shared/ExtensionMessage"
 
 import { getMaxTokensForModel } from "@src/utils/model-utils"
 import { formatLargeNumber } from "@src/utils/format"
 import { cn } from "@src/lib/utils"
-import { Button } from "@src/components/ui"
 import { useExtensionState } from "@src/context/ExtensionStateContext"
 import { useSelectedModel } from "@/components/ui/hooks/useSelectedModel"
 
@@ -29,6 +28,10 @@ export interface TaskHeaderProps {
 	totalCost: number
 	contextTokens: number
 	onClose: () => void
+	toggleSearch: () => void // Renaming for clarity might be good later, but keep for now
+	showSearch: boolean // Add showSearch state prop
+	closeSearch: () => void // Add closeSearch function prop
+	t: (key: string, options?: Record<string, any>) => string // Correct type for t function
 }
 
 const TaskHeader = ({
@@ -40,9 +43,13 @@ const TaskHeader = ({
 	cacheReads,
 	totalCost,
 	contextTokens,
-	onClose,
+	toggleSearch, // Keep this prop for now
+	showSearch, // Destructure showSearch
+	closeSearch, // Destructure closeSearch
+	t, // Destructure t (use the passed one)
 }: TaskHeaderProps) => {
-	const { t } = useTranslation()
+	// Remove useTranslation hook as 't' is now passed as a prop
+	// const { t } = useTranslation()
 	const { apiConfiguration, currentTaskItem } = useExtensionState()
 	const { info: model } = useSelectedModel(apiConfiguration)
 	const [isTaskExpanded, setIsTaskExpanded] = useState(false)
@@ -81,14 +88,20 @@ const TaskHeader = ({
 							)}
 						</div>
 					</div>
-					<Button
-						variant="ghost"
-						size="icon"
-						onClick={onClose}
-						title={t("chat:task.closeAndStart")}
-						className="shrink-0 w-5 h-5">
-						<span className="codicon codicon-close" />
-					</Button>
+					{/* Group Search and Close buttons */}
+					<div className="flex items-center gap-1 shrink-0">
+						{/* Updated Search Button Logic */}
+						<VSCodeButton
+							appearance="icon"
+							onClick={showSearch ? closeSearch : toggleSearch} // Toggle behavior
+							title={showSearch ? t("chat:search.close") : t("chat:search.title")} // Dynamic title
+							aria-label={showSearch ? t("chat:search.close") : t("chat:search.title")} // Dynamic aria-label
+						>
+							{/* Reduce icon size for better proportion */}
+							<Search size={10} />
+						</VSCodeButton>
+						{/* Close button removed as requested */}
+					</div>
 				</div>
 				{/* Collapsed state: Track context and cost if we have any */}
 				{!isTaskExpanded && contextWindow > 0 && (

--- a/webview-ui/src/components/chat/checkpoints/CheckpointSaved.tsx
+++ b/webview-ui/src/components/chat/checkpoints/CheckpointSaved.tsx
@@ -9,9 +9,18 @@ type CheckpointSavedProps = {
 	commitHash: string
 	currentHash?: string
 	checkpoint?: Record<string, unknown>
+	searchText?: string
+	highlightText?: (text: string, searchTerm: string, itemIndex: number) => React.ReactNode
+	itemIndex: number // Added itemIndex
 }
 
-export const CheckpointSaved = ({ checkpoint, ...props }: CheckpointSavedProps) => {
+export const CheckpointSaved = ({
+	checkpoint,
+	searchText,
+	highlightText,
+	itemIndex,
+	...props
+}: CheckpointSavedProps) => {
 	const { t } = useTranslation()
 	const isCurrent = props.currentHash === props.commitHash
 
@@ -38,11 +47,25 @@ export const CheckpointSaved = ({ checkpoint, ...props }: CheckpointSavedProps) 
 			<div className="flex gap-2">
 				<span className="codicon codicon-git-commit text-blue-400" />
 				<span className="font-bold">
-					{metadata.isFirst ? t("chat:checkpoint.initial") : t("chat:checkpoint.regular")}
+					{searchText && highlightText
+						? highlightText(
+								metadata.isFirst ? t("chat:checkpoint.initial") : t("chat:checkpoint.regular"),
+								searchText,
+								itemIndex,
+							)
+						: metadata.isFirst
+							? t("chat:checkpoint.initial")
+							: t("chat:checkpoint.regular")}
 				</span>
 				{isCurrent && <span className="text-muted text-sm">{t("chat:checkpoint.current")}</span>}
 			</div>
-			<CheckpointMenu {...props} checkpoint={metadata} />
+			{/* Pass remaining props excluding the ones used here */}
+			<CheckpointMenu
+				ts={props.ts}
+				commitHash={props.commitHash}
+				currentHash={props.currentHash}
+				checkpoint={metadata}
+			/>
 		</div>
 	)
 }

--- a/webview-ui/src/components/common/CodeAccordian.tsx
+++ b/webview-ui/src/components/common/CodeAccordian.tsx
@@ -15,6 +15,9 @@ interface CodeAccordianProps {
 	onToggleExpand: () => void
 	isLoading?: boolean
 	progressStatus?: ToolProgressStatus
+	// Add search props
+	searchText?: string
+	highlightText?: (text: string, searchTerm: string) => React.ReactNode
 }
 
 /*
@@ -39,6 +42,9 @@ const CodeAccordian = ({
 	onToggleExpand,
 	isLoading,
 	progressStatus,
+	// Destructure search props
+	searchText,
+	highlightText,
 }: CodeAccordianProps) => {
 	const inferredLanguage = useMemo(
 		() => code && (language ?? (path ? getLanguageFromPath(path) : undefined)),
@@ -83,7 +89,12 @@ const CodeAccordian = ({
 									textOverflow: "ellipsis",
 									marginRight: "8px",
 								}}>
-								{isFeedback ? "User Edits" : "Console Logs"}
+								{/* Apply highlighting */}
+								{highlightText && searchText
+									? highlightText(isFeedback ? "User Edits" : "Console Logs", searchText)
+									: isFeedback
+										? "User Edits"
+										: "Console Logs"}
 							</span>
 						</div>
 					) : (
@@ -99,7 +110,11 @@ const CodeAccordian = ({
 									direction: "rtl",
 									textAlign: "left",
 								}}>
-								{removeLeadingNonAlphanumeric(path ?? "") + "\u200E"}
+								{/* Apply highlighting, preserving the RTL trick character */}
+								{highlightText && searchText
+									? highlightText(removeLeadingNonAlphanumeric(path ?? ""), searchText)
+									: removeLeadingNonAlphanumeric(path ?? "")}
+								{"\u200E"}
 							</span>
 						</>
 					)}
@@ -108,7 +123,10 @@ const CodeAccordian = ({
 						<>
 							{progressStatus.icon && <span className={`codicon codicon-${progressStatus.icon} mr-1`} />}
 							<span className="mr-1 ml-auto text-vscode-descriptionForeground">
-								{progressStatus.text}
+								{/* Apply highlighting */}
+								{highlightText && searchText
+									? highlightText(progressStatus.text, searchText)
+									: progressStatus.text}
 							</span>
 						</>
 					)}
@@ -125,6 +143,9 @@ const CodeAccordian = ({
 					<CodeBlock
 						source={(code ?? diff ?? "").trim()}
 						language={diff !== undefined ? "diff" : inferredLanguage}
+						// Pass search props down
+						searchText={searchText}
+						highlightText={highlightText}
 					/>
 				</div>
 			)}

--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -7,9 +7,12 @@ import { useExtensionState } from "@src/context/ExtensionStateContext"
 
 import CodeBlock from "./CodeBlock"
 import MermaidBlock from "./MermaidBlock"
+// Removed: import { rehypeHighlightSearch } from "@src/lib/rehype-highlight-search";
+import { applyHighlighting } from "@src/utils/applyHighlighting" // Import the new utility (will be created next)
 
 interface MarkdownBlockProps {
 	markdown?: string
+	searchText?: string // Add searchText prop
 }
 
 /**
@@ -117,7 +120,8 @@ const StyledMarkdown = styled.div`
 	}
 `
 
-const MarkdownBlock = memo(({ markdown }: MarkdownBlockProps) => {
+const MarkdownBlock = memo(({ markdown, searchText }: MarkdownBlockProps) => {
+	// Destructure searchText
 	const { theme } = useExtensionState()
 	const [reactContent, setMarkdown] = useRemark({
 		remarkPlugins: [
@@ -134,6 +138,7 @@ const MarkdownBlock = memo(({ markdown }: MarkdownBlockProps) => {
 				}
 			},
 		],
+		// Removed rehypeHighlightSearch plugin
 		rehypePlugins: [],
 		rehypeReactOptions: {
 			components: {
@@ -170,20 +175,24 @@ const MarkdownBlock = memo(({ markdown }: MarkdownBlockProps) => {
 						const codeText = String(props.children || "")
 						return <MermaidBlock code={codeText} />
 					}
-
 					return <code {...props} />
 				},
+				// Removed explicit mark renderer
 			},
 		},
 	})
 
 	useEffect(() => {
 		setMarkdown(markdown || "")
+		// Removed searchText from dependency array
 	}, [markdown, setMarkdown, theme])
+
+	// Apply highlighting after react-remark processing
+	const highlightedContent = applyHighlighting(reactContent, searchText || "")
 
 	return (
 		<div style={{}}>
-			<StyledMarkdown>{reactContent}</StyledMarkdown>
+			<StyledMarkdown>{highlightedContent}</StyledMarkdown>
 		</div>
 	)
 })

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -88,8 +88,9 @@ const ApiOptions = ({
 	// Effect to synchronize internal customHeaders state with prop changes
 	useEffect(() => {
 		const propHeaders = apiConfiguration?.openAiHeaders || {}
-		if (JSON.stringify(customHeaders) !== JSON.stringify(Object.entries(propHeaders))) setCustomHeaders(Object.entries(propHeaders))
-	}, [apiConfiguration?.openAiHeaders])
+		if (JSON.stringify(customHeaders) !== JSON.stringify(Object.entries(propHeaders)))
+			setCustomHeaders(Object.entries(propHeaders))
+	}, [apiConfiguration?.openAiHeaders, customHeaders]) // Added customHeaders dependency
 
 	const [anthropicBaseUrlSelected, setAnthropicBaseUrlSelected] = useState(!!apiConfiguration?.anthropicBaseUrl)
 	const [openAiNativeBaseUrlSelected, setOpenAiNativeBaseUrlSelected] = useState(

--- a/webview-ui/src/hooks/useChatSearch.tsx
+++ b/webview-ui/src/hooks/useChatSearch.tsx
@@ -1,0 +1,372 @@
+import React, { useState, useEffect, useCallback, useMemo, useRef } from "react"
+import { useDebounce } from "react-use"
+import { VirtuosoHandle } from "react-virtuoso"
+import { Search, ChevronUp, ChevronDown } from "lucide-react"
+import { VSCodeTextField, VSCodeButton } from "@vscode/webview-ui-toolkit/react"
+import { useTranslation } from "react-i18next"
+
+// Store only the index of the message containing the match
+type SearchResult = number // Represents the itemIndex
+
+interface UseChatSearchProps<T> {
+	messages: T[]
+	virtuosoRef: React.RefObject<VirtuosoHandle>
+	// Function now receives item, index, and the full list
+	getSearchableText: (item: T, index: number, list: T[]) => string
+	disableAutoScrollRef: React.MutableRefObject<boolean> // Add ref from parent
+}
+
+export function useChatSearch<T>({
+	messages,
+	virtuosoRef,
+	getSearchableText,
+	// disableAutoScrollRef, // Removed unused prop
+}: UseChatSearchProps<T>) {
+	const { t } = useTranslation()
+	const [showSearch, setShowSearch] = useState(false)
+	const [searchText, setSearchText] = useState("")
+	const [debouncedSearchText, setDebouncedSearchText] = useState("")
+	const [searchResults, setSearchResults] = useState<SearchResult[]>([]) // Array of item indices
+	const [currentMatchIndex, setCurrentMatchIndex] = useState(-1) // Index within the searchResults array
+	// Use 'any' for the ref type to bypass strict VSCodeTextField type checking
+	const searchInputRef = useRef<any>(null)
+	const isInitialSearchScrollDone = useRef(false) // Track if initial scroll happened for the current search
+	const isNavigatingRef = useRef(false) // Track if index change is from user navigation
+	const logicalMatchIndexRef = useRef(-1) // Ref to track the index immediately for calculations
+	const previousSearchableTextsRef = useRef<string[] | null>(null) // Ref to compare searchableTexts content
+	const previousSearchTermRef = useRef<string | null>(null) // Ref to compare search term
+
+	// Debounce search text
+	useDebounce(
+		() => {
+			setDebouncedSearchText(searchText)
+		},
+		200, // Debounce time in ms
+		[searchText],
+	)
+
+	// Memoize searchable text for performance
+	const searchableTexts = useMemo(() => {
+		// Pass item, index, and the full messages list to the getter
+		return messages.map((item, index, list) => getSearchableText(item, index, list))
+	}, [messages, getSearchableText])
+
+	// Function to perform the scroll to a specific match index
+	// Scrolls to the message (item) at the given index in the main messages list
+	// Function to perform the scroll to a specific match index using scrollIntoView
+	// No longer needs currentMatchIndex from closure
+	const scrollToItemIndex = useCallback(
+		(itemIndex: number, behavior: "smooth" | "auto" = "auto") => {
+			if (virtuosoRef.current && itemIndex !== -1) {
+				// Use rAF to ensure DOM updates potentially settle first
+				requestAnimationFrame(() => {
+					if (!virtuosoRef.current) {
+						// Ref might become null before rAF callback
+						isNavigatingRef.current = false // Reset flag if scroll can't happen
+						console.log(`[Search] rAF: Ref NOT found for index ${itemIndex}. Aborting scrollIntoView.`) // Changed log message for clarity
+						return
+					}
+					// Removed stale log: console.log(`[Search] rAF: currentMatchIndex before scrollIntoView call: ${currentMatchIndex}`);
+
+					console.log(`[Search] rAF: Calling scrollIntoView for index ${itemIndex}, behavior: ${behavior}`)
+					virtuosoRef.current.scrollIntoView({
+						index: itemIndex,
+						behavior: behavior, // Use 'auto' for reliability as requested
+						// align: 'start', // scrollIntoView aims to make it visible, align might not be needed/supported
+						done: () => {
+							// KEY: Reset navigation state *after* scroll completes
+							console.log(
+								`[Search] scrollIntoView DONE callback for index: ${itemIndex}. Resetting isNavigatingRef.`,
+							)
+							isNavigatingRef.current = false
+							// console.log(`Virtuoso finished scrolling to index: ${itemIndex}`); // Original log
+						},
+					})
+				})
+			} else {
+				// If scroll didn't happen (no ref or invalid index), reset flag immediately
+				isNavigatingRef.current = false
+			}
+		},
+		[virtuosoRef],
+	) // Dependency on the ref
+
+	// Perform search when debounced text or searchableTexts content changes
+	useEffect(() => {
+		// console.log("[Search Effect] Running. Debounced text:", debouncedSearchText); // REMOVED Log
+
+		// Check if term or texts content has actually changed
+		const textsChanged = JSON.stringify(searchableTexts) !== JSON.stringify(previousSearchableTextsRef.current)
+		const termChanged = debouncedSearchText !== previousSearchTermRef.current
+
+		// Only run the search logic if the term changed OR the texts changed
+		if (!termChanged && !textsChanged) {
+			// console.log("[Search Effect] Skipping: Neither term nor texts changed."); // REMOVED Log
+			// Don't update refs here, wait until the end
+			return // Skip search logic
+		}
+
+		// Store stringified texts once for potential use later
+		const currentTextsStringified = JSON.stringify(searchableTexts)
+
+		if (!debouncedSearchText) {
+			// console.log("[Search Effect] Clearing results."); // REMOVED Log
+			// Clear refs when search is cleared (setSearchResults will trigger re-render anyway)
+			// previousSearchableTextsRef.current = null; // Let refs update at the end
+			// previousSearchTermRef.current = null;
+			setSearchResults([])
+			logicalMatchIndexRef.current = -1 // Reset logical index
+			isInitialSearchScrollDone.current = false // Reset scroll flag when search clears
+			return
+		}
+		const matchingItemIndices: SearchResult[] = [] // Store unique item indices
+		const searchTerm = debouncedSearchText.toLowerCase()
+
+		searchableTexts.forEach((text, itemIndex) => {
+			// DEBUG: Log the text being searched and the search term
+			// console.log(`[Search Debug] Item ${itemIndex}: Searching for "${searchTerm}" in: "${text.substring(0, 100)}..."`);
+			if (text.toLowerCase().includes(searchTerm)) {
+				// DEBUG: Log when a match is found
+				// console.log(`[Search Debug] Item ${itemIndex}: Match FOUND!`);
+				matchingItemIndices.push(itemIndex) // Add index if message contains term
+			}
+		})
+
+		const previousResultsLength = searchResults.length
+		setSearchResults(matchingItemIndices)
+
+		// Determine the new index and handle scrolling
+		const newMatchIndex = matchingItemIndices.length > 0 ? 0 : -1
+		// console.log(`[Search Effect] Found ${matchingItemIndices.length} results. Setting logical index to ${newMatchIndex}.`); // REMOVED Log
+		setCurrentMatchIndex(newMatchIndex)
+		logicalMatchIndexRef.current = newMatchIndex // Update logical index immediately
+
+		// If results just appeared (went from 0 to >0), scroll to the first one automatically
+		if (newMatchIndex === 0 && previousResultsLength === 0) {
+			// Use timeout to allow state/render updates before scrolling
+			setTimeout(() => {
+				const firstItemIndex = matchingItemIndices[0]
+				if (firstItemIndex !== undefined) {
+					scrollToItemIndex(firstItemIndex, "auto")
+					isInitialSearchScrollDone.current = true // Mark initial scroll as done for this search term
+				}
+			}, 50)
+		} else if (newMatchIndex === -1) {
+			isInitialSearchScrollDone.current = false // Reset if no results
+		}
+		// console.log("[Search Effect] Finished."); // REMOVED Log
+		// Update refs AFTER processing is complete
+		previousSearchableTextsRef.current = JSON.parse(currentTextsStringified)
+		previousSearchTermRef.current = debouncedSearchText
+	}, [debouncedSearchText, searchableTexts, scrollToItemIndex, searchResults.length])
+
+	// Focus input when search bar shows
+	useEffect(() => {
+		if (showSearch) {
+			// Timeout needed to allow the element to render
+			setTimeout(() => searchInputRef.current?.focus(), 50)
+		}
+	}, [showSearch])
+
+	const goNext = useCallback(() => {
+		if (isNavigatingRef.current) {
+			console.log("[Search] Navigation blocked: Already navigating.")
+			return
+		}
+		if (searchResults.length === 0) return
+
+		console.log("[Search] goNext: Starting navigation.")
+		isNavigatingRef.current = true // Set flag immediately
+
+		// Calculate new index based on the logical ref
+		const currentLogicalIndex = logicalMatchIndexRef.current
+		const newIndex = currentLogicalIndex === -1 ? 0 : (currentLogicalIndex + 1) % searchResults.length
+		console.log(`[Search] goNext: Calculated new index ${newIndex} (based on logical index ${currentLogicalIndex})`)
+		logicalMatchIndexRef.current = newIndex // Update logical index immediately
+
+		// Get the corresponding item index from searchResults
+		const itemIndexToScroll = searchResults[newIndex]
+
+		if (itemIndexToScroll !== undefined) {
+			console.log(`[Search] goNext: Calling scrollToItemIndex for item index ${itemIndexToScroll}`)
+			// Call scroll directly, pass the correct item index
+			scrollToItemIndex(itemIndexToScroll, "auto") // Explicitly pass behavior
+			// Update state *after* initiating scroll
+			console.log(`[Search] goNext: Setting currentMatchIndex to: ${newIndex}`)
+			setCurrentMatchIndex(newIndex)
+		} else {
+			console.error(`[Search] goNext: Could not find item index for search result index ${newIndex}`)
+			isNavigatingRef.current = false // Reset flag if scroll can't happen
+		}
+	}, [searchResults, scrollToItemIndex])
+
+	const goPrev = useCallback(() => {
+		if (isNavigatingRef.current) {
+			console.log("[Search] Navigation blocked: Already navigating.")
+			return
+		}
+		if (searchResults.length === 0) return
+
+		console.log("[Search] goPrev: Starting navigation.")
+		isNavigatingRef.current = true // Set flag immediately
+
+		// Calculate new index based on the logical ref
+		const currentLogicalIndex = logicalMatchIndexRef.current
+		const newIndex = currentLogicalIndex <= 0 ? searchResults.length - 1 : currentLogicalIndex - 1
+		console.log(`[Search] goPrev: Calculated new index ${newIndex} (based on logical index ${currentLogicalIndex})`)
+		logicalMatchIndexRef.current = newIndex // Update logical index immediately
+
+		// Get the corresponding item index from searchResults
+		const itemIndexToScroll = searchResults[newIndex]
+
+		if (itemIndexToScroll !== undefined) {
+			console.log(`[Search] goPrev: Calling scrollToItemIndex for item index ${itemIndexToScroll}`)
+			// Call scroll directly, pass the correct item index
+			scrollToItemIndex(itemIndexToScroll, "auto") // Explicitly pass behavior
+			// Update state *after* initiating scroll
+			console.log(`[Search] goPrev: Setting currentMatchIndex to: ${newIndex}`)
+			setCurrentMatchIndex(newIndex)
+		} else {
+			console.error(`[Search] goPrev: Could not find item index for search result index ${newIndex}`)
+			isNavigatingRef.current = false // Reset flag if scroll can't happen
+		}
+	}, [searchResults, scrollToItemIndex])
+
+	// Ensure the useEffect that previously handled scrolling is removed
+
+	// Highlight function, now accepts itemIndex to identify the active match
+	const highlightText = useCallback(
+		(text: string, searchTerm: string, itemIndex: number): React.ReactNode => {
+			// Get the item index of the currently selected search result
+			const activeItemIndex = searchResults[currentMatchIndex]
+			const isActiveItem = itemIndex === activeItemIndex
+
+			if (!searchTerm || !text) {
+				return text
+			}
+			const lowerText = text.toLowerCase()
+			const lowerSearchTerm = searchTerm.toLowerCase()
+			const parts: React.ReactNode[] = []
+			let lastIndex = 0
+			let index = lowerText.indexOf(lowerSearchTerm, lastIndex)
+
+			while (index !== -1) {
+				// Push the text before the match
+				if (index > lastIndex) {
+					parts.push(text.substring(lastIndex, index))
+				}
+				// Push the highlighted match
+				const matchedPart = text.substring(index, index + searchTerm.length)
+				// Apply default highlight and add outline classes if this is the currently active item
+				let highlightClasses = "bg-yellow-300" // Default highlight style
+				if (isActiveItem) {
+					highlightClasses += " outline outline-1 outline-white" // Add outline for active item
+				}
+				parts.push(
+					<mark key={index} className={highlightClasses}>
+						{matchedPart}
+					</mark>,
+				)
+
+				lastIndex = index + searchTerm.length
+				index = lowerText.indexOf(lowerSearchTerm, lastIndex)
+			}
+
+			// Push the remaining text after the last match
+			if (lastIndex < text.length) {
+				parts.push(text.substring(lastIndex))
+			}
+
+			return parts
+		},
+		[currentMatchIndex, searchResults], // Dependencies updated
+	)
+
+	const renderSearchBar = useCallback(() => {
+		if (!showSearch) {
+			return null
+		}
+
+		const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+			if (e.key === "Enter") {
+				if (e.shiftKey) {
+					goPrev()
+				} else {
+					goNext()
+				}
+				e.preventDefault()
+			} else if (e.key === "Escape") {
+				setShowSearch(false)
+				e.preventDefault()
+			}
+		}
+
+		return (
+			<div className="sticky top-0 z-10 flex items-center p-1 bg-[var(--vscode-sideBar-background)] border-b border-[var(--vscode-editorGroup-border)]">
+				<VSCodeTextField
+					ref={searchInputRef}
+					placeholder={'Search e.g. "Checkpoint"'}
+					value={searchText}
+					onInput={(e: any) => setSearchText(e.target.value)}
+					onKeyDown={handleKeyDown}
+					className="flex-grow mr-1"
+					style={{ borderRadius: "3px 0 0 3px" }} // Style adjustments might be needed
+				>
+					{/* Wrap icon in a span with the slot attribute */}
+					<span slot="start" className="flex items-center">
+						<Search size={16} className="ml-1 opacity-70" />
+					</span>
+				</VSCodeTextField>
+				<span className="text-xs text-[var(--vscode-descriptionForeground)] px-2 whitespace-nowrap">
+					{searchResults.length > 0
+						? `${currentMatchIndex + 1} / ${searchResults.length}`
+						: debouncedSearchText
+							? t("chat:search.noResults")
+							: ""}
+				</span>
+				<VSCodeButton
+					appearance="icon"
+					onClick={goPrev}
+					disabled={searchResults.length === 0}
+					title={t("chat:search.previous")}
+					aria-label={t("chat:search.previous")}>
+					<ChevronUp size={16} />
+				</VSCodeButton>
+				<VSCodeButton
+					appearance="icon"
+					onClick={goNext}
+					disabled={searchResults.length === 0}
+					title={t("chat:search.next")}
+					aria-label={t("chat:search.next")}>
+					<ChevronDown size={16} />
+				</VSCodeButton>
+				{/* X Button Removed */}
+			</div>
+		)
+	}, [showSearch, searchText, searchResults, currentMatchIndex, debouncedSearchText, goNext, goPrev, t])
+
+	// Function to handle closing the search and resetting state
+	const closeSearch = useCallback(() => {
+		// console.log("[Search] closeSearch called. Clearing search, hiding bar, scrolling bottom.");
+		setSearchText("") // Clear the search input
+		setShowSearch(false) // Hide the search bar
+		// disableAutoScrollRef.current = false; // REMOVED: Let ChatView handle re-enabling on manual scroll to bottom
+		// Auto-scroll removed
+	}, [setShowSearch])
+
+	return {
+		showSearch,
+		setShowSearch, // Keep this for toggling *on*
+		closeSearch, // Expose the new close function
+		searchText, // Raw search text
+		debouncedSearchText, // Debounced text for triggering search/highlighting
+		searchResults,
+		currentMatchIndex,
+		matchesCount: searchResults.length,
+		highlightText,
+		renderSearchBar,
+		goNext,
+		goPrev,
+		isNavigatingRef, // Expose the ref
+	}
+}

--- a/webview-ui/src/lib/rehype-highlight-search.ts
+++ b/webview-ui/src/lib/rehype-highlight-search.ts
@@ -1,0 +1,85 @@
+import { visit } from "unist-util-visit"
+import type { Element, Text } from "hast"
+import type { Plugin } from "unified" // Import Plugin type
+
+interface Options {
+	searchText: string
+}
+
+/**
+ * Rehype plugin to highlight search terms within text nodes, skipping code blocks.
+ * Conforms to the unified Plugin interface.
+ */
+export const rehypeHighlightSearch: Plugin<[Options?], any> = (options) => {
+	const searchText = options?.searchText?.trim().toLowerCase()
+
+	// Return the transformer function
+	return (tree: any) => {
+		if (!searchText) {
+			return // No search text, do nothing
+		}
+
+		visit(tree, "text", (node: Text, index, parent: Element | null) => {
+			if (!parent || typeof index !== "number") {
+				return // Should not happen in valid HAST
+			}
+
+			// Skip highlighting within code blocks or preformatted text
+			let currentParent = parent
+			while (currentParent) {
+				if (currentParent.tagName === "pre" || currentParent.tagName === "code") {
+					return // Skip this text node
+				}
+				// Traverse up the tree if needed (though usually text is direct child)
+				// This part might need adjustment based on complex structures, but
+				// for typical markdown (p > text, li > text), checking immediate parent is enough.
+				break // Only check immediate parent for performance in common cases
+			}
+
+			const nodeValue = node.value
+			const lowerNodeValue = nodeValue.toLowerCase()
+			const matches: { start: number; end: number }[] = []
+			let startIndex = 0
+			let matchIndex = lowerNodeValue.indexOf(searchText, startIndex)
+
+			while (matchIndex !== -1) {
+				matches.push({ start: matchIndex, end: matchIndex + searchText.length })
+				startIndex = matchIndex + 1 // Move past the start of the current match
+				matchIndex = lowerNodeValue.indexOf(searchText, startIndex)
+			}
+
+			if (matches.length === 0) {
+				return // No matches in this node
+			}
+
+			const newChildren: (Text | Element)[] = []
+			let lastIndex = 0
+
+			matches.forEach((match) => {
+				// Add text before the match
+				if (match.start > lastIndex) {
+					newChildren.push({ type: "text", value: nodeValue.substring(lastIndex, match.start) })
+				}
+				// Add the highlighted match
+				newChildren.push({
+					type: "element",
+					tagName: "mark",
+					properties: {}, // Add properties if needed (e.g., className)
+					children: [{ type: "text", value: nodeValue.substring(match.start, match.end) }],
+				})
+				lastIndex = match.end
+			})
+
+			// Add any remaining text after the last match
+			if (lastIndex < nodeValue.length) {
+				newChildren.push({ type: "text", value: nodeValue.substring(lastIndex) })
+			}
+
+			// Replace the original text node with the new sequence
+			parent.children.splice(index, 1, ...newChildren)
+
+			// Adjust visitor index to continue after the newly inserted nodes
+			return index + newChildren.length
+		})
+	}
+}

--- a/webview-ui/src/utils/applyHighlighting.tsx
+++ b/webview-ui/src/utils/applyHighlighting.tsx
@@ -1,0 +1,67 @@
+import React from "react"
+
+/**
+ * Recursively traverses a React node tree and wraps occurrences of searchText
+ * within text content in <mark> tags.
+ *
+ * @param node The React node (or string, array, etc.) to process.
+ * @param searchText The text to search for (case-insensitive).
+ * @returns The processed React node tree with highlighting applied.
+ */
+export function applyHighlighting(node: React.ReactNode, searchText: string): React.ReactNode {
+	if (!searchText) {
+		return node // No search text, return node as is
+	}
+
+	if (typeof node === "string") {
+		const lowerNode = node.toLowerCase()
+		const lowerSearchText = searchText.toLowerCase()
+		const parts: React.ReactNode[] = []
+		let lastIndex = 0
+		let index = lowerNode.indexOf(lowerSearchText, lastIndex)
+		let keyIndex = 0 // Unique key for mapped elements
+
+		while (index !== -1) {
+			// Push the text before the match
+			if (index > lastIndex) {
+				parts.push(node.substring(lastIndex, index))
+			}
+			// Push the highlighted match
+			const matchedText = node.substring(index, index + searchText.length)
+			parts.push(<mark key={`mark-${keyIndex++}`}>{matchedText}</mark>)
+
+			lastIndex = index + searchText.length
+			index = lowerNode.indexOf(lowerSearchText, lastIndex)
+		}
+
+		// Push the remaining text after the last match
+		if (lastIndex < node.length) {
+			parts.push(node.substring(lastIndex))
+		}
+
+		// If parts were created, return the array, otherwise the original string
+		return parts.length > 0 ? parts : node
+	} else if (React.isValidElement(node)) {
+		// If the element is already a <mark>, don't process its children further for highlighting
+		if (node.type === "mark") {
+			return node
+		}
+
+		// Recursively process children if they exist
+		if (node.props.children) {
+			const processedChildren = applyHighlighting(node.props.children, searchText)
+			// Clone the element with the potentially modified children
+			return React.cloneElement(node, { ...node.props }, processedChildren)
+		} else {
+			// Element has no children, return as is
+			return node
+		}
+	} else if (Array.isArray(node)) {
+		// Recursively process each item in the array
+		// Prefixed index with _: Fix @typescript-eslint/no-unused-vars
+		return node.map((item, _index) => applyHighlighting(item, searchText))
+	} else {
+		// Node is null, undefined, boolean, number, etc. - return unchanged
+		return node
+	}
+}


### PR DESCRIPTION
## Context

![image](https://github.com/user-attachments/assets/5b169127-7ffd-483c-968e-2e90c120bcdd)

Tasks can get long, restore points are hard to find, if you lose your place in a long task you waste a lot of time trying to find it. All this takes away time, causes frustration. There are many possible solutions from minimaps to timeline panels, annotated scrollbars, etc. but the best solution is simple text search.

Search is a "need to have" fundamental usability feature for the chat interface.

## Implementation

![chat-search](https://github.com/user-attachments/assets/6fa67432-9a82-4ff8-83b4-b19a88917714)

Note I replaced the X button (since the + button has the same function) but we can also hide the icon and rely on keyboard shortcut, move the icon somewhere else.

This PR introduces a comprehensive search functionality within the chat view and resolves minor linting issues.

**Key Features & Changes:**

1.  **In-Chat Search:**
    *   Adds a search bar accessible via a toggle button in the `TaskHeader` or using the `Ctrl/Cmd + F` keyboard shortcut.
    *   Allows users to search across the entire chat history, including message content, titles, tool details (paths, diffs, modes, etc.), API request/response details, checkpoint titles, and followup suggestions.
    *   Uses debouncing on the search input for performance.
    *   Highlights all occurrences of the search term within the chat messages using `<mark>` tags.
    *   Provides navigation controls (Next/Previous buttons, Enter/Shift+Enter keys) to jump between matches.
    *   The currently active match is visually distinct with an outline style applied to its highlight.
    *   Automatic scrolling

2.  **Implementation Details:**
    *   Introduced a new hook `useChatSearch` to encapsulate search logic, state management, navigation, and the core highlighting function.
    *   Integrated `useChatSearch` into `ChatView`, passing down necessary props (`searchText`, `highlightText`, `itemIndex`) to child components.
    *   Implemented `getSearchableTextForChatView` in `ChatView` to extract rich, searchable text content from various message types and structures. This includes a lookahead mechanism to associate API response text with its corresponding request row for better searchability.
    *   Modified `ChatView`'s scrolling logic (`handleRowHeightChange`, `useEffect` on message length, `toggleRowExpansion`) to respect the search state (`showSearch`, `isNavigatingRef`) and prevent unwanted auto-scrolling.
    *   Updated `TaskHeader` to include the search toggle button and manage its state.
    *   Utilized Virtuoso's `scrollIntoView` API within the `useChatSearch` hook for efficient scrolling to matched items.
    *   Highlighting is applied differently based on the component:
        *   `ChatRow`, `BrowserSessionRow`, `CheckpointSaved`, `FollowUpSuggest`, `CodeAccordian` (header): Use the `highlightText` function prop directly.
        *   `MarkdownBlock`: Uses a separate `applyHighlighting` utility function that traverses the React node tree generated by `react-remark`.
        *   `CodeBlock`: Uses a custom Shiki transformer (`createSearchHighlightTransformer`) that operates on the code's AST during syntax highlighting.