### PR TITLE
Fix Claude 4 models in Vertex

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -658,7 +658,7 @@ export const vertexModels = {
 		inputPrice: 1.25,
 		outputPrice: 5,
 	},
-	"claude-sonnet-4-20250514:thinking": {
+	"claude-sonnet-4@20250514:thinking": {
 		maxTokens: 64_000,
 		contextWindow: 200_000,
 		supportsImages: true,
@@ -670,7 +670,7 @@ export const vertexModels = {
 		cacheReadsPrice: 0.3,
 		thinking: true,
 	},
-	"claude-sonnet-4-20250514": {
+	"claude-sonnet-4@20250514": {
 		maxTokens: 8192,
 		contextWindow: 200_000,
 		supportsImages: true,
@@ -682,7 +682,7 @@ export const vertexModels = {
 		cacheReadsPrice: 0.3,
 		thinking: false,
 	},
-	"claude-opus-4-20250514:thinking": {
+	"claude-opus-4@20250514:thinking": {
 		maxTokens: 64_000,
 		contextWindow: 200_000,
 		supportsImages: true,
@@ -694,7 +694,7 @@ export const vertexModels = {
 		cacheReadsPrice: 1.5,
 		thinking: true,
 	},
-	"claude-opus-4-20250514": {
+	"claude-opus-4@20250514": {
 		maxTokens: 8192,
 		contextWindow: 200_000,
 		supportsImages: true,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Renamed Claude 4 model IDs in `vertexModels` in `api.ts` to use '@' instead of hyphens before the date.
> 
>   - **Renaming**:
>     - Change model IDs in `vertexModels` from hyphenated to '@' format for Claude 4 models.
>     - Affected models: `claude-sonnet-4-20250514:thinking`, `claude-sonnet-4-20250514`, `claude-opus-4-20250514:thinking`, `claude-opus-4-20250514`.
>   - **Files**:
>     - `api.ts`: Updated model IDs in `vertexModels`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d707a8d72f82d9d8d0c71dff57e2e8a9216917e0. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->