### PR TITLE
[Condense] Add isAutomaticTrigger to condense telemetry

### DIFF
--- a/src/core/condense/index.ts
+++ b/src/core/condense/index.ts
@@ -60,6 +60,7 @@ export type SummarizeResponse = {
  * @param {ApiHandler} apiHandler - The API handler to use for token counting.
  * @param {string} systemPrompt - The system prompt for API requests, which should be considered in the context token count
  * @param {string} taskId - The task ID for the conversation, used for telemetry
+ * @param {boolean} isAutomaticTrigger - Whether the summarization is triggered automatically
  * @returns {SummarizeResponse} - The result of the summarization operation (see above)
  */
 export async function summarizeConversation(
@@ -67,8 +68,9 @@ export async function summarizeConversation(
 	apiHandler: ApiHandler,
 	systemPrompt: string,
 	taskId: string,
+	isAutomaticTrigger?: boolean,
 ): Promise<SummarizeResponse> {
-	telemetryService.captureContextCondensed(taskId)
+	telemetryService.captureContextCondensed(taskId, isAutomaticTrigger ?? false)
 	const response: SummarizeResponse = { messages, cost: 0, summary: "" }
 	const messagesToSummarize = getMessagesSinceLastSummary(messages.slice(0, -N_MESSAGES_TO_KEEP))
 	if (messagesToSummarize.length <= 1) {

--- a/src/core/sliding-window/__tests__/sliding-window.test.ts
+++ b/src/core/sliding-window/__tests__/sliding-window.test.ts
@@ -525,7 +525,13 @@ describe("truncateConversationIfNeeded", () => {
 		})
 
 		// Verify summarizeConversation was called with the right parameters
-		expect(summarizeSpy).toHaveBeenCalledWith(messagesWithSmallContent, mockApiHandler, "System prompt", taskId)
+		expect(summarizeSpy).toHaveBeenCalledWith(
+			messagesWithSmallContent,
+			mockApiHandler,
+			"System prompt",
+			taskId,
+			true,
+		)
 
 		// Verify the result contains the summary information
 		expect(result).toMatchObject({
@@ -663,7 +669,13 @@ describe("truncateConversationIfNeeded", () => {
 		})
 
 		// Verify summarizeConversation was called with the right parameters
-		expect(summarizeSpy).toHaveBeenCalledWith(messagesWithSmallContent, mockApiHandler, "System prompt", taskId)
+		expect(summarizeSpy).toHaveBeenCalledWith(
+			messagesWithSmallContent,
+			mockApiHandler,
+			"System prompt",
+			taskId,
+			true,
+		)
 
 		// Verify the result contains the summary information
 		expect(result).toMatchObject({

--- a/src/core/sliding-window/index.ts
+++ b/src/core/sliding-window/index.ts
@@ -113,7 +113,7 @@ export async function truncateConversationIfNeeded({
 		const contextPercent = (100 * prevContextTokens) / contextWindow
 		if (contextPercent >= autoCondenseContextPercent || prevContextTokens > allowedTokens) {
 			// Attempt to intelligently condense the context
-			const result = await summarizeConversation(messages, apiHandler, systemPrompt, taskId)
+			const result = await summarizeConversation(messages, apiHandler, systemPrompt, taskId, true)
 			if (result.summary) {
 				return { ...result, prevContextTokens }
 			}

--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -120,8 +120,8 @@ class TelemetryService {
 		this.captureEvent(PostHogClient.EVENTS.TASK.CHECKPOINT_RESTORED, { taskId })
 	}
 
-	public captureContextCondensed(taskId: string): void {
-		this.captureEvent(PostHogClient.EVENTS.TASK.CONTEXT_CONDENSED, { taskId })
+	public captureContextCondensed(taskId: string, isAutomaticTrigger: boolean): void {
+		this.captureEvent(PostHogClient.EVENTS.TASK.CONTEXT_CONDENSED, { taskId, isAutomaticTrigger })
 	}
 
 	public captureSlidingWindowTruncation(taskId: string): void {


### PR DESCRIPTION
### Description
Add isAutomaticTrigger to condense telemetry
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `isAutomaticTrigger` to `summarizeConversation` and update telemetry to capture this in `TelemetryService.ts`.
> 
>   - **Behavior**:
>     - Add `isAutomaticTrigger` parameter to `summarizeConversation` in `index.ts` to indicate if summarization is automatic.
>     - Update `captureContextCondensed` in `TelemetryService.ts` to include `isAutomaticTrigger`.
>   - **Tests**:
>     - Update `sliding-window.test.ts` to verify `summarizeConversation` is called with `isAutomaticTrigger` set to `true` in relevant tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 54a22415bb23eb1421969b0241501b43863219ad. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->