### PR TITLE
fix: ensure AI uses tools before asking user questions

### DIFF
--- a/src/core/prompts/__tests__/__snapshots__/system.test.ts.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system.test.ts.snap
@@ -275,6 +275,11 @@ Example: Requesting to execute ls in a specific directory if directed
 
 ## ask_followup_question
 Description: Ask the user a question to gather additional information needed to complete the task. This tool should be used when you encounter ambiguities, need clarification, or require more details to proceed effectively. It allows for interactive problem-solving by enabling direct communication with the user. Use this tool judiciously to maintain a balance between gathering necessary information and avoiding excessive back-and-forth.
+IMPORTANT: Before asking the user for information:
+1. YOU MUST FIRST use available tools (eg, search_files, list_files, ...) to locate any needed information
+2. YOU MUST ONLY request user-provided details when those tools cannot retrieve them (eg, design specific considerations).  
+3. YOU MUST PRIORITIZE your own knowledge and ONLY ask the user if you lack the answer when multiple options are suitable and require human consideration.
+
 Parameters:
 - question: (required) The question to ask the user. This should be a clear, specific question that addresses the information you need.
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
@@ -748,6 +753,11 @@ Example: Requesting to execute ls in a specific directory if directed
 
 ## ask_followup_question
 Description: Ask the user a question to gather additional information needed to complete the task. This tool should be used when you encounter ambiguities, need clarification, or require more details to proceed effectively. It allows for interactive problem-solving by enabling direct communication with the user. Use this tool judiciously to maintain a balance between gathering necessary information and avoiding excessive back-and-forth.
+IMPORTANT: Before asking the user for information:
+1. YOU MUST FIRST use available tools (eg, search_files, list_files, ...) to locate any needed information
+2. YOU MUST ONLY request user-provided details when those tools cannot retrieve them (eg, design specific considerations).  
+3. YOU MUST PRIORITIZE your own knowledge and ONLY ask the user if you lack the answer when multiple options are suitable and require human consideration.
+
 Parameters:
 - question: (required) The question to ask the user. This should be a clear, specific question that addresses the information you need.
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
@@ -1221,6 +1231,11 @@ Example: Requesting to execute ls in a specific directory if directed
 
 ## ask_followup_question
 Description: Ask the user a question to gather additional information needed to complete the task. This tool should be used when you encounter ambiguities, need clarification, or require more details to proceed effectively. It allows for interactive problem-solving by enabling direct communication with the user. Use this tool judiciously to maintain a balance between gathering necessary information and avoiding excessive back-and-forth.
+IMPORTANT: Before asking the user for information:
+1. YOU MUST FIRST use available tools (eg, search_files, list_files, ...) to locate any needed information
+2. YOU MUST ONLY request user-provided details when those tools cannot retrieve them (eg, design specific considerations).  
+3. YOU MUST PRIORITIZE your own knowledge and ONLY ask the user if you lack the answer when multiple options are suitable and require human consideration.
+
 Parameters:
 - question: (required) The question to ask the user. This should be a clear, specific question that addresses the information you need.
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
@@ -1747,6 +1762,11 @@ Example: Requesting to execute ls in a specific directory if directed
 
 ## ask_followup_question
 Description: Ask the user a question to gather additional information needed to complete the task. This tool should be used when you encounter ambiguities, need clarification, or require more details to proceed effectively. It allows for interactive problem-solving by enabling direct communication with the user. Use this tool judiciously to maintain a balance between gathering necessary information and avoiding excessive back-and-forth.
+IMPORTANT: Before asking the user for information:
+1. YOU MUST FIRST use available tools (eg, search_files, list_files, ...) to locate any needed information
+2. YOU MUST ONLY request user-provided details when those tools cannot retrieve them (eg, design specific considerations).  
+3. YOU MUST PRIORITIZE your own knowledge and ONLY ask the user if you lack the answer when multiple options are suitable and require human consideration.
+
 Parameters:
 - question: (required) The question to ask the user. This should be a clear, specific question that addresses the information you need.
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
@@ -2272,6 +2292,11 @@ Example: Requesting to access an MCP resource
 
 ## ask_followup_question
 Description: Ask the user a question to gather additional information needed to complete the task. This tool should be used when you encounter ambiguities, need clarification, or require more details to proceed effectively. It allows for interactive problem-solving by enabling direct communication with the user. Use this tool judiciously to maintain a balance between gathering necessary information and avoiding excessive back-and-forth.
