### PR TITLE
Fix vscode-material-icons path

### DIFF
--- a/.changeset/salty-geese-relate.md
+++ b/.changeset/salty-geese-relate.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix vscode-material-icons path

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -573,7 +573,11 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 		])
 
 		const codiconsUri = getUri(webview, this.contextProxy.extensionUri, ["assets", "codicons", "codicon.css"])
-		const materialIconsUri = getUri(webview, this.contextProxy.extensionUri, ["assets", "vscode-material-icons"])
+		const materialIconsUri = getUri(webview, this.contextProxy.extensionUri, [
+			"assets",
+			"vscode-material-icons",
+			"icons",
+		])
 		const imagesUri = getUri(webview, this.contextProxy.extensionUri, ["assets", "images"])
 		const audioUri = getUri(webview, this.contextProxy.extensionUri, ["webview-ui", "audio"])
 
@@ -650,7 +654,11 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 
 		const scriptUri = getUri(webview, this.contextProxy.extensionUri, ["webview-ui", "build", "assets", "index.js"])
 		const codiconsUri = getUri(webview, this.contextProxy.extensionUri, ["assets", "codicons", "codicon.css"])
-		const materialIconsUri = getUri(webview, this.contextProxy.extensionUri, ["assets", "vscode-material-icons"])
+		const materialIconsUri = getUri(webview, this.contextProxy.extensionUri, [
+			"assets",
+			"vscode-material-icons",
+			"icons",
+		])
 		const imagesUri = getUri(webview, this.contextProxy.extensionUri, ["assets", "images"])
 		const audioUri = getUri(webview, this.contextProxy.extensionUri, ["webview-ui", "audio"])
 


### PR DESCRIPTION
### Description

I missed the fact that the icons are packaged under `icons/`.