### PR TITLE
More VSCode command / build fixes

### DIFF
--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -38,7 +38,10 @@ jobs:
           npm run vsix
           package=$(unzip -l bin/roo-cline-${current_package_version}.vsix)
           echo "$package"
-          echo "$package" | grep -q "dist/extension.js" || exit 1
+          echo "$package" | grep -q "extension/dist/package.json" || exit 1
+          echo "$package" | grep -q "extension/dist/package.nls.json" || exit 1
+          echo "$package" | grep -q "extension/dist/extension.js" || exit 1
+          echo "$package" | grep -q "extension/webview-ui/audio/celebration.wav" || exit 1
           echo "$package" | grep -q "extension/webview-ui/build/assets/index.js" || exit 1
           echo "$package" | grep -q "extension/node_modules/@vscode/codicons/dist/codicon.ttf" || exit 1
           echo "$package" | grep -q ".env" || exit 1

--- a/evals/scripts/setup.sh
+++ b/evals/scripts/setup.sh
@@ -28,11 +28,8 @@ build_extension() {
   echo "🔨 Building the Roo Code extension..."
   cd ..
   mkdir -p bin
-  npm run install-extension -- --silent --no-audit || exit 1
-  npm run install-webview -- --silent --no-audit || exit 1
-  npm run install-e2e -- --silent --no-audit || exit 1
-  npx vsce package --out bin/roo-code-latest.vsix || exit 1
-  code --install-extension bin/roo-code-latest.vsix || exit 1
+  pnpm build --out ../bin/roo-code-$(git rev-parse --short HEAD).vsix || exit 1
+  code --install-extension bin/roo-code-$(git rev-parse --short HEAD).vsix || exit 1
   cd evals
 }
 
@@ -293,8 +290,8 @@ code --install-extension redhat.java &>/dev/null || exit 1
 code --install-extension ms-python.python&>/dev/null || exit 1
 code --install-extension rust-lang.rust-analyzer &>/dev/null || exit 1
 
-if ! code --list-extensions 2>/dev/null | grep -q "rooveterinaryinc.roo-cline"; then
-  code --install-extension rooveterinaryinc.roo-cline &>/dev/null || exit 1
+if ! code --list-extensions 2>/dev/null | grep -q "RooVeterinaryInc.roo-cline"; then
+  code --install-extension RooVeterinaryInc.roo-cline &>/dev/null || exit 1
 fi
 
 echo "✅ Done"

--- a/evals/scripts/setup.sh
+++ b/evals/scripts/setup.sh
@@ -28,8 +28,11 @@ build_extension() {
   echo "🔨 Building the Roo Code extension..."
   cd ..
   mkdir -p bin
-  pnpm build --out ../bin/roo-code-$(git rev-parse --short HEAD).vsix || exit 1
-  code --install-extension bin/roo-code-$(git rev-parse --short HEAD).vsix || exit 1
+  npm run install-extension -- --silent --no-audit || exit 1
+  npm run install-webview -- --silent --no-audit || exit 1
+  npm run install-e2e -- --silent --no-audit || exit 1
+  npx vsce package --out bin/roo-code-latest.vsix || exit 1
+  code --install-extension bin/roo-code-latest.vsix || exit 1
   cd evals
 }
 