+IMPORTANT: Before asking the user for information:
+1. YOU MUST FIRST use available tools (eg, search_files, list_files, ...) to locate any needed information
+2. YOU MUST ONLY request user-provided details when those tools cannot retrieve them (eg, design specific considerations).  
+3. YOU MUST PRIORITIZE your own knowledge and ONLY ask the user if you lack the answer when multiple options are suitable and require human consideration.
+
 Parameters:
 - question: (required) The question to ask the user. This should be a clear, specific question that addresses the information you need.
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
@@ -2817,6 +2842,11 @@ Example: Requesting to execute ls in a specific directory if directed
 
 ## ask_followup_question
 Description: Ask the user a question to gather additional information needed to complete the task. This tool should be used when you encounter ambiguities, need clarification, or require more details to proceed effectively. It allows for interactive problem-solving by enabling direct communication with the user. Use this tool judiciously to maintain a balance between gathering necessary information and avoiding excessive back-and-forth.
+IMPORTANT: Before asking the user for information:
+1. YOU MUST FIRST use available tools (eg, search_files, list_files, ...) to locate any needed information
+2. YOU MUST ONLY request user-provided details when those tools cannot retrieve them (eg, design specific considerations).  
+3. YOU MUST PRIORITIZE your own knowledge and ONLY ask the user if you lack the answer when multiple options are suitable and require human consideration.
+
 Parameters:
 - question: (required) The question to ask the user. This should be a clear, specific question that addresses the information you need.
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
@@ -3383,6 +3413,11 @@ Example: Requesting to execute ls in a specific directory if directed
 
 ## ask_followup_question
 Description: Ask the user a question to gather additional information needed to complete the task. This tool should be used when you encounter ambiguities, need clarification, or require more details to proceed effectively. It allows for interactive problem-solving by enabling direct communication with the user. Use this tool judiciously to maintain a balance between gathering necessary information and avoiding excessive back-and-forth.
+IMPORTANT: Before asking the user for information:
+1. YOU MUST FIRST use available tools (eg, search_files, list_files, ...) to locate any needed information
+2. YOU MUST ONLY request user-provided details when those tools cannot retrieve them (eg, design specific considerations).  
+3. YOU MUST PRIORITIZE your own knowledge and ONLY ask the user if you lack the answer when multiple options are suitable and require human consideration.
+
 Parameters:
 - question: (required) The question to ask the user. This should be a clear, specific question that addresses the information you need.
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
@@ -3856,6 +3891,11 @@ Example: Requesting to execute ls in a specific directory if directed
 
 ## ask_followup_question
 Description: Ask the user a question to gather additional information needed to complete the task. This tool should be used when you encounter ambiguities, need clarification, or require more details to proceed effectively. It allows for interactive problem-solving by enabling direct communication with the user. Use this tool judiciously to maintain a balance between gathering necessary information and avoiding excessive back-and-forth.
+IMPORTANT: Before asking the user for information:
+1. YOU MUST FIRST use available tools (eg, search_files, list_files, ...) to locate any needed information
+2. YOU MUST ONLY request user-provided details when those tools cannot retrieve them (eg, design specific considerations).  
+3. YOU MUST PRIORITIZE your own knowledge and ONLY ask the user if you lack the answer when multiple options are suitable and require human consideration.
+
 Parameters:
 - question: (required) The question to ask the user. This should be a clear, specific question that addresses the information you need.
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
@@ -4420,6 +4460,11 @@ Example: Requesting to access an MCP resource
 
 ## ask_followup_question
 Description: Ask the user a question to gather additional information needed to complete the task. This tool should be used when you encounter ambiguities, need clarification, or require more details to proceed effectively. It allows for interactive problem-solving by enabling direct communication with the user. Use this tool judiciously to maintain a balance between gathering necessary information and avoiding excessive back-and-forth.
+IMPORTANT: Before asking the user for information:
+1. YOU MUST FIRST use available tools (eg, search_files, list_files, ...) to locate any needed information
+2. YOU MUST ONLY request user-provided details when those tools cannot retrieve them (eg, design specific considerations).  
+3. YOU MUST PRIORITIZE your own knowledge and ONLY ask the user if you lack the answer when multiple options are suitable and require human consideration.
+
 Parameters:
 - question: (required) The question to ask the user. This should be a clear, specific question that addresses the information you need.
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
@@ -4899,6 +4944,11 @@ Examples:
 
 ## ask_followup_question
 Description: Ask the user a question to gather additional information needed to complete the task. This tool should be used when you encounter ambiguities, need clarification, or require more details to proceed effectively. It allows for interactive problem-solving by enabling direct communication with the user. Use this tool judiciously to maintain a balance between gathering necessary information and avoiding excessive back-and-forth.
