### PR TITLE
fix(webview): change how we manage the disposables

### DIFF
--- a/src/activate/__tests__/registerCommands.test.ts
+++ b/src/activate/__tests__/registerCommands.test.ts
@@ -55,7 +55,7 @@ describe("getVisibleProviderOrLog", () => {
 
 		expect(result).toBeUndefined()
 		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
-			"Cannot find any active and visible Roo Code provider instances.",
+			"Cannot find any active and visible Roo Code provider instance.",
 		)
 	})
 })

--- a/src/activate/__tests__/registerCommands.test.ts
+++ b/src/activate/__tests__/registerCommands.test.ts
@@ -40,7 +40,7 @@ describe("getVisibleProviderOrLog", () => {
 
 	it("returns the visible provider if found", () => {
 		const mockProvider = {} as ClineProvider
-		;(ClineProvider.getVisibleInstance as jest.Mock).mockReturnValue(mockProvider)
+		;(ClineProvider.getActiveProvider as jest.Mock).mockReturnValue(mockProvider)
 
 		const result = getVisibleProviderOrLog(mockOutputChannel)
 
@@ -49,11 +49,13 @@ describe("getVisibleProviderOrLog", () => {
 	})
 
 	it("logs and returns undefined if no provider found", () => {
-		;(ClineProvider.getVisibleInstance as jest.Mock).mockReturnValue(undefined)
+		;(ClineProvider.getActiveProvider as jest.Mock).mockReturnValue(undefined)
 
 		const result = getVisibleProviderOrLog(mockOutputChannel)
 
 		expect(result).toBeUndefined()
-		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith("Cannot find any visible Roo Code instances.")
+		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
+			"Cannot find any active and visible Roo Code provider instances.",
+		)
 	})
 })

--- a/src/activate/handleUri.ts
+++ b/src/activate/handleUri.ts
@@ -5,8 +5,8 @@ import { ClineProvider } from "../core/webview/ClineProvider"
 export const handleUri = async (uri: vscode.Uri) => {
 	const path = uri.path
 	const query = new URLSearchParams(uri.query.replace(/\+/g, "%2B"))
-	const visibleProvider = ClineProvider.getVisibleInstance()
-	if (!visibleProvider) {
+	const activeProvider = ClineProvider.getActiveProvider()
+	if (!activeProvider) {
 		return
 	}
 
@@ -14,21 +14,21 @@ export const handleUri = async (uri: vscode.Uri) => {
 		case "/glama": {
 			const code = query.get("code")
 			if (code) {
-				await visibleProvider.handleGlamaCallback(code)
+				await activeProvider.handleGlamaCallback(code)
 			}
 			break
 		}
 		case "/openrouter": {
 			const code = query.get("code")
 			if (code) {
-				await visibleProvider.handleOpenRouterCallback(code)
+				await activeProvider.handleOpenRouterCallback(code)
 			}
 			break
 		}
 		case "/requesty": {
 			const code = query.get("code")
 			if (code) {
-				await visibleProvider.handleRequestyCallback(code)
+				await activeProvider.handleRequestyCallback(code)
 			}
 			break
 		}

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -446,7 +446,9 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 					}
 					// For tab panels, their onDidDispose is handled where they are created
 					// (see: openClineInNewTab, which calls setPanel(undefined, "tab"))
-					this.view = undefined
+					if ("dispose" in this.view) {
+						this.view.dispose()
+					}
 					this.log("Cleared this.view reference due to webview disposal.")
 				}
 				// Do NOT call this.dispose() for the provider instance here.
@@ -454,7 +456,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 				// This should only handle the disposal of the webview view itself.
 			},
 			null,
-			this.context.subscriptions,
+			this.disposables,
 		)
 
 		// Listen for when color changes
