### PR TITLE
Decouple Max Tokens from Max Thinking Tokens

### DIFF
--- a/.changeset/fix-max-tokens-slider.md
+++ b/.changeset/fix-max-tokens-slider.md
@@ -1,0 +1,10 @@
+---
+"roo-cline": patch
+---
+
+Fix: Decouple Max Output Tokens from Max Thinking Tokens controls
+
+- Separated Max Output Tokens control into its own component that displays for all models with configurable maxTokens
+- Updated ThinkingBudget component to only handle thinking/reasoning tokens
+- Fixed issue where non-thinking models with configurable maxTokens didn't show the output tokens slider
+- Updated to use new model properties (supportsReasoningBudget) from latest main branch

--- a/webview-ui/src/components/__mocks__/Slider.tsx
+++ b/webview-ui/src/components/__mocks__/Slider.tsx
@@ -1,0 +1,14 @@
+import React from "react"
+
+// This is a manual mock for the Slider component.
+// It will be automatically used by Jest when jest.mock('../Slider') is called.
+
+// Create a Jest mock function for the component itself
+const MockSlider = jest.fn((props: any) => {
+	// You can add basic rendering if needed for other tests,
+	// or just keep it simple for prop checking.
+	// Include data-testid for potential queries if the component rendered something.
+	return <div data-testid="mock-slider" {...props} />
+})
+
+export const Slider = MockSlider

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -54,6 +54,7 @@ import { TemperatureControl } from "./TemperatureControl"
 import { RateLimitSecondsControl } from "./RateLimitSecondsControl"
 import { BedrockCustomArn } from "./providers/BedrockCustomArn"
 import { buildDocLink } from "@src/utils/docLinks"
