### PR TITLE
Fix: Allow Puppeteer to run as root

### DIFF
--- a/src/services/browser/UrlContentFetcher.ts
+++ b/src/services/browser/UrlContentFetcher.ts
@@ -45,10 +45,14 @@ export class UrlContentFetcher {
 			return
 		}
 		const stats = await this.ensureChromiumExists()
+		const args = [
+			"--user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36",
+		]
+		if (process.getuid && process.getuid() === 0) {
+			args.push("--no-sandbox")
+		}
 		this.browser = await stats.puppeteer.launch({
-			args: [
-				"--user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36",
-			],
+			args,
 			executablePath: stats.executablePath,
 		})
 		// (latest version of puppeteer does not add headless to user agent)

--- a/src/services/browser/__tests__/UrlContentFetcher.test.ts
+++ b/src/services/browser/__tests__/UrlContentFetcher.test.ts
@@ -1,0 +1,85 @@
+import * as vscode from "vscode"
+import { UrlContentFetcher } from "../UrlContentFetcher"
+import * as fs from "fs/promises" // Import the fs module
+
+// Mock PCR and puppeteer-core
+jest.mock("puppeteer-chromium-resolver", () => {
+	return jest.fn().mockResolvedValue({
+		puppeteer: {
+			launch: jest.fn().mockResolvedValue({
+				newPage: jest.fn().mockResolvedValue({
+					goto: jest.fn().mockResolvedValue(undefined),
+					content: jest.fn().mockResolvedValue("<html><body>Mocked HTML</body></html>"),
+				}),
+				close: jest.fn().mockResolvedValue(undefined),
+			}),
+		},
+		executablePath: "/mocked/path/to/chromium",
+	})
+})
+
+jest.mock("fs/promises", () => ({
+	...jest.requireActual("fs/promises"), // Import and retain default behavior
+	mkdir: jest.fn().mockResolvedValue(undefined), // Mock mkdir
+}))
+
+describe("UrlContentFetcher", () => {
+	let context: vscode.ExtensionContext
+	let urlContentFetcher: UrlContentFetcher
+
+	beforeEach(() => {
+		context = {
+			globalStorageUri: { fsPath: "/mock/globalStoragePath" } as vscode.Uri,
+		} as vscode.ExtensionContext
+		urlContentFetcher = new UrlContentFetcher(context)
+	})
+
+	afterEach(async () => {
+		await urlContentFetcher.closeBrowser()
+		jest.restoreAllMocks()
+	})
+
+	it("should add --no-sandbox flag when running as root", async () => {
+		const originalGetuid = process.getuid
+		// @ts-ignore
+		process.getuid = jest.fn(() => 0) // Mock getuid to return 0 (root user)
+
+		await urlContentFetcher.launchBrowser()
+
+		const pcr = require("puppeteer-chromium-resolver")
+		const puppeteerLaunchMock = pcr.mock.results[0].value.puppeteer.launch
+		expect(puppeteerLaunchMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				args: expect.arrayContaining(["--no-sandbox"]),
+			}),
+		)
+
+		// Restore original getuid
+		process.getuid = originalGetuid
+	})
+
+	it("should not add --no-sandbox flag when not running as root", async () => {
+		const originalGetuid = process.getuid
+		// @ts-ignore
+		process.getuid = jest.fn(() => 1000) // Mock getuid to return a non-root UID
+
+		await urlContentFetcher.launchBrowser()
+
+		const pcr = require("puppeteer-chromium-resolver")
+		const puppeteerLaunchMock = pcr.mock.results[0].value.puppeteer.launch
+		expect(puppeteerLaunchMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				args: expect.not.arrayContaining(["--no-sandbox"]),
+			}),
+		)
+
+		// Restore original getuid
+		process.getuid = originalGetuid
+	})
+
+	it("should fetch and convert URL to markdown", async () => {
+		await urlContentFetcher.launchBrowser()
+		const markdown = await urlContentFetcher.urlToMarkdown("https://example.com")
+		expect(markdown).toBe("Mocked HTML") // Turndown would convert <html><body>Mocked HTML</body></html> to "Mocked HTML"
+	})
+})


### PR DESCRIPTION
Closes #2537 
This is a jules test
This commit addresses an issue where RooCode, when running as a remote SSH plugin as root, was unable to fetch HTTP pages. The problem stemmed from Puppeteer's default security measure that prevents it from running as root without the `--no-sandbox` flag.

The solution involves modifying the `launchBrowser` method in `src/services/browser/UrlContentFetcher.ts`. The code now checks if the current user is root (UID 0). If so, it adds the `--no-sandbox` flag to the Puppeteer launch arguments, allowing it to operate correctly in a root environment.

Additionally, I've added unit tests to `src/services/browser/__tests__/UrlContentFetcher.test.ts` to verify this new behavior. The tests mock `process.getuid()` to simulate both root and non-root users, ensuring that the `--no-sandbox` flag is conditionally added as expected and that URL fetching remains functional.

<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: # <!-- Replace with the issue number, e.g., Closes: #123 -->

### Description

<!--
Briefly summarize the changes in this PR and how they address the linked issue.
The issue should cover the "what" and "why"; this section should focus on:
- The "how": key implementation details, design choices, or trade-offs made.
- Anything specific reviewers should pay attention to in this PR.
-->

### Test Procedure

<!--
Detail the steps to test your changes. This helps reviewers verify your work.
- How did you test this specific implementation? (e.g., unit tests, manual testing steps)
- How can reviewers reproduce your tests or verify the fix/feature?
- Include relevant testing environment details if applicable.
-->

### Type of Change

<!-- Mark all applicable boxes with an 'x'. -->

- [ ] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [ ] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [ ] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [ ] **Self-Review**: I have performed a thorough self-review of my code.
- [ ] **Code Quality**:
    - [ ] My code adheres to the project's style guidelines.
    - [ ] There are no new linting errors or warnings (`npm run lint`).
    - [ ] All debug code (e.g., `console.log`) has been removed.
- [ ] **Testing**:
    - [ ] New and/or updated tests have been added to cover my changes.
    - [ ] All tests pass locally (`npm test`).
    - [ ] The application builds successfully with my changes.
- [ ] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [ ] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [ ] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [ ] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](../CONTRIBUTING.md).

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->

### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes Puppeteer root execution by adding `--no-sandbox` flag in `UrlContentFetcher.ts` and tests in `UrlContentFetcher.test.ts`.
> 
>   - **Behavior**:
>     - Modify `launchBrowser` in `UrlContentFetcher.ts` to add `--no-sandbox` flag if running as root (UID 0).
>     - Ensures Puppeteer can fetch HTTP pages when running as root.
>   - **Testing**:
>     - Add unit tests in `UrlContentFetcher.test.ts` to verify `--no-sandbox` flag is added for root users and not for non-root users.
>     - Tests mock `process.getuid()` to simulate different user environments.
>     - Verify URL fetching and conversion to markdown functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b0123bc70d5fe881c94570cb961f83b74cc57645. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->