### PR TITLE
Fix: Ensure write_to_file creates empty files when content is empty

### DIFF
--- a/src/core/tools/__tests__/writeToFileTool.test.ts
+++ b/src/core/tools/__tests__/writeToFileTool.test.ts
@@ -1,0 +1,380 @@
+import * as path from "path"
+
+import { fileExistsAtPath } from "../../../utils/fs"
+import { detectCodeOmission } from "../../../integrations/editor/detect-omission"
+import { isPathOutsideWorkspace } from "../../../utils/pathUtils"
+import { getReadablePath } from "../../../utils/path"
+import { unescapeHtmlEntities } from "../../../utils/text-normalization"
+import { everyLineHasLineNumbers, stripLineNumbers } from "../../../integrations/misc/extract-text"
+import { ToolUse, ToolResponse } from "../../../shared/tools"
+import { writeToFileTool } from "../writeToFileTool"
+
+jest.mock("path", () => {
+	const originalPath = jest.requireActual("path")
+	return {
+		...originalPath,
+		resolve: jest.fn().mockImplementation((...args) => args.join("/")),
+	}
+})
+
+jest.mock("delay", () => jest.fn())
+
+jest.mock("../../../utils/fs", () => ({
+	fileExistsAtPath: jest.fn().mockResolvedValue(false),
+}))
+
+jest.mock("../../prompts/responses", () => ({
+	formatResponse: {
+		toolError: jest.fn((msg) => `Error: ${msg}`),
+		rooIgnoreError: jest.fn((path) => `Access denied: ${path}`),
+		lineCountTruncationError: jest.fn(
+			(count, isNew, diffEnabled) => `Line count error: ${count}, new: ${isNew}, diff: ${diffEnabled}`,
+		),
+		createPrettyPatch: jest.fn(() => "mock-diff"),
+	},
+}))
+
+jest.mock("../../../integrations/editor/detect-omission", () => ({
+	detectCodeOmission: jest.fn().mockReturnValue(false),
+}))
+
+jest.mock("../../../utils/pathUtils", () => ({
+	isPathOutsideWorkspace: jest.fn().mockReturnValue(false),
+}))
+
+jest.mock("../../../utils/path", () => ({
+	getReadablePath: jest.fn().mockReturnValue("test/path.txt"),
+}))
+
+jest.mock("../../../utils/text-normalization", () => ({
+	unescapeHtmlEntities: jest.fn().mockImplementation((content) => content),
+}))
+
+jest.mock("../../../integrations/misc/extract-text", () => ({
+	everyLineHasLineNumbers: jest.fn().mockReturnValue(false),
+	stripLineNumbers: jest.fn().mockImplementation((content) => content),
+	addLineNumbers: jest.fn().mockImplementation((content: string) =>
+		content
+			.split("\n")
+			.map((line: string, i: number) => `${i + 1} | ${line}`)
+			.join("\n"),
+	),
+}))
+
+jest.mock("vscode", () => ({
+	window: {
+		showWarningMessage: jest.fn().mockResolvedValue(undefined),
+	},
+	env: {
+		openExternal: jest.fn(),
+	},
+	Uri: {
+		parse: jest.fn(),
+	},
+}))
+
+jest.mock("../../ignore/RooIgnoreController", () => ({
+	RooIgnoreController: class {
+		initialize() {
+			return Promise.resolve()
+		}
+		validateAccess() {
+			return true
+		}
+	},
+}))
+
+describe("writeToFileTool", () => {
+	// Test data
+	const testFilePath = "test/file.txt"
+	const absoluteFilePath = "/test/file.txt"
+	const testContent = "Line 1\nLine 2\nLine 3"
+	const testContentWithMarkdown = "```javascript\nLine 1\nLine 2\n```"
+
+	// Mocked functions with correct types
+	const mockedFileExistsAtPath = fileExistsAtPath as jest.MockedFunction<typeof fileExistsAtPath>
+	const mockedDetectCodeOmission = detectCodeOmission as jest.MockedFunction<typeof detectCodeOmission>
+	const mockedIsPathOutsideWorkspace = isPathOutsideWorkspace as jest.MockedFunction<typeof isPathOutsideWorkspace>
+	const mockedGetReadablePath = getReadablePath as jest.MockedFunction<typeof getReadablePath>
+	const mockedUnescapeHtmlEntities = unescapeHtmlEntities as jest.MockedFunction<typeof unescapeHtmlEntities>
+	const mockedEveryLineHasLineNumbers = everyLineHasLineNumbers as jest.MockedFunction<typeof everyLineHasLineNumbers>
+	const mockedStripLineNumbers = stripLineNumbers as jest.MockedFunction<typeof stripLineNumbers>
+	const mockedPathResolve = path.resolve as jest.MockedFunction<typeof path.resolve>
+
+	const mockCline: any = {}
+	let mockAskApproval: jest.Mock
+	let mockHandleError: jest.Mock
+	let mockPushToolResult: jest.Mock
+	let mockRemoveClosingTag: jest.Mock
+	let toolResult: ToolResponse | undefined
+
+	beforeEach(() => {
+		jest.clearAllMocks()
+
+		mockedPathResolve.mockReturnValue(absoluteFilePath)
+		mockedFileExistsAtPath.mockResolvedValue(false)
+		mockedDetectCodeOmission.mockReturnValue(false)
+		mockedIsPathOutsideWorkspace.mockReturnValue(false)
+		mockedGetReadablePath.mockReturnValue("test/path.txt")
+		mockedUnescapeHtmlEntities.mockImplementation((content) => content)
+		mockedEveryLineHasLineNumbers.mockReturnValue(false)
+		mockedStripLineNumbers.mockImplementation((content) => content)
+
+		mockCline.cwd = "/"
+		mockCline.consecutiveMistakeCount = 0
+		mockCline.didEditFile = false
+		mockCline.diffStrategy = undefined
+		mockCline.rooIgnoreController = {
+			validateAccess: jest.fn().mockReturnValue(true),
+		}
+		mockCline.diffViewProvider = {
+			editType: undefined,
+			isEditing: false,
+			originalContent: "",
+			open: jest.fn().mockResolvedValue(undefined),
+			update: jest.fn().mockResolvedValue(undefined),
+			reset: jest.fn().mockResolvedValue(undefined),
+			revertChanges: jest.fn().mockResolvedValue(undefined),
+			saveChanges: jest.fn().mockResolvedValue({
+				newProblemsMessage: "",
+				userEdits: null,
+				finalContent: "final content",
+			}),
+			scrollToFirstDiff: jest.fn(),
+		}
+		mockCline.api = {
+			getModel: jest.fn().mockReturnValue({ id: "claude-3" }),
+		}
+		mockCline.fileContextTracker = {
+			trackFileContext: jest.fn().mockResolvedValue(undefined),
+		}
+		mockCline.say = jest.fn().mockResolvedValue(undefined)
+		mockCline.ask = jest.fn().mockResolvedValue(undefined)
+		mockCline.recordToolError = jest.fn()
+		mockCline.sayAndCreateMissingParamError = jest.fn().mockResolvedValue("Missing param error")
+
+		mockAskApproval = jest.fn().mockResolvedValue(true)
+		mockHandleError = jest.fn().mockResolvedValue(undefined)
+		mockRemoveClosingTag = jest.fn((tag, content) => content)
+
+		toolResult = undefined
+	})
+
+	/**
+	 * Helper function to execute the write file tool with different parameters
+	 */
+	async function executeWriteFileTool(
+		params: Partial<ToolUse["params"]> = {},
+		options: {
+			fileExists?: boolean
+			isPartial?: boolean
+			accessAllowed?: boolean
+		} = {},
+	): Promise<ToolResponse | undefined> {
+		// Configure mocks based on test scenario
+		const fileExists = options.fileExists ?? false
+		const isPartial = options.isPartial ?? false
+		const accessAllowed = options.accessAllowed ?? true
+
+		mockedFileExistsAtPath.mockResolvedValue(fileExists)
+		mockCline.rooIgnoreController.validateAccess.mockReturnValue(accessAllowed)
+
+		// Create a tool use object
+		const toolUse: ToolUse = {
+			type: "tool_use",
+			name: "write_to_file",
+			params: {
+				path: testFilePath,
+				content: testContent,
+				line_count: "3",
+				...params,
+			},
+			partial: isPartial,
+		}
+
+		await writeToFileTool(
+			mockCline,
+			toolUse,
+			mockAskApproval,
+			mockHandleError,
+			(result: ToolResponse) => {
+				toolResult = result
+			},
+			mockRemoveClosingTag,
+		)
+
+		return toolResult
+	}
+
+	describe("access control", () => {
+		it("validates and allows access when rooIgnoreController permits", async () => {
+			await executeWriteFileTool({}, { accessAllowed: true })
+
+			expect(mockCline.rooIgnoreController.validateAccess).toHaveBeenCalledWith(testFilePath)
+			expect(mockCline.diffViewProvider.open).toHaveBeenCalledWith(testFilePath)
+		})
+	})
+
+	describe("file existence detection", () => {
+		it("detects existing file and sets editType to modify", async () => {
+			await executeWriteFileTool({}, { fileExists: true })
+
+			expect(mockedFileExistsAtPath).toHaveBeenCalledWith(absoluteFilePath)
+			expect(mockCline.diffViewProvider.editType).toBe("modify")
+		})
+
+		it("detects new file and sets editType to create", async () => {
+			await executeWriteFileTool({}, { fileExists: false })
+
+			expect(mockedFileExistsAtPath).toHaveBeenCalledWith(absoluteFilePath)
+			expect(mockCline.diffViewProvider.editType).toBe("create")
+		})
+
+		it("uses cached editType without filesystem check", async () => {
+			mockCline.diffViewProvider.editType = "modify"
+
+			await executeWriteFileTool({})
+
+			expect(mockedFileExistsAtPath).not.toHaveBeenCalled()
+		})
+	})
+
+	describe("content preprocessing", () => {
+		it("removes markdown code block markers from content", async () => {
+			await executeWriteFileTool({ content: testContentWithMarkdown })
+
+			expect(mockCline.diffViewProvider.update).toHaveBeenCalledWith("Line 1\nLine 2", true)
+		})
+
+		it("passes through empty content unchanged", async () => {
+			await executeWriteFileTool({ content: "" })
+
+			expect(mockCline.diffViewProvider.update).toHaveBeenCalledWith("", true)
+		})
+
+		it("unescapes HTML entities for non-Claude models", async () => {
+			mockCline.api.getModel.mockReturnValue({ id: "gpt-4" })
+
+			await executeWriteFileTool({ content: "&lt;test&gt;" })
+
+			expect(mockedUnescapeHtmlEntities).toHaveBeenCalledWith("&lt;test&gt;")
+		})
+
+		it("skips HTML unescaping for Claude models", async () => {
+			mockCline.api.getModel.mockReturnValue({ id: "claude-3" })
+
+			await executeWriteFileTool({ content: "&lt;test&gt;" })
+
+			expect(mockedUnescapeHtmlEntities).not.toHaveBeenCalled()
+		})
+
+		it("strips line numbers from numbered content", async () => {
+			const contentWithLineNumbers = "1 | line one\n2 | line two"
+			mockedEveryLineHasLineNumbers.mockReturnValue(true)
+			mockedStripLineNumbers.mockReturnValue("line one\nline two")
+
+			await executeWriteFileTool({ content: contentWithLineNumbers })
+
+			expect(mockedEveryLineHasLineNumbers).toHaveBeenCalledWith(contentWithLineNumbers)
+			expect(mockedStripLineNumbers).toHaveBeenCalledWith(contentWithLineNumbers)
+			expect(mockCline.diffViewProvider.update).toHaveBeenCalledWith("line one\nline two", true)
+		})
+	})
+
+	describe("file operations", () => {
+		it("successfully creates new files with full workflow", async () => {
+			await executeWriteFileTool({}, { fileExists: false })
+
+			expect(mockCline.consecutiveMistakeCount).toBe(0)
+			expect(mockCline.diffViewProvider.open).toHaveBeenCalledWith(testFilePath)
+			expect(mockCline.diffViewProvider.update).toHaveBeenCalledWith(testContent, true)
+			expect(mockAskApproval).toHaveBeenCalled()
+			expect(mockCline.diffViewProvider.saveChanges).toHaveBeenCalled()
+			expect(mockCline.fileContextTracker.trackFileContext).toHaveBeenCalledWith(testFilePath, "roo_edited")
+			expect(mockCline.didEditFile).toBe(true)
+		})
+
+		it("processes files outside workspace boundary", async () => {
+			mockedIsPathOutsideWorkspace.mockReturnValue(true)
+
+			await executeWriteFileTool({})
+
+			expect(mockedIsPathOutsideWorkspace).toHaveBeenCalled()
+		})
+
+		it("processes files with very large line counts", async () => {
+			await executeWriteFileTool({ line_count: "999999" })
+
+			// Should process normally without issues
+			expect(mockCline.consecutiveMistakeCount).toBe(0)
+		})
+	})
+
+	describe("partial block handling", () => {
+		it("returns early when path is missing in partial block", async () => {
+			await executeWriteFileTool({ path: undefined }, { isPartial: true })
+
+			expect(mockCline.diffViewProvider.open).not.toHaveBeenCalled()
+		})
+
+		it("returns early when content is undefined in partial block", async () => {
+			await executeWriteFileTool({ content: undefined }, { isPartial: true })
+
+			expect(mockCline.diffViewProvider.open).not.toHaveBeenCalled()
+		})
+
+		it("streams content updates during partial execution", async () => {
+			await executeWriteFileTool({}, { isPartial: true })
+
+			expect(mockCline.ask).toHaveBeenCalled()
+			expect(mockCline.diffViewProvider.open).toHaveBeenCalledWith(testFilePath)
+			expect(mockCline.diffViewProvider.update).toHaveBeenCalledWith(testContent, false)
+		})
+	})
+
+	describe("user interaction", () => {
+		it("reverts changes when user rejects approval", async () => {
+			mockAskApproval.mockResolvedValue(false)
+
+			await executeWriteFileTool({})
+
+			expect(mockCline.diffViewProvider.revertChanges).toHaveBeenCalled()
+			expect(mockCline.diffViewProvider.saveChanges).not.toHaveBeenCalled()
+		})
+
+		it("reports user edits with diff feedback", async () => {
+			mockCline.diffViewProvider.saveChanges.mockResolvedValue({
+				newProblemsMessage: " with warnings",
+				userEdits: "- old line\n+ new line",
+				finalContent: "modified content",
+			})
+
+			await executeWriteFileTool({}, { fileExists: true })
+
+			expect(mockCline.say).toHaveBeenCalledWith(
+				"user_feedback_diff",
+				expect.stringContaining("editedExistingFile"),
+			)
+		})
+	})
+
+	describe("error handling", () => {
+		it("handles general file operation errors", async () => {
+			mockCline.diffViewProvider.open.mockRejectedValue(new Error("General error"))
+
+			await executeWriteFileTool({})
+
+			expect(mockHandleError).toHaveBeenCalledWith("writing file", expect.any(Error))
+			expect(mockCline.diffViewProvider.reset).toHaveBeenCalled()
+		})
+
+		it("handles partial streaming errors", async () => {
+			mockCline.diffViewProvider.open.mockRejectedValue(new Error("Open failed"))
+
+			await executeWriteFileTool({}, { isPartial: true })
+
+			expect(mockHandleError).toHaveBeenCalledWith("writing file", expect.any(Error))
+			expect(mockCline.diffViewProvider.reset).toHaveBeenCalled()
+		})
+	})
+})

