### PR TITLE
Improve version number derivation

### DIFF
--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -38,12 +38,14 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Count commits
-        id: count
-        run: echo "total=$(git rev-list --all --count)" >> $GITHUB_OUTPUT
+      - name: Forge numeric Nightly version
+        id: version
+        env:
+          RUN_NUMBER: ${{ github.run_number }}
+        run: echo "number=$(( 5500 + ${RUN_NUMBER} ))" >> $GITHUB_OUTPUT
       - name: Patch package.json version
         env:
-          COMMIT_COUNT: ${{ steps.count.outputs.total }}
+          VERSION_NUMBER: ${{ steps.version.outputs.number }}
         run: |
           node <<'EOF'
             const fs = require('fs');
@@ -51,7 +53,7 @@ jobs:
             const pkgPath = path.join(__dirname, 'apps', 'vscode-nightly', 'package.nightly.json');
             const pkg = JSON.parse(fs.readFileSync(pkgPath,'utf8'));
             const [maj, min] = pkg.version.split('.');
-            pkg.version = `${maj}.${min}.${process.env.COMMIT_COUNT}`;
+            pkg.version = `${maj}.${min}.${process.env.VERSION_NUMBER}`;
             fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
             console.log(`🔖 Nightly version set to ${pkg.version}`);
           EOF


### PR DESCRIPTION
### Description

Counting git commits wasn't reliable.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces git commit count with GitHub run number for nightly version derivation in `nightly-publish.yml`.
> 
>   - **Behavior**:
>     - Replaces git commit count with GitHub run number for nightly version derivation in `nightly-publish.yml`.
>     - Updates `package.nightly.json` version using `5500 + RUN_NUMBER`.
>   - **Misc**:
>     - Removes `Count commits` step and adds `Forge numeric Nightly version` step in `nightly-publish.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ee0d04d0643bc90c93b8c97a4540f1e4557d55d2. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->