### PR TITLE
Fix task history copy button to preserve tags

### DIFF
--- a/webview-ui/src/components/history/CopyButton.tsx
+++ b/webview-ui/src/components/history/CopyButton.tsx
@@ -13,16 +13,17 @@ export const CopyButton = ({ itemTask }: CopyButtonProps) => {
 	const { isCopied, copy } = useClipboard()
 	const { t } = useAppTranslation()
 
-	const onCopy = useCallback(
-		(e: React.MouseEvent) => {
-			e.stopPropagation()
-			const tempDiv = document.createElement("div")
-			tempDiv.innerHTML = itemTask
-			const text = tempDiv.textContent || tempDiv.innerText || ""
-			!isCopied && copy(text)
-		},
-		[isCopied, copy, itemTask],
-	)
+        const onCopy = useCallback(
+                (e: React.MouseEvent) => {
+                        e.stopPropagation()
+                        const withoutHighlights = itemTask.replace(
+                                /<span class="history-item-highlight">(.*?)<\/span>/g,
+                                "$1",
+                        )
+                        !isCopied && copy(withoutHighlights)
+                },
+                [isCopied, copy, itemTask],
+        )
 
 	return (
 		<Button


### PR DESCRIPTION
## Summary
- keep XML structure when copying task history items

Closes #3648 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `CopyButton` to preserve XML structure by removing specific HTML tags in `CopyButton.tsx`.
> 
>   - **Behavior**:
>     - `onCopy` function in `CopyButton.tsx` updated to preserve XML structure by removing `<span class="history-item-highlight">` tags instead of all HTML tags.
>   - **Testing**:
>     - `npm ci` fails due to "Exit handler never called" error, unrelated to code changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5403db241f3743ffea770d5cbb4788408b0a3d57. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->