### PR TITLE
Improve GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -73,7 +73,7 @@ body:
     attributes:
       label: 💥 Outcome Summary
       description: |
-        Recap what went wrong in one or two lines. Use this if the bug is weird, unexpected, or needs extra context.
+        Recap what went wrong in one or two lines.
 
         Example: "Expected code to run, but got an empty response and no error."
       placeholder: Expected ___, but got ___.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -71,16 +71,18 @@ body:
   - type: textarea
     id: what-happened
     attributes:
-      label: 💥 Outcome Summary (Optional)
+      label: 💥 Outcome Summary
       description: |
         Recap what went wrong in one or two lines. Use this if the bug is weird, unexpected, or needs extra context.
 
         Example: "Expected code to run, but got an empty response and no error."
       placeholder: Expected ___, but got ___.
+    validations:
+      required: true
 
   - type: textarea
     id: logs
     attributes:
-      label: 📄 Relevant Logs or Errors
+      label: 📄 Relevant Logs or Errors (Optional)
       description: Paste API logs, terminal output, or errors here. Use triple backticks (```) for code formatting.
       render: shell

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -61,7 +61,7 @@ Detail the steps to test your changes. This helps reviewers verify your work.
 - [ ] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
 - [ ] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
 - [ ] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
-- [ ] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](../CONTRIBUTING.md).
+- [ ] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](../../CONTRIBUTING.md).
 
 ### Screenshots / Videos
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -61,7 +61,7 @@ Detail the steps to test your changes. This helps reviewers verify your work.
 - [ ] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
 - [ ] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
 - [ ] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
-- [ ] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](../../CONTRIBUTING.md).
+- [ ] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).
 
 ### Screenshots / Videos
 


### PR DESCRIPTION
- Make bug report outcome summary required for better issue quality
- Make logs/errors optional to reduce friction for simple bugs
- Fix CONTRIBUTING.md path in PR template (../../ instead of ../)


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improve GitHub templates by requiring outcome summary in bug reports and fixing CONTRIBUTING.md path in PR template.
> 
>   - **Bug Report Template**:
>     - Makes "Outcome Summary" required to improve issue quality.
>     - Marks "Relevant Logs or Errors" as optional to reduce friction for simple bugs.
>   - **Pull Request Template**:
>     - Fixes path to `CONTRIBUTING.md` from `../` to `../../`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 980c9cef77d5647cb8761216e2aa607d3cb8f746. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->