+import { MaxOutputTokensControl } from "./MaxOutputTokensControl"
 
 export interface ApiOptionsProps {
 	uriScheme: string | undefined
@@ -462,8 +463,19 @@ const ApiOptions = ({
 						isDescriptionExpanded={isDescriptionExpanded}
 						setIsDescriptionExpanded={setIsDescriptionExpanded}
 					/>
+
 				</>
 			)}
+
+			{selectedModelInfo &&
+				typeof selectedModelInfo.maxTokens === "number" &&
+				selectedModelInfo.maxTokens > 0 && (
+					<MaxOutputTokensControl
+						apiConfiguration={apiConfiguration}
+						setApiConfigurationField={setApiConfigurationField}
+						modelInfo={selectedModelInfo}
+					/>
+				)}
 
 			<ThinkingBudget
 				key={`${selectedProvider}-${selectedModelId}`}

--- a/webview-ui/src/components/settings/MaxOutputTokensControl.test.tsx
+++ b/webview-ui/src/components/settings/MaxOutputTokensControl.test.tsx
@@ -1,0 +1,280 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { MaxOutputTokensControl } from "./MaxOutputTokensControl"
+import { ApiConfiguration, ModelInfo } from "@roo/shared/api"
+
+// Mock ResizeObserver globally
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+	observe: jest.fn(),
+	unobserve: jest.fn(),
+	disconnect: jest.fn(),
+}))
+// Static import of Slider removed again to avoid TS error for non-existent module
+
+// Mock i18n
+jest.mock("react-i18next", () => ({
+	useTranslation: () => ({
+		t: (key: string) => key,
+	}),
+}))
+
+// Use jest.doMock with { virtual: true } to mock a non-existent module.
+// This mock factory will be used when '../Slider' is imported.
+jest.mock("../ui/slider", () => ({
+	__esModule: true,
+	Slider: jest.fn((props) => <div data-testid="mock-slider" {...props} />),
+}))
+
+// Import the mocked Slider *after* jest.mock
+// We need to refer to it for assertions and clearing.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const MockedSlider = require("../ui/slider").Slider as jest.Mock
+
+describe("MaxOutputTokensControl", () => {
+	const mockSetApiConfigurationField = jest.fn()
+	const mockApiConfiguration: ApiConfiguration = {
+		apiProvider: "openai",
+		openAiModelId: "test-model",
+		modelTemperature: 0.5,
+		modelMaxTokens: undefined,
+		modelMaxThinkingTokens: undefined,
+	}
+
+	beforeEach(() => {
+		mockSetApiConfigurationField.mockClear()
+		MockedSlider.mockClear()
+	})
+
+	it("should render when modelInfo.maxTokens is a positive number", () => {
+		const modelInfo: Partial<ModelInfo> = {
+			maxTokens: 16000,
+			// Add other potentially accessed properties if needed by the component, even if undefined
+		}
+
+		render(
+			<MaxOutputTokensControl
+				modelInfo={modelInfo as ModelInfo}
+				apiConfiguration={mockApiConfiguration}
+				setApiConfigurationField={mockSetApiConfigurationField}
+			/>,
+		)
+
+		expect(screen.getByTestId("max-output-tokens-control")).toBeInTheDocument()
+	})
+
+	it("should display the current value and label", () => {
+		const modelInfo: Partial<ModelInfo> = {
+			maxTokens: 16000,
+		}
+		const apiConfigurationWithOverride: ApiConfiguration = {
+			...mockApiConfiguration,
+			modelMaxTokens: 10000, // Override the default maxTokens
+		}
+
+		render(
+			<MaxOutputTokensControl
+				modelInfo={modelInfo as ModelInfo}
+				apiConfiguration={apiConfigurationWithOverride}
+				setApiConfigurationField={mockSetApiConfigurationField}
+			/>,
+		)
+
+		// Calculate the expected displayed value
+		const expectedValue = apiConfigurationWithOverride.modelMaxTokens ?? modelInfo.maxTokens!
+
+		// Assert that the current value is displayed
+		expect(screen.getByText(expectedValue.toString())).toBeInTheDocument()
+
+		// Assert that the label is displayed (using the mocked translation key)
+		expect(screen.getByText("providers.customModel.maxTokens.label")).toBeInTheDocument()
+	})
+
+	// Make the test async to use dynamic import
+	it("should pass min={8192} to the Slider component when rendered", async () => {
+		// Dynamically import Slider; it will be the mocked version due to jest.doMock
+		// Note: For this to work, the test function must be async and you await the import.
+		// However, for prop checking on a mock function, we can directly use the
+		// mockSliderImplementation defined in the jest.doMock scope.
+		// No need for dynamic import if we directly use the mock function instance.
+
+		const modelInfo: Partial<ModelInfo> = {
+			maxTokens: 16000, // A positive number to ensure rendering
+		}
+
+		render(
+			<MaxOutputTokensControl
+				modelInfo={modelInfo as ModelInfo}
+				apiConfiguration={mockApiConfiguration}
+				setApiConfigurationField={mockSetApiConfigurationField}
+			/>,
+		)
+
+		// First, ensure the main control is rendered
+		expect(screen.getByTestId("max-output-tokens-control")).toBeInTheDocument()
+
+		// Assert that the mockSliderImplementation (which is what Slider becomes)
+		// was called with the correct 'min' prop.
+		// This test is expected to fail because Slider is not yet used or not with this prop.
+		expect(MockedSlider).toHaveBeenCalledWith(
+			expect.objectContaining({
+				min: 8192,
+			}),
+			expect.anything(), // Context for React components
+		)
+	})
+
+	it("should pass max={modelInfo.maxTokens!} to the Slider component when rendered", () => {
+		const modelInfo: Partial<ModelInfo> = {
+			maxTokens: 32000, // A positive number to ensure rendering
+		}
+
+		render(
+			<MaxOutputTokensControl
+				modelInfo={modelInfo as ModelInfo}
+				apiConfiguration={mockApiConfiguration}
+				setApiConfigurationField={mockSetApiConfigurationField}
+			/>,
+		)
+
+		// First, ensure the main control is rendered
+		expect(screen.getByTestId("max-output-tokens-control")).toBeInTheDocument()
+
+		// Assert that the MockedSlider was called with the correct 'max' prop.
+		expect(MockedSlider).toHaveBeenCalledWith(
+			expect.objectContaining({
+				max: modelInfo.maxTokens,
+			}),
+			expect.anything(), // Context for React components
+		)
+	})
+
+	it("should pass step={1024} to the Slider component when rendered", () => {
+		const modelInfo: Partial<ModelInfo> = {
+			maxTokens: 16000, // A positive number to ensure rendering
+		}
+
+		render(
+			<MaxOutputTokensControl
+				modelInfo={modelInfo as ModelInfo}
+				apiConfiguration={mockApiConfiguration}
+				setApiConfigurationField={mockSetApiConfigurationField}
+			/>,
+		)
+
+		// First, ensure the main control is rendered
+		expect(screen.getByTestId("max-output-tokens-control")).toBeInTheDocument()
+
+		// Assert that the MockedSlider was called with the correct 'step' prop.
+		expect(MockedSlider).toHaveBeenCalledWith(
+			expect.objectContaining({
+				step: 1024,
+			}),
+			expect.anything(), // Context for React components
+		)
+	})
+
+	describe("should pass the correct initial value to the Slider component", () => {
+		it("when apiConfiguration.modelMaxTokens is defined", () => {
+			const modelInfo: Partial<ModelInfo> = {
+				maxTokens: 32000, // This should be ignored
+			}
+			const apiConfigurationWithOverride: ApiConfiguration = {
+				...mockApiConfiguration,
+				modelMaxTokens: 10000,
+			}
+
+			render(
+				<MaxOutputTokensControl
+					modelInfo={modelInfo as ModelInfo}
+					apiConfiguration={apiConfigurationWithOverride}
+					setApiConfigurationField={mockSetApiConfigurationField}
+				/>,
+			)
+
+			expect(MockedSlider).toHaveBeenCalledWith(
+				expect.objectContaining({
+					value: [apiConfigurationWithOverride.modelMaxTokens],
+				}),
+				expect.anything(),
+			)
+		})
+
+		it("when apiConfiguration.modelMaxTokens is undefined", () => {
+			const modelInfo: Partial<ModelInfo> = {
+				maxTokens: 16000, // This should be used
+			}
+			const apiConfigurationWithoutOverride: ApiConfiguration = {
+				...mockApiConfiguration,
+				modelMaxTokens: undefined,
+			}
+
+			render(
+				<MaxOutputTokensControl
+					modelInfo={modelInfo as ModelInfo}
+					apiConfiguration={apiConfigurationWithoutOverride}
+					setApiConfigurationField={mockSetApiConfigurationField}
+				/>,
+			)
+
+			expect(MockedSlider).toHaveBeenCalledWith(
+				expect.objectContaining({
+					value: [modelInfo.maxTokens!],
+				}),
+				expect.anything(),
+			)
+		})
+
+		it('should call setApiConfigurationField with "modelMaxTokens" and the new value when the slider value changes', () => {
+			const modelInfo: Partial<ModelInfo> = {
+				maxTokens: 32000, // A positive number to ensure rendering
+			}
+
+			render(
+				<MaxOutputTokensControl
+					modelInfo={modelInfo as ModelInfo}
+					apiConfiguration={mockApiConfiguration}
+					setApiConfigurationField={mockSetApiConfigurationField}
+				/>,
+			)
+
+			// Simulate a value change by calling the onValueChange prop of the mocked Slider
+			// We need to access the props that the mocked component was called with.
+			// MockedSlider.mock.calls[0][0] gives us the props of the first render call.
+			const sliderProps = MockedSlider.mock.calls[0][0]
+			const newValue = [20000]
+			sliderProps.onValueChange(newValue)
+
+			// Assert that setApiConfigurationField was called with the correct arguments
+			expect(mockSetApiConfigurationField).toHaveBeenCalledWith("modelMaxTokens", newValue[0])
+		})
+	})
+
+	describe("should not render when modelInfo.maxTokens is not a positive number", () => {
+		const testCases = [
+			{ name: "undefined", value: undefined },
+			{ name: "null", value: null },
+			{ name: "0", value: 0 },
+		]
+
+		it.each(testCases)("when maxTokens is $name ($value)", ({ value }) => {
+			const modelInfo: Partial<ModelInfo> = {
+				maxTokens: value as any, // Use 'as any' to allow null/undefined for testing
+			}
+
+			render(
+				<MaxOutputTokensControl
+					modelInfo={modelInfo as ModelInfo}
+					apiConfiguration={mockApiConfiguration}
+					setApiConfigurationField={mockSetApiConfigurationField}
+				/>,
+			)
+
+			// Check that the component renders null or an empty fragment
+			// by querying for the test ID and expecting it not to be there.
+			expect(screen.queryByTestId("max-output-tokens-control")).not.toBeInTheDocument()
+			// Alternatively, if the component renders null, its container might be empty or contain minimal structure.
+			// For a component that should render absolutely nothing, its direct container might be empty.
+			// However, queryByTestId is more robust for checking absence.
+		})
+	})
+})