@@ -581,13 +583,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 	}
 
 	public async postMessageToWebview(message: ExtensionMessage) {
-		if (this.view && this.view.webview) {
-			await this.view.webview.postMessage(message)
-		} else {
-			this.outputChannel.appendLine(
-				`Cannot post message to webview (${this.viewType}): Webview is not available. Message type: ${message.type}`,
-			)
-		}
+		await this.view?.webview.postMessage(message)
 	}
 
 	private async getHMRHtmlContent(webview: vscode.Webview): Promise<string> {

--- a/src/core/webview/__tests__/ClineProvider.test.ts
+++ b/src/core/webview/__tests__/ClineProvider.test.ts
@@ -328,10 +328,9 @@ describe("ClineProvider", () => {
 
 	test("constructor initializes correctly", () => {
 		expect(provider).toBeInstanceOf(ClineProvider)
-		// Since getVisibleInstance returns the last instance where view.visible is true
 		// @ts-ignore - accessing private property for testing
 		provider.view = mockWebviewView
-		expect(ClineProvider.getVisibleInstance()).toBe(provider)
+		expect(ClineProvider.getActiveProvider()).toBe(provider)
 	})
 
 	test("resolveWebviewView sets up webview correctly", async () => {

--- a/src/core/webview/__tests__/ClineProvider.test.ts
+++ b/src/core/webview/__tests__/ClineProvider.test.ts
@@ -227,6 +227,11 @@ jest.mock("../../../integrations/misc/extract-text", () => ({
 	}),
 }))
 
+jest.mock("../../../activate/registerCommands.ts", () => ({
+	getPanel: jest.fn(),
+	setPanel: jest.fn(),
+}))
+
 afterAll(() => {
 	jest.restoreAllMocks()
 })
@@ -309,6 +314,9 @@ describe("ClineProvider", () => {
 			}),
 			onDidChangeVisibility: jest.fn().mockImplementation(() => ({ dispose: jest.fn() })),
 		} as unknown as vscode.WebviewView
+
+		const { getPanel } = require("../../../activate/registerCommands")
+		;(getPanel as jest.Mock).mockReturnValue(mockWebviewView)
 
 		provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
 

--- a/src/shared/array.ts
+++ b/src/shared/array.ts
@@ -15,3 +15,8 @@ export function findLastIndex<T>(array: Array<T>, predicate: (value: T, index: n
 	}
 	return -1
 }
+
+export function findLast<T>(array: Array<T>, predicate: (value: T, index: number, obj: T[]) => boolean): T | undefined {
+	const index = findLastIndex(array, predicate)
+	return index === -1 ? undefined : array[index]
+}

--- a/src/shared/array.ts
+++ b/src/shared/array.ts
@@ -15,8 +15,3 @@ export function findLastIndex<T>(array: Array<T>, predicate: (value: T, index: n
 	}
 	return -1
 }
-
-export function findLast<T>(array: Array<T>, predicate: (value: T, index: number, obj: T[]) => boolean): T | undefined {
-	const index = findLastIndex(array, predicate)
-	return index === -1 ? undefined : array[index]
-}


### PR DESCRIPTION
### Related GitHub Issue

Closes: #2591

### Description

This is mostly one-shotted by 2.5 pro with some adjustments

- Changed how we get the current active instance (an instance can be active but not visible yet)
- Changed how we dispose the webview instance, instead of relying on the global provider `dispose()` we're separating the disposal of view instance. I'm guessing whenever we move the panel to other panel/sidebar, there's some mismatch when getting the instance due to how we're disposing them.
- Added 200ms delay to 'wait' for an instance to be active _and_ visible

The command listener seems to be received by the wrong instance, which is why clicking on any of the menu doesn't do anything.

### Test Procedure

- Open RooCode
- Try navigating between tabs (prompts, settings, etc)
- Move it to other sidebar or panel
- Try navigating between tabs, it should work now where previously it won't

### Type of Change

<!-- Mark all applicable boxes with an 'x'. -->

- [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [ ] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [x] **Testing**:
    - [x] New and/or updated tests have been added to cover my changes.
    - [x] All tests pass locally (`npm test`).
    - [x] The application builds successfully with my changes.
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [ ] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](../../CONTRIBUTING.md).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor webview instance management in `ClineProvider` to handle disposals separately and ensure correct active instance handling.
> 
>   - **Behavior**:
>     - Replaces `ClineProvider.getVisibleInstance()` with `ClineProvider.getActiveProvider()` in `registerCommands.ts`, `handleUri.ts`, and `ClineProvider.ts`.
>     - Separates disposal of webview instances from global provider disposal in `ClineProvider.ts`.
>     - Adds 200ms delay in `registerCommands.ts` to ensure instance is active and visible.
>   - **Tests**:
>     - Updates tests in `registerCommands.test.ts` and `ClineProvider.test.ts` to mock `getActiveProvider()` instead of `getVisibleInstance()`.
>   - **Misc**:
>     - Removes `findLast()` from `array.ts` as it is no longer used.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b397eff3935b0417cbfb9ebdbd1822e2f5e6ad76. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->