--- a/package.json
+++ b/package.json
@@ -51,16 +51,6 @@
 	],
 	"main": "./dist/extension.js",
 	"contributes": {
-		"submenus": [
-			{
-				"id": "roo-code.contextMenu",
-				"label": "%views.contextMenu.label%"
-			},
-			{
-				"id": "roo-code.terminalMenu",
-				"label": "%views.terminalMenu.label%"
-			}
-		],
 		"viewsContainers": {
 			"activitybar": [
 				{
@@ -166,7 +156,7 @@
 				"category": "%configuration.title%"
 			},
 			{
-				"command": "roo.acceptInput",
+				"command": "roo-cline.acceptInput",
 				"title": "%command.acceptInput.title%",
 				"category": "%configuration.title%"
 			}
@@ -174,11 +164,11 @@
 		"menus": {
 			"editor/context": [
 				{
-					"submenu": "roo-code.contextMenu",
+					"submenu": "roo-cline.contextMenu",
 					"group": "navigation"
 				}
 			],
-			"roo-code.contextMenu": [
+			"roo-cline.contextMenu": [
 				{
 					"command": "roo-cline.addToContext",
 					"group": "1_actions@1"
@@ -194,11 +184,11 @@
 			],
 			"terminal/context": [
 				{
-					"submenu": "roo-code.terminalMenu",
+					"submenu": "roo-cline.terminalMenu",
 					"group": "navigation"
 				}
 			],
-			"roo-code.terminalMenu": [
+			"roo-cline.terminalMenu": [
 				{
 					"command": "roo-cline.terminalAddToContext",
 					"group": "1_actions@1"
@@ -277,6 +267,16 @@
 				}
 			]
 		},
+		"submenus": [
+			{
+				"id": "roo-cline.contextMenu",
+				"label": "%views.contextMenu.label%"
+			},
+			{
+				"id": "roo-cline.terminalMenu",
+				"label": "%views.terminalMenu.label%"
+			}
+		],
 		"configuration": {
 			"title": "%configuration.title%",
 			"properties": {

--- a/src/exports/roo-code.d.ts
+++ b/src/exports/roo-code.d.ts
@@ -1544,6 +1544,7 @@ declare const Package: {
 	readonly publisher: string
 	readonly name: string
 	readonly version: string
+	readonly outputChannel: string
 }
 /**
  * ProviderName

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,9 +49,9 @@ let extensionContext: vscode.ExtensionContext
 // Your extension is activated the very first time the command is executed.
 export async function activate(context: vscode.ExtensionContext) {
 	extensionContext = context
-	outputChannel = vscode.window.createOutputChannel("Roo-Code")
+	outputChannel = vscode.window.createOutputChannel(Package.outputChannel)
 	context.subscriptions.push(outputChannel)
-	outputChannel.appendLine("Roo-Code extension activated")
+	outputChannel.appendLine(`${Package.name} extension activated`)
 
 	// Migrate old settings to new
 	await migrateSettings(context, outputChannel)
@@ -147,13 +147,10 @@ export async function activate(context: vscode.ExtensionContext) {
 	return new API(outputChannel, provider, socketPath, enableLogging)
 }
 
-// This method is called when your extension is deactivated
+// This method is called when your extension is deactivated.
 export async function deactivate() {
-	outputChannel.appendLine("Roo-Code extension deactivated")
-	// Clean up MCP server manager
+	outputChannel.appendLine(`${Package.name} extension deactivated`)
 	await McpServerManager.cleanup(extensionContext)
 	telemetryService.shutdown()
-
-	// Clean up terminal handlers
 	TerminalRegistry.cleanup()
 }

--- a/src/schemas/__tests__/index.test.ts
+++ b/src/schemas/__tests__/index.test.ts
@@ -1,6 +1,8 @@
 // npx jest src/schemas/__tests__/index.test.ts
 
-import { GLOBAL_STATE_KEYS } from "../index"
+import { contributes } from "../../../package.json"
+
+import { GLOBAL_STATE_KEYS, Package, codeActionIds, terminalActionIds, commandIds } from "../index"
 
 describe("GLOBAL_STATE_KEYS", () => {
 	it("should contain provider settings keys", () => {
@@ -13,5 +15,27 @@ describe("GLOBAL_STATE_KEYS", () => {
 
 	it("should not contain secret state keys", () => {
 		expect(GLOBAL_STATE_KEYS).not.toContain("openRouterApiKey")
+	})
+})
+
+describe("package.json#contributes", () => {
+	it("is in sync with the schema's commands", () => {
+		// These aren't explicitly referenced in package.json despite
+		// being registered by the extension.
+		const absent = new Set([
+			"activationCompleted",
+			"showHumanRelayDialog",
+			"registerHumanRelayCallback",
+			"unregisterHumanRelayCallback",
+			"handleHumanRelayResponse",
+		])
+
+		// This test will notify us if package.json drifts from the schema.
+		expect(contributes.commands.map((command) => command.command).sort()).toEqual(
+			[...new Set([...commandIds, ...terminalActionIds, ...codeActionIds])]
+				.filter((id) => !absent.has(id))
+				.map((id) => `${Package.name}.${id}`)
+				.sort(),
+		)
 	})
 })

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -12,10 +12,17 @@ import { Equals, Keys, AssertEqual } from "../utils/type-fu"
 
 import { publisher, name, version } from "../../package.json"
 
+// These ENV variables can be defined by ESBuild when building the extension
+// in order to override the values in package.json. This allows us built
+// different extension variants with the same package.json file.
+// The build process still needs to emit a modified package.json for consumption
+// by VSCode, but that build artifact is not used during the transpile step of
+// the build, so we still need this override mechanism.
 export const Package = {
-	publisher,
-	name,
-	version,
+	publisher: process.env.PKG_PUBLISHER || publisher,
+	name: process.env.PKG_NAME || name,
+	version: process.env.PKG_VERSION || version,
+	outputChannel: process.env.PKG_OUTPUT_CHANNEL || "Roo-Code",
 } as const
 
 /**

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -13,7 +13,7 @@ import { Equals, Keys, AssertEqual } from "../utils/type-fu"
 import { publisher, name, version } from "../../package.json"
 
 // These ENV variables can be defined by ESBuild when building the extension
-// in order to override the values in package.json. This allows us built
+// in order to override the values in package.json. This allows us to build
 // different extension variants with the same package.json file.
 // The build process still needs to emit a modified package.json for consumption
 // by VSCode, but that build artifact is not used during the transpile step of

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -29,39 +29,49 @@ export const Package = {
  * CodeAction
  */
 
-export type CodeActionName = "EXPLAIN" | "FIX" | "IMPROVE" | "ADD_TO_CONTEXT" | "NEW_TASK"
+export const codeActionIds = ["explainCode", "fixCode", "improveCode", "addToContext", "newTask"] as const
 
-export type CodeActionId = "explainCode" | "fixCode" | "improveCode" | "addToContext" | "newTask"
+export type CodeActionId = (typeof codeActionIds)[number]
+
+export type CodeActionName = "EXPLAIN" | "FIX" | "IMPROVE" | "ADD_TO_CONTEXT" | "NEW_TASK"
 
 /**
  * TerminalAction
  */
 
+export const terminalActionIds = ["terminalAddToContext", "terminalFixCommand", "terminalExplainCommand"] as const
+
+export type TerminalActionId = (typeof terminalActionIds)[number]
+
 export type TerminalActionName = "ADD_TO_CONTEXT" | "FIX" | "EXPLAIN"
 
 export type TerminalActionPromptType = `TERMINAL_${TerminalActionName}`
-
-export type TerminalActionId = "terminalAddToContext" | "terminalFixCommand" | "terminalExplainCommand"
 
 /**
  * Command
  */
 
-const commandIds = [
+export const commandIds = [
 	"activationCompleted",
+
 	"plusButtonClicked",
-	"mcpButtonClicked",
 	"promptsButtonClicked",
-	"popoutButtonClicked",
-	"openInNewTab",
-	"settingsButtonClicked",
+	"mcpButtonClicked",
 	"historyButtonClicked",
+	"popoutButtonClicked",
+	"settingsButtonClicked",
+
+	"openInNewTab",
+
 	"showHumanRelayDialog",
 	"registerHumanRelayCallback",
 	"unregisterHumanRelayCallback",
 	"handleHumanRelayResponse",
+
 	"newTask",
+
 	"setCustomStoragePath",
+
 	"focusInput",
 	"acceptInput",
 ] as const


### PR DESCRIPTION
### Description

All VSCode id values in the package.json `contributes` section need to use the extension name prefix (`roo-cline`), otherwise it's difficult to change the extension identifier with build tooling. We were using all of `roo-cline`, `roo-code` and `roo` for some reason.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Standardize VSCode extension ID prefix to `roo-cline` and update related scripts and tests for consistency.
> 
>   - **Behavior**:
>     - Standardize VSCode extension ID prefix to `roo-cline` in `package.json` `contributes` section.
>     - Update `marketplace-publish.yml` to check for additional files in the VSIX package.
>   - **Scripts**:
>     - Update `setup.sh` to use `RooVeterinaryInc.roo-cline` for extension installation.
>   - **Tests**:
>     - Update `index.test.ts` to ensure `package.json` commands are in sync with schema commands.
>   - **Misc**:
>     - Add `outputChannel` to `Package` in `roo-code.d.ts`.
>     - Use `Package.outputChannel` in `extension.ts` for output channel creation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0bdeca3964bf943a5c9234c5b798b7434859e81f. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->