### PR TITLE
[Condense] Add button for basic condensing of task message history

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1181,6 +1181,22 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 		}
 	}
 
+	/* Condenses a task's message history to use fewer tokens. */
+	async condenseTaskHistory(id: string) {
+		let task = undefined
+		for (let i = this.clineStack.length - 1; i >= 0; i--) {
+			if (this.clineStack[i].taskId === id) {
+				task = this.clineStack[i]
+				break
+			}
+		}
+		if (!task) {
+			const { historyItem } = await this.getTaskWithId(id)
+			task = await this.initClineWithHistoryItem(historyItem)
+		}
+		await task.condenseHistory()
+	}
+
 	async deleteTaskFromState(id: string) {
 		const taskHistory = this.getGlobalState("taskHistory") ?? []
 		const updatedTaskHistory = taskHistory.filter((task) => task.id !== id)

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -198,6 +198,9 @@ export const webviewMessageHandler = async (provider: ClineProvider, message: We
 		case "deleteTaskWithId":
 			provider.deleteTaskWithId(message.text!)
 			break
+		case "condenseTaskHistory":
+			provider.condenseTaskHistory(message.text!)
+			break
 		case "deleteMultipleTasksWithIds": {
 			const ids = message.ids
 

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -38,6 +38,7 @@ export interface WebviewMessage {
 		| "showTaskWithId"
 		| "deleteTaskWithId"
 		| "exportTaskWithId"
+		| "condenseTaskHistory"
 		| "importSettings"
 		| "exportSettings"
 		| "resetState"

--- a/webview-ui/src/components/chat/TaskActions.tsx
+++ b/webview-ui/src/components/chat/TaskActions.tsx
@@ -27,6 +27,13 @@ export const TaskActions = ({ item }: { item: HistoryItem | undefined }) => {
 					<Button
 						variant="ghost"
 						size="sm"
+						title={t("chat:task.condenseTaskHistory")}
+						onClick={() => vscode.postMessage({ type: "condenseTaskHistory", text: item?.id })}>
+						<span className="codicon codicon-file-zip" />
+					</Button>
+					<Button
+						variant="ghost"
+						size="sm"
 						title={t("chat:task.delete")}
 						onClick={(e) => {
 							e.stopPropagation()

--- a/webview-ui/src/i18n/locales/en/chat.json
+++ b/webview-ui/src/i18n/locales/en/chat.json
@@ -10,6 +10,7 @@
 		"contextWindow": "Context Length:",
 		"closeAndStart": "Close task and start a new one",
 		"export": "Export task history",
+		"condenseTaskHistory": "Condense task message history",
 		"delete": "Delete Task (Shift + Click to skip confirmation)"
 	},
 	"unpin": "Unpin",


### PR DESCRIPTION
### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: # <!-- Replace with the issue number, e.g., Closes: #123 -->

### Description
Adds a button to the expanded `TaskActions` component which allows the user to manually condense the message history. Currently this button just calls the existing code to truncate messages if the context window is full, but its implementation will be replaced with an LLM call to summarize the message history a la https://github.com/cline/cline/pull/3086.

### Test Procedure

<!--
Detail the steps to test your changes. This helps reviewers verify your work.
- How did you test this specific implementation? (e.g., unit tests, manual testing steps)
- How can reviewers reproduce your tests or verify the fix/feature?
- Include relevant testing environment details if applicable.
-->

### Type of Change
- [ ] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [x] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist
- [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [ ] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [ ] **Self-Review**: I have performed a thorough self-review of my code.
- [ ] **Code Quality**:
    - [ ] My code adheres to the project's style guidelines.
    - [ ] There are no new linting errors or warnings (`npm run lint`).
    - [ ] All debug code (e.g., `console.log`) has been removed.
- [ ] **Testing**:
    - [ ] New and/or updated tests have been added to cover my changes.
    - [ ] All tests pass locally (`npm test`).
    - [ ] The application builds successfully with my changes.
- [ ] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [ ] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [ ] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [ ] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](../CONTRIBUTING.md).

### Screenshots / Videos

<img width="619" alt="Screenshot 2025-05-12 at 3 18 00 PM" src="https://github.com/user-attachments/assets/4dd316c1-97bc-4ff7-b0da-918ab781d07a" />

### Documentation Updates

Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [x] Yes, documentation updates are required. 

No obvious spot for this in the docs right now but ideally all UI features should be documented.

### Additional Notes
The current implementation of `task.condenseHistory` is pretty useless since `maybeTruncateConversationHistory` is called in `task.attemptApiRequest` anyway, but the goal is to replace the `condenseHistory` implementation with an LLM summarization.