--- a/webview-ui/src/components/settings/MaxOutputTokensControl.tsx
+++ b/webview-ui/src/components/settings/MaxOutputTokensControl.tsx
@@ -1,0 +1,46 @@
+import React from "react"
+import { ApiConfiguration, ModelInfo } from "@roo/shared/api"
+import { Slider } from "../ui/slider"
+import { useTranslation } from "react-i18next"
+
+interface MaxOutputTokensControlProps {
+	apiConfiguration: ApiConfiguration
+	setApiConfigurationField: <K extends keyof ApiConfiguration>(field: K, value: ApiConfiguration[K]) => void
+	modelInfo?: ModelInfo
+}
+
+const MIN_OUTPUT_TOKENS = 8192
+const STEP_OUTPUT_TOKENS = 1024
+
+export const MaxOutputTokensControl: React.FC<MaxOutputTokensControlProps> = ({
+	apiConfiguration,
+	setApiConfigurationField,
+	modelInfo,
+}) => {
+	const { t } = useTranslation()
+	const shouldRender = modelInfo && typeof modelInfo.maxTokens === "number" && modelInfo.maxTokens > 0
+
+	if (!shouldRender) {
+		return null
+	}
+
+	const currentMaxOutputTokens = apiConfiguration.modelMaxTokens ?? modelInfo.maxTokens!
+
+	// Basic structure for now, will be expanded in later tasks.
+	return (
+		<div data-testid="max-output-tokens-control">
+			<label className="block mb-2">{t("providers.customModel.maxTokens.label")}</label>
+			<div className="flex items-center space-x-2">
+				<Slider
+					className="flex-grow"
+					min={MIN_OUTPUT_TOKENS}
+					max={modelInfo.maxTokens!}
+					step={STEP_OUTPUT_TOKENS}
+					value={[currentMaxOutputTokens]}
+					onValueChange={([value]) => setApiConfigurationField("modelMaxTokens", value)}
+				/>
+				<div className="w-12 text-sm text-right">{currentMaxOutputTokens}</div>
+			</div>
+		</div>
+	)
+}

