### PR TITLE
[Condense] Fix double counting last message when condensing

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -492,16 +492,9 @@ export class Task extends EventEmitter<ClineEvents> {
 		if (!summary) {
 			return
 		}
-		const lastMessageContent = this.apiConversationHistory.at(-1)?.content
 		await this.overwriteApiConversationHistory(messages)
 		const { contextTokens } = this.getTokenUsage()
-		const lastContent =
-			typeof lastMessageContent === "string"
-				? [{ type: "text" as const, text: lastMessageContent }]
-				: lastMessageContent
-		const lastMessageTokens = lastContent ? await this.api.countTokens(lastContent) : 0
-		const prevContextTokens = contextTokens + lastMessageTokens
-		const contextCondense: ContextCondense = { summary, cost, newContextTokens, prevContextTokens }
+		const contextCondense: ContextCondense = { summary, cost, newContextTokens, prevContextTokens: contextTokens }
 		await this.say(
 			"condense_context",
 			undefined /* text */,


### PR DESCRIPTION
### Description
I think we typically have to count the tokens in the last message during API requests because the new user message hasn't been accounted for yet.
When a manual condense operation is triggered, we shouldn't be in the middle of an API request, so this shouldn't be the case.
I believe this code double-counts the last message.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes double-counting of last message tokens during manual condense operations in `Task.ts`.
> 
>   - **Behavior**:
>     - Fixes double-counting of the last message's tokens during manual condense operations in `Task.ts`.
>     - Removes unnecessary token counting logic for the last message in `condenseContext()`.
>   - **Functions**:
>     - Updates `condenseContext()` to use `contextTokens` directly for `prevContextTokens` without adding last message tokens.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7379d8aba7fea85a70f799f1498eed7cce14d30b. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->