--- a/src/core/tools/writeToFileTool.ts
+++ b/src/core/tools/writeToFileTool.ts
@@ -26,7 +26,7 @@ export async function writeToFileTool(
 	let newContent: string | undefined = block.params.content
 	let predictedLineCount: number | undefined = parseInt(block.params.line_count ?? "0")
 
-	if (!relPath || !newContent) {
+	if (!relPath || newContent === undefined) {
 		// checking for newContent ensure relPath is complete
 		// wait so we can determine if it's a new file or editing an existing file
 		return
@@ -104,7 +104,7 @@ export async function writeToFileTool(
 				return
 			}
 
-			if (!newContent) {
+			if (newContent === undefined) {
 				cline.consecutiveMistakeCount++
 				cline.recordToolError("write_to_file")
 				pushToolResult(await cline.sayAndCreateMissingParamError("write_to_file", "content"))
@@ -112,7 +112,7 @@ export async function writeToFileTool(
 				return
 			}
 
-			if (!predictedLineCount) {
+			if (predictedLineCount === undefined) {
 				cline.consecutiveMistakeCount++
 				cline.recordToolError("write_to_file")
 


### PR DESCRIPTION
Early check for partial-block
Small typo
Missing path normalization

### Related GitHub Issue

Closes: #3650

### Description

This PR fixes a bug where the [`write_to_file`](https://github.com/RooCodeInc/Roo-Code/blob/main/src/core/tools/writeToFileTool.ts) tool would appear to succeed but fail to create files when the content parameter is empty. The tool now properly creates empty files when requested, ensuring consistent behavior regardless of content length.

**Key changes:**
- Modified the file writing logic to handle empty content correctly
- Enhanced error handling for edge cases
- Refactor file for simplification and reduced code-duplication
- Add Unit-Tests for writeToFileTool

### Test Procedure

- Unit-tests
- Ask model to create an empty file

### Type of Change

<!-- Mark all applicable boxes with an 'x'. -->

- [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [ ] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [x] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [x] **Testing**:
    - [x] New and/or updated tests have been added to cover my changes.
    - [x] All tests pass locally (`npm test`).
    - [x] The application builds successfully with my changes.
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](../CONTRIBUTING.md).

### Documentation Updates

- [x] No documentation updates are required.

### Get in Touch

Discord: `ruakij`

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `writeToFileTool` to handle empty content correctly, adds error handling, refactors for clarity, and introduces comprehensive unit tests.
> 
>   - **Behavior**:
>     - Fixes `writeToFileTool` to create files even when content is empty in `writeToFileTool.ts`.
>     - Adds early return for missing path or content in partial blocks.
>     - Improves error handling for missing parameters and line count discrepancies.
>   - **Refactoring**:
>     - Introduces helper functions: `validateAccess`, `checkFileExists`, `preprocessContent`, `createMessageProps`, and `handleDiffViewUpdate` in `writeToFileTool.ts`.
>     - Refactors file writing logic for clarity and reduced duplication.
>   - **Testing**:
>     - Adds `writeToFileTool.test.ts` with unit tests for parameter validation, access control, file existence, content preprocessing, file operations, partial block handling, user interaction, and error handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 06d8bbb50beb129a4edca457d34b8bdc3581c46e. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->