--- a/webview-ui/src/components/settings/MaxOutputTokensControl.tsx
+++ b/webview-ui/src/components/settings/MaxOutputTokensControl.tsx
@@ -1,15 +1,17 @@
 import React from "react"
-import { ApiConfiguration, ModelInfo } from "@roo/shared/api"
-import { Slider } from "../ui/slider"
-import { useTranslation } from "react-i18next"
+
+import { type ProviderSettings, type ModelInfo } from "@roo-code/types"
+
+import { useAppTranslation } from "@src/i18n/TranslationContext"
+import { Slider } from "@src/components/ui"
 
 interface MaxOutputTokensControlProps {
-	apiConfiguration: ApiConfiguration
-	setApiConfigurationField: <K extends keyof ApiConfiguration>(field: K, value: ApiConfiguration[K]) => void
+	apiConfiguration: ProviderSettings
+	setApiConfigurationField: <K extends keyof ProviderSettings>(field: K, value: ProviderSettings[K]) => void
 	modelInfo?: ModelInfo
 }
 
-const MIN_OUTPUT_TOKENS = 8192
+const MIN_OUTPUT_TOKENS = 2048
 const STEP_OUTPUT_TOKENS = 1024
 
 export const MaxOutputTokensControl: React.FC<MaxOutputTokensControlProps> = ({
@@ -17,7 +19,7 @@ export const MaxOutputTokensControl: React.FC<MaxOutputTokensControlProps> = ({
 	setApiConfigurationField,
 	modelInfo,
 }) => {
-	const { t } = useTranslation()
+	const { t } = useAppTranslation()
 	const shouldRender = modelInfo && typeof modelInfo.maxTokens === "number" && modelInfo.maxTokens > 0
 
 	if (!shouldRender) {
@@ -26,20 +28,18 @@ export const MaxOutputTokensControl: React.FC<MaxOutputTokensControlProps> = ({
 
 	const currentMaxOutputTokens = apiConfiguration.modelMaxTokens ?? modelInfo.maxTokens!
 
-	// Basic structure for now, will be expanded in later tasks.
 	return (
-		<div data-testid="max-output-tokens-control">
-			<label className="block mb-2">{t("providers.customModel.maxTokens.label")}</label>
-			<div className="flex items-center space-x-2">
+		<div className="flex flex-col gap-1" data-testid="max-output-tokens-control">
+			<div className="font-medium">{t("settings:thinkingBudget.maxTokens")}</div>
+			<div className="flex items-center gap-1">
 				<Slider
-					className="flex-grow"
 					min={MIN_OUTPUT_TOKENS}
 					max={modelInfo.maxTokens!}
 					step={STEP_OUTPUT_TOKENS}
 					value={[currentMaxOutputTokens]}
 					onValueChange={([value]) => setApiConfigurationField("modelMaxTokens", value)}
 				/>
-				<div className="w-12 text-sm text-right">{currentMaxOutputTokens}</div>
+				<div className="w-12 text-sm text-center">{currentMaxOutputTokens}</div>
 			</div>
 		</div>
 	)

--- a/webview-ui/src/components/settings/ThinkingBudget.tsx
+++ b/webview-ui/src/components/settings/ThinkingBudget.tsx
@@ -59,34 +59,19 @@ export const ThinkingBudget = ({ apiConfiguration, setApiConfigurationField, mod
 				</div>
 			)}
 			{(isReasoningBudgetRequired || enableReasoningEffort) && (
-				<>
-					<div className="flex flex-col gap-1">
-						<div className="font-medium">{t("settings:thinkingBudget.maxTokens")}</div>
-						<div className="flex items-center gap-1">
-							<Slider
-								min={8192}
-								max={modelInfo.maxTokens}
-								step={1024}
-								value={[customMaxOutputTokens]}
-								onValueChange={([value]) => setApiConfigurationField("modelMaxTokens", value)}
-							/>
-							<div className="w-12 text-sm text-center">{customMaxOutputTokens}</div>
-						</div>
+				<div className="flex flex-col gap-1">
+					<div className="font-medium">{t("settings:thinkingBudget.maxThinkingTokens")}</div>
+					<div className="flex items-center gap-1" data-testid="reasoning-budget">
+						<Slider
+							min={1024}
+							max={modelMaxThinkingTokens}
+							step={1024}
+							value={[customMaxThinkingTokens]}
+							onValueChange={([value]) => setApiConfigurationField("modelMaxThinkingTokens", value)}
+						/>
+						<div className="w-12 text-sm text-center">{customMaxThinkingTokens}</div>
 					</div>
-					<div className="flex flex-col gap-1">
-						<div className="font-medium">{t("settings:thinkingBudget.maxThinkingTokens")}</div>
-						<div className="flex items-center gap-1" data-testid="reasoning-budget">
-							<Slider
-								min={1024}
-								max={modelMaxThinkingTokens}
-								step={1024}
-								value={[customMaxThinkingTokens]}
-								onValueChange={([value]) => setApiConfigurationField("modelMaxThinkingTokens", value)}
-							/>
-							<div className="w-12 text-sm text-center">{customMaxThinkingTokens}</div>
-						</div>
-					</div>
-				</>
+				</div>
 			)}
 		</>
 	) : isReasoningEffortSupported ? (

--- a/webview-ui/src/components/settings/__tests__/MaxOutputTokensControl.test.tsx
+++ b/webview-ui/src/components/settings/__tests__/MaxOutputTokensControl.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react"
 
 import type { ProviderSettings, ModelInfo } from "@roo-code/types"
 
-import { MaxOutputTokensControl } from "./MaxOutputTokensControl"
+import { MaxOutputTokensControl } from "../MaxOutputTokensControl"
 import { Slider } from "@src/components/ui"
 
 // Mock ResizeObserver globally

--- a/webview-ui/src/components/settings/__tests__/ThinkingBudget.test.tsx
+++ b/webview-ui/src/components/settings/__tests__/ThinkingBudget.test.tsx
@@ -126,10 +126,10 @@ describe("ThinkingBudget", () => {
 		render(
 			<ThinkingBudget
 				{...defaultProps}
-				apiConfiguration={{ 
-					modelMaxTokens: 10000, 
+				apiConfiguration={{
+					modelMaxTokens: 10000,
 					modelMaxThinkingTokens: 9000,
-					enableReasoningEffort: true 
+					enableReasoningEffort: true,
 				}}
 				setApiConfigurationField={setApiConfigurationField}
 			/>,
@@ -140,10 +140,12 @@ describe("ThinkingBudget", () => {
 	})
 
 	it("should use default thinking tokens if not provided", () => {
-		render(<ThinkingBudget {...defaultProps} apiConfiguration={{ modelMaxTokens: 10000, enableReasoningEffort: true }} />)
+		render(<ThinkingBudget {...defaultProps} apiConfiguration={{ enableReasoningEffort: true }} />)
 
 		const slider = screen.getByTestId("slider")
-		expect(slider).toHaveValue("8192") // DEFAULT_HYBRID_REASONING_MODEL_THINKING_TOKENS
+		// Default is 8192, but capped at 80% of max output tokens (16384 * 0.8 = 13107.2, rounded down)
+		// Since default max output tokens is 16384 and 8192 < 13107, it should be 8192
+		expect(slider).toHaveValue("8192")
 	})
 
 	it("should render reasoning effort select for models that support it", () => {


### PR DESCRIPTION
### Related GitHub Issue

Closes: #3009 and #3010 

### Description

This PR addresses the issue where the "Max Tokens" configuration slider was not visible for certain models that have a configurable `maxTokens` property but are not classified as "thinking" models.

The solution involved refactoring the webview settings UI to decouple the "Max Output Tokens" slider from the "Max Thinking Tokens" slider.

Key implementation details:
- Created a new component, [`webview-ui/src/components/settings/MaxOutputTokensControl.tsx`](webview-ui/src/components/settings/MaxOutputTokensControl.tsx), to handle the display and logic for the "Max Output Tokens" slider. This component's visibility is now solely based on the presence and value of `modelInfo.maxTokens`.
- Refactored the existing [`webview-ui/src/components/settings/ThinkingBudget.tsx`](webview-ui/src/components/settings/ThinkingBudget.tsx) component to *only* manage and display the "Max Thinking Tokens" slider. Its visibility remains tied to `modelInfo.thinking === true` and `modelInfo.maxTokens`.
- Updated the [`webview-ui/src/components/settings/ApiOptions.tsx`](webview-ui/src/components/settings/ApiOptions.tsx) component to conditionally render both `MaxOutputTokensControl` and the refactored `ThinkingBudget` based on their respective visibility logic.
- Adjusted the styling of the `MaxOutputTokensControl` component to match the layout of the `ThinkingBudget` slider, displaying the numerical value to the right.
- Ensured the correct, existing localization key (`providers.customModel.maxTokens.label`) is used for the "Max Output Tokens" slider label.

The development followed a granular, iterative Test-Driven Development (TDD) approach, with small cycles of writing/modifying tests and then implementing the corresponding code, as detailed in the [`todo.md`](todo.md) file.

### Test Procedure

The changes were developed and verified using a granular TDD workflow:
1.  For each component (`MaxOutputTokensControl`, `ThinkingBudget`, `ApiOptions`), tests were written/modified first 
2.  These tests were run to confirm they failed as expected (Red phase).
3.  Corresponding code was implemented/refactored (Tasks C1.C*, C2.C*, C3.C*) to make the tests pass (Green phase).
4.  This cycle was repeated for each granular task within the component's development.
5.  Upon completion of each component's development cycle, all project unit tests (excluding e2e) were run to check for regressions.
6.   All unit tests are currently passing.

Manual UI verification is required to confirm the visual behavior:
- Test with a non-thinking model that has `maxTokens` (e.g., `gemini-2.5-pro-exp-03-25` with GCP Vertex AI): "Max Output Tokens" slider should be visible, "Max Thinking Tokens" should not.
- Test with a thinking model (e.g., `claude-3-7-sonnet-20250219:thinking` with Anthropic): Both "Max Output Tokens" and "Max Thinking Tokens" sliders should be visible.
- Test with a model that has no `maxTokens` or `maxTokens: 0`: Neither slider related to these should be visible.
- Verify default values and slider behavior in these scenarios.

### Type of Change

- [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [ ] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**:
    - [x] My code adheres to the project's style guidelines. (Addressed during development)
    - [x] There are no new linting errors or warnings (`npm run lint`). (Addressed during development/testing)
    - [x] All debug code (e.g., `console.log`) has been removed. (Addressed during development/testing)
- [x] **Testing**:
    - [x] New and/or updated tests have been added to cover my changes. (Completed as per `todo.md`)
    - [x] All tests pass locally (`npm test`). (Confirmed during development cycles)
    - [x] The application builds successfully with my changes. (Confirmed after resolving build issues)
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch. 
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below). 
- [ ] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](../../CONTRIBUTING.md).

### Screenshots / Videos

Before:
<img width="437" alt="Screenshot 2025-05-08 at 22 04 42" src="https://github.com/user-attachments/assets/675fec2d-7707-4bc0-b9a0-bec236dd417f" />

After:
<img width="439" alt="Screenshot 2025-05-08 at 22 15 33" src="https://github.com/user-attachments/assets/ebdb6c24-f1a6-4ea1-988e-612b08a62ff5" />

### Documentation Updates

[ ] No documentation updates are required.
[ ] Yes, documentation updates are required. (Assess if user-facing documentation describing settings needs updating).
[x] I am not fully sure, but I guess no.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Decouples Max Output Tokens and Max Thinking Tokens sliders in the UI, adding a new component for Max Output Tokens and refactoring existing logic, with comprehensive tests.
> 
>   - **UI Components**:
>     - Added `MaxOutputTokensControl` component in `MaxOutputTokensControl.tsx` to manage "Max Output Tokens" slider visibility based on `modelInfo.maxTokens`.
>     - Refactored `ThinkingBudget.tsx` to only manage "Max Thinking Tokens" slider, visible when `modelInfo.thinking` is true.
>     - Updated `ApiOptions.tsx` to conditionally render `MaxOutputTokensControl` and `ThinkingBudget` based on model properties.
>   - **Testing**:
>     - Added `MaxOutputTokensControl.test.tsx` to test rendering and behavior of the new component.
>     - Updated `ApiOptions.test.tsx` and `ThinkingBudget.test.tsx` to reflect changes in component logic and rendering.
>   - **Misc**:
>     - Mocked `Slider` component in `__mocks__/Slider.tsx` for testing purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 9be98c06b971d4a0481de520d994ad3c18e83ef1. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->