### PR TITLE
Fix: Missing or inconsistent syntax highlighting across UI components

### DIFF
--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -13,6 +13,7 @@ import { useExtensionState } from "@src/context/ExtensionStateContext"
 import { findMatchingResourceOrTemplate } from "@src/utils/mcp"
 import { vscode } from "@src/utils/vscode"
 import { removeLeadingNonAlphanumeric } from "@src/utils/removeLeadingNonAlphanumeric"
+import { getLanguageFromPath } from "@src/utils/getLanguageFromPath"
 import { Button } from "@src/components/ui"
 
 import { ToolUseBlock, ToolUseBlockHeader } from "../common/ToolUseBlock"
@@ -291,7 +292,7 @@ export const ChatRowContent = ({
 						<CodeAccordian
 							path={tool.path}
 							code={tool.content ?? tool.diff}
-							language={tool.tool === "appliedDiff" ? "diff" : undefined}
+							language="diff"
 							progressStatus={message.progressStatus}
 							isLoading={message.partial}
 							isExpanded={isExpanded}
@@ -339,6 +340,7 @@ export const ChatRowContent = ({
 						<CodeAccordian
 							path={tool.path}
 							code={tool.diff}
+							language="diff"
 							progressStatus={message.progressStatus}
 							isLoading={message.partial}
 							isExpanded={isExpanded}
@@ -356,6 +358,7 @@ export const ChatRowContent = ({
 						<CodeAccordian
 							path={tool.path}
 							code={tool.content}
+							language={getLanguageFromPath(tool.path || "") || "log"}
 							isLoading={message.partial}
 							isExpanded={isExpanded}
 							onToggleExpand={onToggleExpand}
@@ -401,6 +404,7 @@ export const ChatRowContent = ({
 						</div>
 						<CodeAccordian
 							code={tool.content}
+							language="markdown"
 							isLoading={message.partial}
 							isExpanded={isExpanded}
 							onToggleExpand={onToggleExpand}
@@ -441,7 +445,7 @@ export const ChatRowContent = ({
 						<CodeAccordian
 							path={tool.path}
 							code={tool.content}
-							language="shell-session"
+							language="shellsession"
 							isExpanded={isExpanded}
 							onToggleExpand={onToggleExpand}
 						/>
@@ -461,6 +465,7 @@ export const ChatRowContent = ({
 						<CodeAccordian
 							path={tool.path}
 							code={tool.content}
+							language="markdown"
 							isExpanded={isExpanded}
 							onToggleExpand={onToggleExpand}
 						/>
@@ -490,7 +495,7 @@ export const ChatRowContent = ({
 						<CodeAccordian
 							path={tool.path! + (tool.filePattern ? `/(${tool.filePattern})` : "")}
 							code={tool.content}
-							language="log"
+							language="shellsession"
 							isExpanded={isExpanded}
 							onToggleExpand={onToggleExpand}
 						/>
@@ -710,7 +715,7 @@ export const ChatRowContent = ({
 											backgroundColor: "var(--vscode-editor-background)",
 											borderTop: "none",
 										}}>
-										<CodeBlock source={`${"```"}plaintext\n${message.text || ""}\n${"```"}`} />
+										<CodeBlock source={message.text || ""} language="xml" />
 									</div>
 								)}
 							</div>

--- a/webview-ui/src/components/common/CodeAccordian.tsx
+++ b/webview-ui/src/components/common/CodeAccordian.tsx
@@ -11,7 +11,7 @@ import CodeBlock from "./CodeBlock"
 interface CodeAccordianProps {
 	path?: string
 	code?: string
-	language?: string | undefined
+	language: string
 	progressStatus?: ToolProgressStatus
 	isLoading?: boolean
 	isExpanded: boolean
@@ -29,7 +29,7 @@ const CodeAccordian = ({
 	isFeedback,
 	onToggleExpand,
 }: CodeAccordianProps) => {
-	const inferredLanguage = useMemo(() => language ?? (path ? getLanguageFromPath(path) : undefined), [path, language])
+	const inferredLanguage = useMemo(() => language ?? (path ? getLanguageFromPath(path) : "txt"), [path, language])
 	const source = useMemo(() => code.trim(), [code])
 	const hasHeader = Boolean(path || isFeedback)
 

--- a/webview-ui/src/components/common/CodeBlock.tsx
+++ b/webview-ui/src/components/common/CodeBlock.tsx
@@ -30,7 +30,7 @@ minWidth: "max-content",
 interface CodeBlockProps {
 	source?: string
 	rawSource?: string // Add rawSource prop for copying raw text
-	language?: string
+	language: string
 	preStyle?: React.CSSProperties
 	initialWordWrap?: boolean
 	collapsedHeight?: number
@@ -637,57 +637,48 @@ const CodeBlock = memo(
 						ref={copyButtonWrapperRef}
 						onMouseOver={() => updateCodeBlockButtonPosition()}
 						style={{ gap: 0 }}>
-						{language && (
-							<LanguageSelect
-								value={currentLanguage}
-								style={{
-									width: `calc(${currentLanguage?.length || 0}ch + 9px)`,
-								}}
-								onClick={(e) => {
-									e.currentTarget.focus()
-								}}
-								onChange={(e) => {
-									const newLang = normalizeLanguage(e.target.value)
-									userChangedLanguageRef.current = true
-									setCurrentLanguage(newLang)
-									if (onLanguageChange) {
-										onLanguageChange(newLang)
-									}
-								}}>
-								{
-									// Display original language at top of list for quick selection
-									language && (
-										<option
-											value={normalizeLanguage(language)}
-											style={{ fontWeight: "bold", textAlign: "left", fontSize: "1.2em" }}>
-											{normalizeLanguage(language)}
-										</option>
-									)
+						<LanguageSelect
+							value={currentLanguage}
+							style={{
+								width: `calc(${currentLanguage?.length || 0}ch + 9px)`,
+							}}
+							onClick={(e) => {
+								e.currentTarget.focus()
+							}}
+							onChange={(e) => {
+								const newLang = normalizeLanguage(e.target.value)
+								userChangedLanguageRef.current = true
+								setCurrentLanguage(newLang)
+								if (onLanguageChange) {
+									onLanguageChange(newLang)
 								}
-								{
-									// Display all available languages in alphabetical order
-									Object.keys(bundledLanguages)
-										.sort()
-										.map((lang) => {
-											const normalizedLang = normalizeLanguage(lang)
-											return (
-												<option
-													key={normalizedLang}
-													value={normalizedLang}
-													style={{
-														fontWeight:
-															normalizedLang === currentLanguage ? "bold" : "normal",
-														textAlign: "left",
-														fontSize:
-															normalizedLang === currentLanguage ? "1.2em" : "inherit",
-													}}>
-													{normalizedLang}
-												</option>
-											)
-										})
-								}
-							</LanguageSelect>
-						)}
+							}}>
+							<option
+								value={normalizeLanguage(language)}
+								style={{ fontWeight: "bold", textAlign: "left", fontSize: "1.2em" }}>
+								{normalizeLanguage(language)}
+							</option>
+							{
+								// Display all available languages in alphabetical order
+								Object.keys(bundledLanguages)
+									.sort()
+									.map((lang) => {
+										const normalizedLang = normalizeLanguage(lang)
+										return (
+											<option
+												key={normalizedLang}
+												value={normalizedLang}
+												style={{
+													fontWeight: normalizedLang === currentLanguage ? "bold" : "normal",
+													textAlign: "left",
+													fontSize: normalizedLang === currentLanguage ? "1.2em" : "inherit",
+												}}>
+												{normalizedLang}
+											</option>
+										)
+									})
+							}
+						</LanguageSelect>
 						{showCollapseButton && (
 							<CodeBlockButton
 								onClick={() => {

--- a/webview-ui/src/components/common/__mocks__/CodeBlock.tsx
+++ b/webview-ui/src/components/common/__mocks__/CodeBlock.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 
 interface CodeBlockProps {
 	children?: React.ReactNode
-	language?: string
+	language: string
 }
 
 const CodeBlock: React.FC<CodeBlockProps> = () => <div data-testid="mock-code-block">Mocked Code Block</div>


### PR DESCRIPTION
## Context

This PR addresses issue #3655 by improving syntax highlighting across various UI components.
closes #3655
This PR is quite small if you ignore white space:

```ts
]$ git diff origin/main...  -w --stat
 webview-ui/src/components/chat/ChatRow.tsx               | 13 +++++++++----
 webview-ui/src/components/common/CodeAccordian.tsx       |  4 ++--
 webview-ui/src/components/common/CodeBlock.tsx           | 15 +++------------
 webview-ui/src/components/common/__mocks__/CodeBlock.tsx |  2 +-
 4 files changed, 15 insertions(+), 19 deletions(-)
```

## Implementation

- Changed file listings (listFilesTopLevel, listFilesRecursive, searchFiles) to use 'shellsession' for terminal-like highlighting
- Updated listCodeDefinitionNames to use 'markdown' for better highlighting of file headers and code definitions
- Added file extension-based language detection for new files
- Ensured consistent 'diff' highlighting for all diff-related content
- Used 'xml' language for error messages
- Made language property required in CodeAccordian
- Set default fallback to 'txt' instead of undefined

## How to Test

1. Use various tools that display file listings (list_files, search_files)
2. Use the listCodeDefinitionNames tool
3. Create new files with different extensions
4. Check diff displays for consistency
5. Trigger an error message to verify XML highlighting

## Get in Touch

Discord: KJ7LNW
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves syntax highlighting by setting specific languages for various content types in `ChatRow.tsx` and `CodeAccordian.tsx`, and makes `language` property required in `CodeAccordian`.
> 
>   - **Behavior**:
>     - Set `language` to `diff` for all diff-related content in `ChatRow.tsx`.
>     - Use `shellsession` for terminal-like content in `listFilesTopLevel`, `listFilesRecursive`, and `searchFiles` in `ChatRow.tsx`.
>     - Use `markdown` for `listCodeDefinitionNames` and error messages in `ChatRow.tsx`.
>     - Use `xml` for error messages in `ChatRow.tsx`.
>     - Add file extension-based language detection for new files in `ChatRow.tsx`.
>     - Set default fallback language to `txt` in `CodeAccordian.tsx`.
>   - **Components**:
>     - Made `language` property required in `CodeAccordian`.
>   - **Misc**:
>     - Renamed `shell-session` to `shellsession` in `ChatRow.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for fff27cc51070fe6091b44a243b9af77b39a6f829. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->