### PR TITLE
UI Tweak: Fade buttons on history preview (homescreen) if no interaction in progress. 

### DIFF
--- a/webview-ui/src/components/history/CopyButton.tsx
+++ b/webview-ui/src/components/history/CopyButton.tsx
@@ -7,9 +7,10 @@ import { useAppTranslation } from "@/i18n/TranslationContext"
 
 type CopyButtonProps = {
 	itemTask: string
+	className?: string
 }
 
-export const CopyButton = ({ itemTask }: CopyButtonProps) => {
+export const CopyButton = ({ itemTask, className }: CopyButtonProps) => {
 	const { isCopied, copy } = useClipboard()
 	const { t } = useAppTranslation()
 
@@ -31,7 +32,7 @@ export const CopyButton = ({ itemTask }: CopyButtonProps) => {
 			title={t("history:copyPrompt")}
 			onClick={onCopy}
 			data-testid="copy-prompt-button"
-			className="opacity-50 hover:opacity-100">
+			className={cn("opacity-50 hover:opacity-100", className)}>
 			<span className={cn("codicon scale-80", { "codicon-check": isCopied, "codicon-copy": !isCopied })} />
 		</Button>
 	)

--- a/webview-ui/src/components/history/HistoryPreview.tsx
+++ b/webview-ui/src/components/history/HistoryPreview.tsx
@@ -19,14 +19,17 @@ const HistoryPreview = () => {
 						{tasks.slice(0, 3).map((item) => (
 							<div
 								key={item.id}
-								className="bg-vscode-editor-background rounded relative overflow-hidden cursor-pointer border border-vscode-toolbar-hoverBackground/30 hover:border-vscode-toolbar-hoverBackground/60"
+								className="group bg-vscode-editor-background rounded relative overflow-hidden cursor-pointer border border-vscode-toolbar-hoverBackground/30 hover:border-vscode-toolbar-hoverBackground/60"
 								onClick={() => vscode.postMessage({ type: "showTaskWithId", text: item.id })}>
 								<div className="flex flex-col gap-2 p-3 pt-1">
 									<div className="flex justify-between items-center">
 										<span className="text-xs font-medium text-vscode-descriptionForeground uppercase">
 											{formatDate(item.ts)}
 										</span>
-										<CopyButton itemTask={item.task} />
+										<CopyButton
+											itemTask={item.task}
+											className="opacity-20 group-hover:opacity-50"
+										/>
 									</div>
 									<div
 										className="text-vscode-foreground overflow-hidden whitespace-pre-wrap"


### PR DESCRIPTION
### Description

Minor UI Tweak: Fades the buttons on the homescreen history preview section if there's no interaction in progress to reduce visual clutter on that screen. This makes no functional difference, it simply reduces the visual _prominence_ of the copy buttons and 'mutes' them if the relevant item is not currently in an active/hover state. 

(Before: Left / After: Right) 

![Screenshot 2025-05-12 at 7 43 37 PM](https://github.com/user-attachments/assets/f1cf128a-4c30-472d-a426-ec8f6191844c)

### Type of Change

- [X] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).

### Pre-Submission Checklist


- [X] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [X] **Self-Review**: I have performed a thorough self-review of my code.
- [ ] **Code Quality**:
    - [X] My code adheres to the project's style guidelines.
    - [X] There are no new linting errors or warnings (`npm run lint`).
    - [X] All debug code (e.g., `console.log`) has been removed.
- [X] **Testing**:
    - [X] New and/or updated tests have been added to cover my changes.
    - [X] All tests pass locally (`npm test`).
    - [X] The application builds successfully with my changes.
- [X] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [X] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [X] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [X] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](../CONTRIBUTING.md).

### Screenshots / Videos

https://github.com/user-attachments/assets/56c5128f-902f-44e5-a1a1-c012d56ccd21

### Documentation Updates

Does this PR necessitate updates to user-facing documentation?
- [X] No documentation updates are required.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> UI change to fade `CopyButton` in `HistoryPreview` when not interacted with, reducing visual clutter.
> 
>   - **UI Change**:
>     - `CopyButton` in `CopyButton.tsx` now accepts an optional `className` prop to customize styles.
>     - In `HistoryPreview.tsx`, `CopyButton` is given `className` with `opacity-20` and `group-hover:opacity-50` to fade when not hovered.
>   - **Behavior**:
>     - Buttons in history preview fade to reduce visual clutter when not interacted with.
>     - No functional changes, purely stylistic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b6b4fb5cd0f0c00d52fd038e5c4ec5192b558019. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->