### PR TITLE
Fix global settings export

### DIFF
--- a/.changeset/young-buckets-fold.md
+++ b/.changeset/young-buckets-fold.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix global settings export

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1263,7 +1263,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 			alwaysAllowMcp: alwaysAllowMcp ?? false,
 			alwaysAllowModeSwitch: alwaysAllowModeSwitch ?? false,
 			alwaysAllowSubtasks: alwaysAllowSubtasks ?? false,
-			allowedMaxRequests: allowedMaxRequests ?? Infinity,
+			allowedMaxRequests,
 			autoCondenseContextPercent: autoCondenseContextPercent ?? 100,
 			uriScheme: vscode.env.uriScheme,
 			currentTaskItem: this.getCurrentCline()?.taskId
@@ -1369,7 +1369,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 			alwaysAllowMcp: stateValues.alwaysAllowMcp ?? false,
 			alwaysAllowModeSwitch: stateValues.alwaysAllowModeSwitch ?? false,
 			alwaysAllowSubtasks: stateValues.alwaysAllowSubtasks ?? false,
-			allowedMaxRequests: stateValues.allowedMaxRequests ?? Infinity,
+			allowedMaxRequests: stateValues.allowedMaxRequests,
 			autoCondenseContextPercent: stateValues.autoCondenseContextPercent ?? 100,
 			taskHistory: stateValues.taskHistory,
 			allowedCommands: stateValues.allowedCommands,

--- a/src/exports/roo-code.d.ts
+++ b/src/exports/roo-code.d.ts
@@ -72,7 +72,7 @@ type GlobalSettings = {
 	alwaysAllowSubtasks?: boolean | undefined
 	alwaysAllowExecute?: boolean | undefined
 	allowedCommands?: string[] | undefined
-	allowedMaxRequests?: number | undefined
+	allowedMaxRequests?: (number | null) | undefined
 	autoCondenseContextPercent?: number | undefined
 	browserToolEnabled?: boolean | undefined
 	browserViewportSize?: string | undefined
@@ -809,7 +809,7 @@ type IpcMessage =
 								alwaysAllowSubtasks?: boolean | undefined
 								alwaysAllowExecute?: boolean | undefined
 								allowedCommands?: string[] | undefined
-								allowedMaxRequests?: number | undefined
+								allowedMaxRequests?: (number | null) | undefined
 								autoCondenseContextPercent?: number | undefined
 								browserToolEnabled?: boolean | undefined
 								browserViewportSize?: string | undefined
@@ -1286,7 +1286,7 @@ type TaskCommand =
 					alwaysAllowSubtasks?: boolean | undefined
 					alwaysAllowExecute?: boolean | undefined
 					allowedCommands?: string[] | undefined
-					allowedMaxRequests?: number | undefined
+					allowedMaxRequests?: (number | null) | undefined
 					autoCondenseContextPercent?: number | undefined
 					browserToolEnabled?: boolean | undefined
 					browserViewportSize?: string | undefined

--- a/src/exports/types.ts
+++ b/src/exports/types.ts
@@ -72,7 +72,7 @@ type GlobalSettings = {
 	alwaysAllowSubtasks?: boolean | undefined
 	alwaysAllowExecute?: boolean | undefined
 	allowedCommands?: string[] | undefined
-	allowedMaxRequests?: number | undefined
+	allowedMaxRequests?: (number | null) | undefined
 	autoCondenseContextPercent?: number | undefined
 	browserToolEnabled?: boolean | undefined
 	browserViewportSize?: string | undefined
@@ -823,7 +823,7 @@ type IpcMessage =
 								alwaysAllowSubtasks?: boolean | undefined
 								alwaysAllowExecute?: boolean | undefined
 								allowedCommands?: string[] | undefined
-								allowedMaxRequests?: number | undefined
+								allowedMaxRequests?: (number | null) | undefined
 								autoCondenseContextPercent?: number | undefined
 								browserToolEnabled?: boolean | undefined
 								browserViewportSize?: string | undefined
@@ -1302,7 +1302,7 @@ type TaskCommand =
 					alwaysAllowSubtasks?: boolean | undefined
 					alwaysAllowExecute?: boolean | undefined
 					allowedCommands?: string[] | undefined
-					allowedMaxRequests?: number | undefined
+					allowedMaxRequests?: (number | null) | undefined
 					autoCondenseContextPercent?: number | undefined
 					browserToolEnabled?: boolean | undefined
 					browserViewportSize?: string | undefined

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -752,7 +752,7 @@ export const globalSettingsSchema = z.object({
 	alwaysAllowSubtasks: z.boolean().optional(),
 	alwaysAllowExecute: z.boolean().optional(),
 	allowedCommands: z.array(z.string()).optional(),
-	allowedMaxRequests: z.number().optional(),
+	allowedMaxRequests: z.number().nullish(),
 	autoCondenseContextPercent: z.number().optional(),
 
 	browserToolEnabled: z.boolean().optional(),

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -250,7 +250,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 			vscode.postMessage({ type: "alwaysAllowBrowser", bool: alwaysAllowBrowser })
 			vscode.postMessage({ type: "alwaysAllowMcp", bool: alwaysAllowMcp })
 			vscode.postMessage({ type: "allowedCommands", commands: allowedCommands ?? [] })
-			vscode.postMessage({ type: "allowedMaxRequests", value: allowedMaxRequests })
+			vscode.postMessage({ type: "allowedMaxRequests", value: allowedMaxRequests ?? undefined })
 			vscode.postMessage({ type: "autoCondenseContextPercent", value: autoCondenseContextPercent })
 			vscode.postMessage({ type: "browserToolEnabled", bool: browserToolEnabled })
 			vscode.postMessage({ type: "soundEnabled", bool: soundEnabled })

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -140,7 +140,6 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		taskHistory: [],
 		shouldShowAnnouncement: false,
 		allowedCommands: [],
-		allowedMaxRequests: Infinity,
 		soundEnabled: false,
 		soundVolume: 0.5,
 		ttsEnabled: false,


### PR DESCRIPTION
### Description

The `maxAllowedRequests` value seems to be `null` in some cases. I'm not sure why; I wonder if it has to do with zod and `Infinity`. This ends up removing global settings from exports due to the schema parse error. I've allowed null values for now.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix export issue by allowing `allowedMaxRequests` to be `null` in global settings.
> 
>   - **Behavior**:
>     - Allow `allowedMaxRequests` to be `null` in `globalSettingsSchema` in `schemas/index.ts`.
>     - Update `ClineProvider` in `ClineProvider.ts` to handle `allowedMaxRequests` without defaulting to `Infinity`.
>     - Ensure `allowedMaxRequests` is correctly handled in `SettingsView.tsx`.
>   - **Tests**:
>     - Add test in `importExport.test.ts` to verify global settings export when `allowedMaxRequests` is `null`.
>   - **Types**:
>     - Update `GlobalSettings` type in `roo-code.d.ts` and `types.ts` to allow `allowedMaxRequests` to be `null`.
>   - **Misc**:
>     - Add changeset `young-buckets-fold.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 416a595b7b05cc18534f0792ea263fa2e3d257f0. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->