### PR TITLE
fix: respect user-configured terminal integration timeout

### DIFF
--- a/src/integrations/terminal/BaseTerminal.ts
+++ b/src/integrations/terminal/BaseTerminal.ts
@@ -170,7 +170,7 @@ export abstract class BaseTerminal implements RooTerminal {
 	}
 
 	public static getShellIntegrationTimeout(): number {
-		return Math.min(BaseTerminal.shellIntegrationTimeout, BaseTerminal.defaultShellIntegrationTimeout)
+		return BaseTerminal.shellIntegrationTimeout
 	}
 
 	public static setShellIntegrationDisabled(disabled: boolean): void {


### PR DESCRIPTION
## Context

Terminal integration timeout was being capped at 5 seconds regardless of user configuration, causing shell integration to fail prematurely when initialization took longer than 5 seconds.

## Implementation

Removed the Math.min call in getShellIntegrationTimeout() that was capping the timeout at the default value of 5000ms, allowing the user-configured timeout value to be respected.

## How to Test

1. Set terminal integration timeout to a value higher than 5 seconds (e.g., 60 seconds)
2. Run a command that takes longer than 5 seconds to initialize shell integration
3. Verify that shell integration doesn't fail after 5 seconds but waits for the configured timeout

Fixes #3885
Fixes #3829
Regression from #2820

## Get in Touch
Discord: KJ7LNW
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removed timeout cap in `getShellIntegrationTimeout()` in `BaseTerminal.ts` to respect user-configured values, fixing premature shell integration failures.
> 
>   - **Behavior**:
>     - Removed `Math.min` call in `getShellIntegrationTimeout()` in `BaseTerminal.ts`, allowing user-configured timeout values to be respected.
>     - Fixes premature shell integration failure when initialization exceeds 5 seconds.
>   - **Testing**:
>     - Set terminal integration timeout above 5 seconds and verify shell integration waits for configured timeout.
>   - **Issues Fixed**:
>     - Fixes #3885, #3829.
>     - Regression from #2820.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0701a9d57cff4eac7d9692ced4eafe97c94a2313. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->