### PR TITLE
Add Gemini Flash 2.5 05-20 variants for the Vertex provider

### DIFF
--- a/.changeset/clean-taxis-feel.md
+++ b/.changeset/clean-taxis-feel.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Add support for `gemini-2.5-flash-preview-05-20` on the Vertex provider

--- a/.changeset/clean-taxis-feel.md
+++ b/.changeset/clean-taxis-feel.md
@@ -3,3 +3,4 @@
 ---
 
 Add support for `gemini-2.5-flash-preview-05-20` on the Vertex provider
+Add support for `gemini-2.5-flash-preview-05-20:thinking` on the Vertex provider

--- a/src/core/config/__tests__/ProviderSettingsManager.test.ts
+++ b/src/core/config/__tests__/ProviderSettingsManager.test.ts
@@ -222,7 +222,7 @@ describe("ProviderSettingsManager", () => {
 
 			const newConfig: ProviderSettings = {
 				apiProvider: "vertex",
-				apiModelId: "gemini-2.5-flash-preview-04-17",
+				apiModelId: "gemini-2.5-flash-preview-05-20",
 				vertexKeyFile: "test-key-file",
 			}
 

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -472,6 +472,25 @@ export const openRouterDefaultModelInfo: ModelInfo = {
 export type VertexModelId = keyof typeof vertexModels
 export const vertexDefaultModelId: VertexModelId = "claude-3-7-sonnet@20250219"
 export const vertexModels = {
+	"gemini-2.5-flash-preview-05-20:thinking": {
+		maxTokens: 65_535,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 0.15,
+		outputPrice: 3.5,
+		thinking: true,
+		maxThinkingTokens: 24_576,
+	},
+	"gemini-2.5-flash-preview-05-20": {
+		maxTokens: 65_535,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 0.15,
+		outputPrice: 0.6,
+		thinking: false,
+	},
 	"gemini-2.5-flash-preview-04-17:thinking": {
 		maxTokens: 65_535,
 		contextWindow: 1_048_576,
@@ -483,15 +502,6 @@ export const vertexModels = {
 		maxThinkingTokens: 24_576,
 	},
 	"gemini-2.5-flash-preview-04-17": {
-		maxTokens: 65_535,
-		contextWindow: 1_048_576,
-		supportsImages: true,
-		supportsPromptCache: false,
-		inputPrice: 0.15,
-		outputPrice: 0.6,
-		thinking: false,
-	},
-	"gemini-2.5-flash-preview-05-20": {
 		maxTokens: 65_535,
 		contextWindow: 1_048_576,
 		supportsImages: true,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -491,6 +491,15 @@ export const vertexModels = {
 		outputPrice: 0.6,
 		thinking: false,
 	},
+	"gemini-2.5-flash-preview-05-20": {
+		maxTokens: 65_535,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 0.15,
+		outputPrice: 0.6,
+		thinking: false,
+	},
 	"gemini-2.5-pro-preview-03-25": {
 		maxTokens: 65_535,
 		contextWindow: 1_048_576,


### PR DESCRIPTION
### Related GitHub Issue

Closes: #3760

### Description

Adds `gemini-2.5-flash-preview-05-20` to the Vertex provider 
Adds `gemini-2.5-flash-preview-05-20:thinking` to the Vertex provider 
Update the model in `src/core/config/__tests__/ProviderSettingsManager.test.ts` in case Google decides to deprecate the old version for no reason.

### Test Procedure

1. Create a profile
2. Select Vertex as a provider
3. Select  `gemini-2.5-flash-preview-05-20` or `gemini-2.5-flash-preview-05-20:thinking` as the model
4. Say "Hello"

### Type of Change

<!-- Mark all applicable boxes with an 'x'. -->

- [ ] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [x] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [ ] **Testing**:
    - [ ] New and/or updated tests have been added to cover my changes.
    - [x] All tests pass locally (`npm test`).
    - [x] The application builds successfully with my changes.
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](../CONTRIBUTING.md).


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `gemini-2.5-flash-preview-05-20` model to Vertex provider and update tests accordingly.
> 
>   - **Behavior**:
>     - Adds `gemini-2.5-flash-preview-05-20` to `vertexModels` in `api.ts` with specific attributes like `maxTokens`, `contextWindow`, `supportsImages`, etc.
>     - Updates test in `ProviderSettingsManager.test.ts` to use `gemini-2.5-flash-preview-05-20` as `apiModelId`.
>   - **Misc**:
>     - Adds a changeset file `clean-taxis-feel.md` to document the addition of the new model.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 24077d7c0b97c32cebd2e68c712f88760212dac8. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->