### PR TITLE
fix: prevent dump of an entire file into the context on user edit 

### DIFF
--- a/src/core/tools/applyDiffTool.ts
+++ b/src/core/tools/applyDiffTool.ts
@@ -8,7 +8,6 @@ import { ToolUse, RemoveClosingTag } from "../../shared/tools"
 import { formatResponse } from "../prompts/responses"
 import { AskApproval, HandleError, PushToolResult } from "../../shared/tools"
 import { fileExistsAtPath } from "../../utils/fs"
-import { addLineNumbers } from "../../integrations/misc/extract-text"
 import { RecordSource } from "../context-tracking/FileContextTrackerTypes"
 import { telemetryService } from "../../services/telemetry/TelemetryService"
 import { unescapeHtmlEntities } from "../../utils/text-normalization"
@@ -163,7 +162,8 @@ export async function applyDiffTool(
 				return
 			}
 
-			const { newProblemsMessage, userEdits, finalContent } = await cline.diffViewProvider.saveChanges()
+			// Call saveChanges to update the DiffViewProvider properties
+			await cline.diffViewProvider.saveChanges()
 
 			// Track file edit operation
 			if (relPath) {
@@ -178,33 +178,13 @@ export async function applyDiffTool(
 				partFailHint = `But unable to apply all diff parts to file: ${absolutePath}, silently use <read_file> tool to check newest file version and re-apply diffs\n`
 			}
 
-			if (userEdits) {
-				await cline.say(
-					"user_feedback_diff",
-					JSON.stringify({
-						tool: fileExists ? "editedExistingFile" : "newFileCreated",
-						path: getReadablePath(cline.cwd, relPath),
-						diff: userEdits,
-					} satisfies ClineSayTool),
-				)
+			// Get the formatted response message
+			const message = await cline.diffViewProvider.pushToolWriteResult(cline, cline.cwd, !fileExists)
 
-				pushToolResult(
-					`The user made the following updates to your content:\n\n${userEdits}\n\n` +
-						partFailHint +
-						`The updated content, which includes both your original modifications and the user's edits, has been successfully saved to ${relPath.toPosix()}. Here is the full, updated content of the file, including line numbers:\n\n` +
-						`<final_file_content path="${relPath.toPosix()}">\n${addLineNumbers(
-							finalContent || "",
-						)}\n</final_file_content>\n\n` +
-						`Please note:\n` +
-						`1. You do not need to re-write the file with these changes, as they have already been applied.\n` +
-						`2. Proceed with the task using this updated file content as the new baseline.\n` +
-						`3. If the user's edits have addressed part of the task or changed the requirements, adjust your approach accordingly.` +
-						`${newProblemsMessage}`,
-				)
+			if (partFailHint) {
+				pushToolResult(partFailHint + message)
 			} else {
-				pushToolResult(
-					`Changes successfully applied to ${relPath.toPosix()}:\n\n${newProblemsMessage}\n` + partFailHint,
-				)
+				pushToolResult(message)
 			}
 
 			await cline.diffViewProvider.reset()

--- a/src/core/tools/insertContentTool.ts
+++ b/src/core/tools/insertContentTool.ts
@@ -128,7 +128,8 @@ export async function insertContentTool(
 			return
 		}
 
-		const { newProblemsMessage, userEdits, finalContent } = await cline.diffViewProvider.saveChanges()
+		// Call saveChanges to update the DiffViewProvider properties
+		await cline.diffViewProvider.saveChanges()
 
 		// Track file edit operation
 		if (relPath) {
@@ -137,34 +138,14 @@ export async function insertContentTool(
 
 		cline.didEditFile = true
 
-		if (!userEdits) {
-			pushToolResult(
-				`The content was successfully inserted in ${relPath.toPosix()} at line ${lineNumber}.${newProblemsMessage}`,
-			)
-			await cline.diffViewProvider.reset()
-			return
-		}
-
-		await cline.say(
-			"user_feedback_diff",
-			JSON.stringify({
-				tool: "insertContent",
-				path: getReadablePath(cline.cwd, relPath),
-				diff: userEdits,
-				lineNumber: lineNumber,
-			} satisfies ClineSayTool),
+		// Get the formatted response message
+		const message = await cline.diffViewProvider.pushToolWriteResult(
+			cline,
+			cline.cwd,
+			false, // Always false for insert_content
 		)
 
-		pushToolResult(
-			`The user made the following updates to your content:\n\n${userEdits}\n\n` +
-				`The updated content has been successfully saved to ${relPath.toPosix()}. Here is the full, updated content of the file:\n\n` +
-				`<final_file_content path="${relPath.toPosix()}">\n${finalContent}\n</final_file_content>\n\n` +
-				`Please note:\n` +
-				`1. You do not need to re-write the file with these changes, as they have already been applied.\n` +
-				`2. Proceed with the task using this updated file content as the new baseline.\n` +
-				`3. If the user's edits have addressed part of the task or changed the requirements, adjust your approach accordingly.` +
-				`${newProblemsMessage}`,
-		)
+		pushToolResult(message)
 
 		await cline.diffViewProvider.reset()
 	} catch (error) {

--- a/src/core/tools/searchAndReplaceTool.ts
+++ b/src/core/tools/searchAndReplaceTool.ts
@@ -211,7 +211,8 @@ export async function searchAndReplaceTool(
 			return
 		}
 
-		const { newProblemsMessage, userEdits, finalContent } = await cline.diffViewProvider.saveChanges()
+		// Call saveChanges to update the DiffViewProvider properties
+		await cline.diffViewProvider.saveChanges()
 
 		// Track file edit operation
 		if (relPath) {
@@ -220,34 +221,14 @@ export async function searchAndReplaceTool(
 
 		cline.didEditFile = true
 
-		if (!userEdits) {
-			pushToolResult(`The content was successfully replaced in ${relPath}.${newProblemsMessage}`)
-			await cline.diffViewProvider.reset()
-			return
-		}
-
-		await cline.say(
-			"user_feedback_diff",
-			JSON.stringify({
-				tool: "appliedDiff",
-				path: getReadablePath(cline.cwd, relPath),
-				diff: userEdits,
-			} satisfies ClineSayTool),
+		// Get the formatted response message
+		const message = await cline.diffViewProvider.pushToolWriteResult(
+			cline,
+			cline.cwd,
+			false, // Always false for search_and_replace
 		)
 
-		// Format and send response with user's updates
-		const resultMessage = [
-			`The user made the following updates to your content:\n\n${userEdits}\n\n`,
-			`The updated content has been successfully saved to ${validRelPath.toPosix()}. Here is the full, updated content of the file:\n\n`,
-			`<final_file_content path="${validRelPath.toPosix()}">\n${finalContent}\n</final_file_content>\n\n`,
-			`Please note:\n`,
-			`1. You do not need to re-write the file with these changes, as they have already been applied.\n`,
-			`2. Proceed with the task using the updated file content as the new baseline.\n`,
-			`3. If the user's edits have addressed part of the task or changed the requirements, adjust your approach accordingly.`,
-			newProblemsMessage,
-		].join("")
-
-		pushToolResult(resultMessage)
+		pushToolResult(message)
 
 		// Record successful tool usage and cleanup
 		cline.recordToolUsage("search_and_replace")

--- a/src/core/tools/writeToFileTool.ts
+++ b/src/core/tools/writeToFileTool.ts
@@ -8,7 +8,7 @@ import { formatResponse } from "../prompts/responses"
 import { ToolUse, AskApproval, HandleError, PushToolResult, RemoveClosingTag } from "../../shared/tools"
 import { RecordSource } from "../context-tracking/FileContextTrackerTypes"
 import { fileExistsAtPath } from "../../utils/fs"
-import { addLineNumbers, stripLineNumbers, everyLineHasLineNumbers } from "../../integrations/misc/extract-text"
+import { stripLineNumbers, everyLineHasLineNumbers } from "../../integrations/misc/extract-text"
 import { getReadablePath } from "../../utils/path"
 import { isPathOutsideWorkspace } from "../../utils/pathUtils"
 import { detectCodeOmission } from "../../integrations/editor/detect-omission"
@@ -208,7 +208,8 @@ export async function writeToFileTool(
 				return
 			}
 
-			const { newProblemsMessage, userEdits, finalContent } = await cline.diffViewProvider.saveChanges()
+			// Call saveChanges to update the DiffViewProvider properties
+			await cline.diffViewProvider.saveChanges()
 
 			// Track file edit operation
 			if (relPath) {
@@ -217,31 +218,10 @@ export async function writeToFileTool(
 
 			cline.didEditFile = true // used to determine if we should wait for busy terminal to update before sending api request
 
-			if (userEdits) {
-				await cline.say(
-					"user_feedback_diff",
-					JSON.stringify({
-						tool: fileExists ? "editedExistingFile" : "newFileCreated",
-						path: getReadablePath(cline.cwd, relPath),
-						diff: userEdits,
-					} satisfies ClineSayTool),
-				)
+			// Get the formatted response message
+			const message = await cline.diffViewProvider.pushToolWriteResult(cline, cline.cwd, !fileExists)
 
-				pushToolResult(
-					`The user made the following updates to your content:\n\n${userEdits}\n\n` +
-						`The updated content, which includes both your original modifications and the user's edits, has been successfully saved to ${relPath.toPosix()}. Here is the full, updated content of the file, including line numbers:\n\n` +
-						`<final_file_content path="${relPath.toPosix()}">\n${addLineNumbers(
-							finalContent || "",
-						)}\n</final_file_content>\n\n` +
-						`Please note:\n` +
-						`1. You do not need to re-write the file with these changes, as they have already been applied.\n` +
-						`2. Proceed with the task using this updated file content as the new baseline.\n` +
-						`3. If the user's edits have addressed part of the task or changed the requirements, adjust your approach accordingly.` +
-						`${newProblemsMessage}`,
-				)
-			} else {
-				pushToolResult(`The content was successfully saved to ${relPath.toPosix()}.${newProblemsMessage}`)
-			}
+			pushToolResult(message)
 
 			await cline.diffViewProvider.reset()
 

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -290,9 +290,13 @@ export class DiffViewProvider {
 				problems: this.newProblemsMessage || undefined,
 				notice: {
 					i: [
-						"You do not need to re-read the file, as you have seen all changes in the diff above.",
+						"You do not need to re-read the file, as you have seen all changes",
 						"Proceed with the task using these changes as the new baseline.",
-						"If the user's edits have addressed part of the task or changed the requirements, adjust your approach accordingly.",
+						...(this.userEdits
+							? [
+									"If the user's edits have addressed part of the task or changed the requirements, adjust your approach accordingly.",
+								]
+							: []),
 					],
 				},
 			},

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -3,11 +3,14 @@ import * as path from "path"
 import * as fs from "fs/promises"
 import * as diff from "diff"
 import stripBom from "strip-bom"
+import { XMLBuilder } from "fast-xml-parser"
 
 import { createDirectoriesForFile } from "../../utils/fs"
-import { arePathsEqual } from "../../utils/path"
+import { arePathsEqual, getReadablePath } from "../../utils/path"
 import { formatResponse } from "../../core/prompts/responses"
 import { diagnosticsToProblemsString, getNewDiagnostics } from "../diagnostics"
+import { ClineSayTool } from "../../shared/ExtensionMessage"
+import { Task } from "../../core/task/Task"
 
 import { DecorationController } from "./DecorationController"
 
@@ -15,6 +18,9 @@ export const DIFF_VIEW_URI_SCHEME = "cline-diff"
 
 // TODO: https://github.com/cline/cline/pull/3354
 export class DiffViewProvider {
+	// Properties to store the results of saveChanges
+	newProblemsMessage?: string
+	userEdits?: string
 	editType?: "create" | "modify"
 	isEditing = false
 	originalContent: string | undefined
@@ -235,11 +241,85 @@ export class DiffViewProvider {
 				normalizedEditedContent,
 			)
 
+			// Store the results as class properties for formatFileWriteResponse to use
+			this.newProblemsMessage = newProblemsMessage
+			this.userEdits = userEdits
+
 			return { newProblemsMessage, userEdits, finalContent: normalizedEditedContent }
 		} else {
 			// No changes to Roo's edits.
+			// Store the results as class properties for formatFileWriteResponse to use
+			this.newProblemsMessage = newProblemsMessage
+			this.userEdits = undefined
+
 			return { newProblemsMessage, userEdits: undefined, finalContent: normalizedEditedContent }
 		}
+	}
+
+	/**
+	 * Formats a standardized XML response for file write operations
+	 *
+	 * @param cwd Current working directory for path resolution
+	 * @param isNewFile Whether this is a new file or an existing file being modified
+	 * @returns Formatted message and say object for UI feedback
+	 */
+	async pushToolWriteResult(task: Task, cwd: string, isNewFile: boolean): Promise<string> {
+		if (!this.relPath) {
+			throw new Error("No file path available in DiffViewProvider")
+		}
+
+		// Only send user_feedback_diff if userEdits exists
+		if (this.userEdits) {
+			// Create say object for UI feedback
+			const say: ClineSayTool = {
+				tool: isNewFile ? "newFileCreated" : "editedExistingFile",
+				path: getReadablePath(cwd, this.relPath),
+				diff: this.userEdits,
+			}
+
+			// Send the user feedback
+			await task.say("user_feedback_diff", JSON.stringify(say))
+		}
+
+		// Build XML response
+		const xmlObj = {
+			file_write_result: {
+				path: this.relPath,
+				operation: isNewFile ? "created" : "modified",
+				user_edits: this.userEdits ? this.userEdits : undefined,
+				problems: this.newProblemsMessage || undefined,
+				notice: {
+					i: [
+						"You do not need to re-read the file, as you have seen all changes in the diff above.",
+						"Proceed with the task using these changes as the new baseline.",
+						"If the user's edits have addressed part of the task or changed the requirements, adjust your approach accordingly.",
+					],
+				},
+			},
+		}
+
+		const builder = new XMLBuilder({
+			format: true,
+			indentBy: "",
+			suppressEmptyNode: true,
+			processEntities: false,
+			tagValueProcessor: (name, value) => {
+				if (typeof value === "string") {
+					// Only escape <, >, and & characters
+					return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+				}
+				return value
+			},
+			attributeValueProcessor: (name, value) => {
+				if (typeof value === "string") {
+					// Only escape <, >, and & characters
+					return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+				}
+				return value
+			},
+		})
+
+		return builder.build(xmlObj)
 	}
 
 	async revertChanges(): Promise<void> {


### PR DESCRIPTION
## Problem fixed by this PR

This pull request fixes the problem of dumping an entire file into the context under the following condition:

1. auto approve is turned off for writes
2. the model proposes a file modification 
3. the user modifies the file before clicking save 
4. user clicks save

After the user clicks save, `<final_file_content>[entire file]</final_file_content>` is dumped into the conversation even for a one-line change, which is a severe problem because it:

1. distracts the model from the focus (especially with large files)
2. bloats context 
3. increases costs 

Fixes: #3647

## The fix

The change by the user shown in Step-3, above, is provided to the model in the existing implementation using the standard `diff` format, so it understands the change that was made.  All we are doing here is omitting  `<final_file_content>[entire file]</final_file_content>` to prevent context bloat and maintain model focus.

Because this issue exists in all tools that modify files, this pull request is also a refactor to standardize the tool response for file modifications across `write_to_file`, `apply_diff`, `search_and_replace`, and `insert_content`:

```ts
]$ git diff  origin/main... --stat
 src/core/tools/applyDiffTool.ts             | 36 ++++------------
 src/core/tools/insertContentTool.ts         | 35 ++++------------
 src/core/tools/searchAndReplaceTool.ts      | 35 ++++------------
 src/core/tools/writeToFileTool.ts           | 32 +++------------
 src/integrations/editor/DiffViewProvider.ts | 86 ++++++++++++++++++++++++++++++++++++++-
 5 files changed, 115 insertions(+), 109 deletions(-)
```


## History

The `final_file_content` feature was introduced by Saoud Rizwan and copy-pasted across all file modification tools as new tools were added.

1. **write_to_file**: Commit cbf942e700de2edefe0d0b2a39670bc3eda8364d (Oct 18, 2024) by Saoud Rizwan
7. **apply_diff**: Commit c0b070e6f0e36092219424f341a73a2c0e4f9044, PR #52 (Dec 8, 2024) by @mrubens 
8. **search_and_replace** and **insert_content**: Commit 2c97b59ed1d412b0c298cc9f41fac26697ed9e98 (Jan 21, 2025) by @mrubens 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactored to centralize response formatting and messaging in `DiffViewProvider`, adding `pushToolWriteResult` for XML response and user feedback, affecting multiple tool files.
> 
>   - **Refactoring**:
>     - Centralized response formatting and messaging logic in `DiffViewProvider`.
>     - Added `pushToolWriteResult` method to `DiffViewProvider` for XML response formatting and user feedback messaging.
>     - Stores results from `saveChanges` in class properties.
>   - **Behavior**:
>     - Tool files (`applyDiffTool.ts`, `insertContentTool.ts`, `searchAndReplaceTool.ts`, `writeToFileTool.ts`) now call `pushToolWriteResult` instead of duplicating logic.
>     - Sends `user_feedback_diff` only when user edits exist.
>     - Configures `XMLBuilder` with no indentation for cleaner output.
>   - **Misc**:
>     - Removed `addLineNumbers` import from `applyDiffTool.ts` and `writeToFileTool.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a119ca4586e8dee604d7ed99f28adb5b4577bbf3. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->