### PR TITLE
Fix changeset version bumping

### DIFF
--- a/.changeset/quick-years-grow.md
+++ b/.changeset/quick-years-grow.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix changeset npm script

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           commit: "changeset version bump"
           title: "Changeset version bump"
-          version: pnpm --filter roo-cline version-packages # This performs the changeset version bump
+          version: pnpm changeset:version # This performs the changeset version bump
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 		"clean": "turbo clean --log-order grouped --output-logs new-only && rimraf dist out bin .vite-port .turbo",
 		"build": "pnpm --filter roo-cline vsix",
 		"build:nightly": "pnpm --filter @roo-code/vscode-nightly vsix",
-		"changeset": "changeset",
+		"publish": "pnpm build && changeset publish && pnpm install --frozen-lockfile",
+		"changeset:version": "changeset version && pnpm install --frozen-lockfile",
 		"knip": "pnpm --filter @roo-code/build build && knip --include files",
 		"update-contributors": "node scripts/update-contributors.js"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,12 +330,6 @@ importers:
         specifier: ^3.24.2
         version: 3.24.4
     devDependencies:
-      '@changesets/cli':
-        specifier: ^2.27.10
-        version: 2.29.4
-      '@changesets/types':
-        specifier: ^6.0.0
-        version: 6.1.0
       '@jest/globals':
         specifier: ^29.7.0
         version: 29.7.0

--- a/src/package.json
+++ b/src/package.json
@@ -327,8 +327,6 @@
 		"build": "pnpm bundle --production && pnpm --filter @roo-code/vscode-webview build",
 		"build:development": "pnpm bundle && pnpm --filter @roo-code/vscode-webview build",
 		"publish:marketplace": "vsce publish --no-dependencies && ovsx publish --no-dependencies",
-		"publish": "pnpm vsix && changeset publish && pnpm install --package-lock-only",
-		"version-packages": "changeset version && pnpm install --package-lock-only",
 		"vscode:prepublish": "pnpm build",
 		"vsix": "mkdirp ../bin && npx vsce package --no-dependencies --out ../bin",
 		"watch:esbuild": "pnpm bundle --watch",
@@ -397,8 +395,6 @@
 		"zod": "^3.24.2"
 	},
 	"devDependencies": {
-		"@changesets/cli": "^2.27.10",
-		"@changesets/types": "^6.0.0",
 		"@jest/globals": "^29.7.0",
 		"@roo-code/config-eslint": "workspace:^",
 		"@roo-code/config-typescript": "workspace:^",


### PR DESCRIPTION
### Description

See title.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes changeset version bumping by updating the workflow and npm scripts for correct version management.
> 
>   - **Behavior**:
>     - Fixes changeset version bumping by updating the command in `changeset-release.yml` from `pnpm --filter roo-cline version-packages` to `pnpm changeset:version`.
>     - Updates `publish` and `changeset:version` scripts in `package.json` to ensure proper version bumping and dependency installation.
>   - **Scripts**:
>     - Removes `publish` and `version-packages` scripts from `src/package.json`.
>   - **Dependencies**:
>     - Removes `@changesets/cli` and `@changesets/types` from `src/package.json` `devDependencies`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b279eefb532c9cc4b841ed6bc02f36a0eb73615c. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->