+IMPORTANT: Before asking the user for information:
+1. YOU MUST FIRST use available tools (eg, search_files, list_files, ...) to locate any needed information
+2. YOU MUST ONLY request user-provided details when those tools cannot retrieve them (eg, design specific considerations).  
+3. YOU MUST PRIORITIZE your own knowledge and ONLY ask the user if you lack the answer when multiple options are suitable and require human consideration.
+
 Parameters:
 - question: (required) The question to ask the user. This should be a clear, specific question that addresses the information you need.
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
@@ -5260,6 +5310,11 @@ Examples:
 
 ## ask_followup_question
 Description: Ask the user a question to gather additional information needed to complete the task. This tool should be used when you encounter ambiguities, need clarification, or require more details to proceed effectively. It allows for interactive problem-solving by enabling direct communication with the user. Use this tool judiciously to maintain a balance between gathering necessary information and avoiding excessive back-and-forth.
+IMPORTANT: Before asking the user for information:
+1. YOU MUST FIRST use available tools (eg, search_files, list_files, ...) to locate any needed information
+2. YOU MUST ONLY request user-provided details when those tools cannot retrieve them (eg, design specific considerations).  
+3. YOU MUST PRIORITIZE your own knowledge and ONLY ask the user if you lack the answer when multiple options are suitable and require human consideration.
+
 Parameters:
 - question: (required) The question to ask the user. This should be a clear, specific question that addresses the information you need.
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
@@ -5815,6 +5870,11 @@ Example: Requesting to access an MCP resource
 
 ## ask_followup_question
 Description: Ask the user a question to gather additional information needed to complete the task. This tool should be used when you encounter ambiguities, need clarification, or require more details to proceed effectively. It allows for interactive problem-solving by enabling direct communication with the user. Use this tool judiciously to maintain a balance between gathering necessary information and avoiding excessive back-and-forth.
+IMPORTANT: Before asking the user for information:
+1. YOU MUST FIRST use available tools (eg, search_files, list_files, ...) to locate any needed information
+2. YOU MUST ONLY request user-provided details when those tools cannot retrieve them (eg, design specific considerations).  
+3. YOU MUST PRIORITIZE your own knowledge and ONLY ask the user if you lack the answer when multiple options are suitable and require human consideration.
+
 Parameters:
 - question: (required) The question to ask the user. This should be a clear, specific question that addresses the information you need.
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:

--- a/src/core/prompts/tools/ask-followup-question.ts
+++ b/src/core/prompts/tools/ask-followup-question.ts
@@ -1,6 +1,11 @@
 export function getAskFollowupQuestionDescription(): string {
 	return `## ask_followup_question
 Description: Ask the user a question to gather additional information needed to complete the task. This tool should be used when you encounter ambiguities, need clarification, or require more details to proceed effectively. It allows for interactive problem-solving by enabling direct communication with the user. Use this tool judiciously to maintain a balance between gathering necessary information and avoiding excessive back-and-forth.
+IMPORTANT: Before asking the user for information:
+1. YOU MUST FIRST use available tools (eg, search_files, list_files, ...) to locate any needed information
+2. YOU MUST ONLY request user-provided details when those tools cannot retrieve them (eg, design specific considerations).  
+3. YOU MUST PRIORITIZE your own knowledge and ONLY ask the user if you lack the answer when multiple options are suitable and require human consideration.
+
 Parameters:
 - question: (required) The question to ask the user. This should be a clear, specific question that addresses the information you need.
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:


### PR DESCRIPTION
## Context

The AI was sometimes asking users for information (like file paths) that it could have found itself using available tools like search_files or list_files. This created unnecessary back-and-forth with users and made the AI seem less capable than it actually is.

## Implementation

This change adds explicit instructions to the ask_followup_question tool description to ensure the AI:

1. FIRST uses available tools (like search_files, list_files) to locate needed information
2. ONLY requests user-provided details when those tools cannot retrieve them
3. PRIORITIZES its own knowledge and only asks the user when multiple options require human consideration

The changes were made to the ask-followup-question.ts file and the corresponding snapshot tests were updated.

## Screenshots

N/A - This is a behavior change in the AI's prompting.

## How to Test

1. Ask the AI to find a file without specifying the exact path
2. The AI should use search_files or list_files to locate the file rather than asking you for the path
3. The AI should only ask follow-up questions when it genuinely cannot determine the information using available tools

## Get in Touch

Discord: KJ7LNW

Fixes #3873