### PR TITLE
Fix max tokens in the task header

### DIFF
--- a/.changeset/ten-bags-hang.md
+++ b/.changeset/ten-bags-hang.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix max tokens in task header

--- a/src/api/transform/model-params.ts
+++ b/src/api/transform/model-params.ts
@@ -87,16 +87,17 @@ export function getModelParams({
 		reasoningEffort = customReasoningEffort ?? model.reasoningEffort
 	}
 
+	const isAnthropic = format === "anthropic" || (format === "openrouter" && modelId.startsWith("anthropic/"))
+
 	// For "Hybrid" reasoning models, we should discard the model's actual
-	// `maxTokens` value if we're not using reasoning.
-	if (model.supportsReasoningBudget && !reasoningBudget) {
+	// `maxTokens` value if we're not using reasoning. We do this for Anthropic
+	// models only for now. Should we do this for Gemini too?
+	if (model.supportsReasoningBudget && !reasoningBudget && isAnthropic) {
 		maxTokens = ANTHROPIC_DEFAULT_MAX_TOKENS
 	}
 
 	// For Anthropic models we should always make sure a `maxTokens` value is
 	// set.
-	const isAnthropic = format === "anthropic" || (format === "openrouter" && modelId.startsWith("anthropic/"))
-
 	if (!maxTokens && isAnthropic) {
 		maxTokens = ANTHROPIC_DEFAULT_MAX_TOKENS
 	}

--- a/src/api/transform/model-params.ts
+++ b/src/api/transform/model-params.ts
@@ -87,6 +87,9 @@ export function getModelParams({
 		reasoningEffort = customReasoningEffort ?? model.reasoningEffort
 	}
 
+	// TODO: We should consolidate this logic to compute `maxTokens` with
+	// `getModelMaxOutputTokens` in order to maintain a single source of truth.
+
 	const isAnthropic = format === "anthropic" || (format === "openrouter" && modelId.startsWith("anthropic/"))
 
 	// For "Hybrid" reasoning models, we should discard the model's actual

--- a/webview-ui/src/__tests__/ContextWindowProgress.test.tsx
+++ b/webview-ui/src/__tests__/ContextWindowProgress.test.tsx
@@ -38,6 +38,7 @@ jest.mock("@src/components/chat/TaskHeader", () => {
 // Mock useSelectedModel hook
 jest.mock("@src/components/ui/hooks/useSelectedModel", () => ({
 	useSelectedModel: jest.fn(() => ({
+		id: "test",
 		info: { contextWindow: 4000 },
 	})),
 }))

--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -48,7 +48,7 @@ const TaskHeader = ({
 }: TaskHeaderProps) => {
 	const { t } = useTranslation()
 	const { apiConfiguration, currentTaskItem } = useExtensionState()
-	const { info: model } = useSelectedModel(apiConfiguration)
+	const { id: modelId, info: model } = useSelectedModel(apiConfiguration)
 	const [isTaskExpanded, setIsTaskExpanded] = useState(false)
 
 	const textContainerRef = useRef<HTMLDivElement>(null)
@@ -101,7 +101,9 @@ const TaskHeader = ({
 							contextWindow={contextWindow}
 							contextTokens={contextTokens || 0}
 							maxTokens={
-								model ? getModelMaxOutputTokens({ model, settings: apiConfiguration }) : undefined
+								model
+									? getModelMaxOutputTokens({ modelId, model, settings: apiConfiguration })
+									: undefined
 							}
 						/>
 						{!!totalCost && <VSCodeBadge>${totalCost.toFixed(2)}</VSCodeBadge>}
@@ -140,7 +142,11 @@ const TaskHeader = ({
 										contextTokens={contextTokens || 0}
 										maxTokens={
 											model
-												? getModelMaxOutputTokens({ model, settings: apiConfiguration })
+												? getModelMaxOutputTokens({
+														modelId,
+														model,
+														settings: apiConfiguration,
+													})
 												: undefined
 										}
 									/>


### PR DESCRIPTION
### Description

This logic exists in `getModelParams` but not `getModelMaxOutputTokens`. As a follow-up I'll consolidate these. One primary goal of the refactor from #3870 was to have a single source of truth, but I never got around to update this function that the task header calls.