### PR TITLE
Fix o1-pro on OpenRouter

### DIFF
--- a/.changeset/slow-spies-walk.md
+++ b/.changeset/slow-spies-walk.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix o1-pro on OpenRouter

--- a/src/api/providers/__tests__/ollama.spec.ts
+++ b/src/api/providers/__tests__/ollama.spec.ts
@@ -1,14 +1,17 @@
+// npx vitest run api/providers/__tests__/ollama.spec.ts
+
+import { vitest } from "vitest"
 import { Anthropic } from "@anthropic-ai/sdk"
 
 import { OllamaHandler } from "../ollama"
 import { ApiHandlerOptions } from "../../../shared/api"
 
-// Mock OpenAI client
-const mockCreate = jest.fn()
-jest.mock("openai", () => {
+const mockCreate = vitest.fn()
+
+vitest.mock("openai", () => {
 	return {
 		__esModule: true,
-		default: jest.fn().mockImplementation(() => ({
+		default: vitest.fn().mockImplementation(() => ({
 			chat: {
 				completions: {
 					create: mockCreate.mockImplementation(async (options) => {

--- a/src/api/providers/__tests__/openai-usage-tracking.spec.ts
+++ b/src/api/providers/__tests__/openai-usage-tracking.spec.ts
@@ -1,13 +1,17 @@
-import { OpenAiHandler } from "../openai"
-import { ApiHandlerOptions } from "../../../shared/api"
+// npx vitest run api/providers/__tests__/openai-usage-tracking.spec.ts
+
+import { vitest } from "vitest"
 import { Anthropic } from "@anthropic-ai/sdk"
 
-// Mock OpenAI client with multiple chunks that contain usage data
-const mockCreate = jest.fn()
-jest.mock("openai", () => {
+import { ApiHandlerOptions } from "../../../shared/api"
+import { OpenAiHandler } from "../openai"
+
+const mockCreate = vitest.fn()
+
+vitest.mock("openai", () => {
 	return {
 		__esModule: true,
-		default: jest.fn().mockImplementation(() => ({
+		default: vitest.fn().mockImplementation(() => ({
 			chat: {
 				completions: {
 					create: mockCreate.mockImplementation(async (options) => {

--- a/src/api/providers/__tests__/openai.spec.ts
+++ b/src/api/providers/__tests__/openai.spec.ts
@@ -1,15 +1,18 @@
-// npx jest src/api/providers/__tests__/openai.test.ts
+// npx vitest run api/providers/__tests__/openai.spec.ts
 
+import { vitest, vi } from "vitest"
 import { OpenAiHandler } from "../openai"
 import { ApiHandlerOptions } from "../../../shared/api"
 import { Anthropic } from "@anthropic-ai/sdk"
+import OpenAI from "openai"
 
-// Mock OpenAI client
-const mockCreate = jest.fn()
-jest.mock("openai", () => {
+const mockCreate = vitest.fn()
+
+vitest.mock("openai", () => {
+	const mockConstructor = vitest.fn()
 	return {
 		__esModule: true,
-		default: jest.fn().mockImplementation(() => ({
+		default: mockConstructor.mockImplementation(() => ({
 			chat: {
 				completions: {
 					create: mockCreate.mockImplementation(async (options) => {
@@ -94,10 +97,8 @@ describe("OpenAiHandler", () => {
 		})
 
 		it("should set default headers correctly", () => {
-			// Get the mock constructor from the jest mock system
-			const openAiMock = jest.requireMock("openai").default
-
-			expect(openAiMock).toHaveBeenCalledWith({
+			// Check that the OpenAI constructor was called with correct parameters
+			expect(vi.mocked(OpenAI)).toHaveBeenCalledWith({
 				baseURL: expect.any(String),
 				apiKey: expect.any(String),
 				defaultHeaders: {

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -165,7 +165,7 @@ export class OpenAiNativeHandler extends BaseProvider implements SingleCompletio
 
 		const info: ModelInfo = openAiNativeModels[id]
 
-		const { temperature, ...params } = getModelParams({
+		const params = getModelParams({
 			format: "openai",
 			modelId: id,
 			model: info,
@@ -175,13 +175,7 @@ export class OpenAiNativeHandler extends BaseProvider implements SingleCompletio
 
 		// The o3 models are named like "o3-mini-[reasoning-effort]", which are
 		// not valid model ids, so we need to strip the suffix.
-		// Also note that temperature is not supported for o1 and o3-mini.
-		return {
-			id: id.startsWith("o3-mini") ? "o3-mini" : id,
-			info,
-			...params,
-			temperature: id.startsWith("o1") || id.startsWith("o3-mini") ? undefined : temperature,
-		}
+		return { id: id.startsWith("o3-mini") ? "o3-mini" : id, info, ...params }
 	}
 
 	async completePrompt(prompt: string): Promise<string> {

--- a/src/vitest.config.ts
+++ b/src/vitest.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from "vitest/config"
 
 export default defineConfig({
-	test: { include: ["**/__tests__/**/*.spec.ts"] },
+	test: {
+		include: ["**/__tests__/**/*.spec.ts"],
+		globals: true,
+	},
 })


### PR DESCRIPTION
### Related GitHub Issue

Closes: #3725

### Description

OpenRouter's `supported_parameters` indicates that `temperature` is allowed but it is not. We're manually stripping it for now, but longer term we should add this to `ModelInfo`.

I also switched some test from jest to vitest to see how smoothly that can go (it's not bad).
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `temperature` parameter handling for specific models in OpenRouter and switches tests from Jest to Vitest.
> 
>   - **Behavior**:
>     - Strips `temperature` parameter for `o1`, `o1-preview`, `o1-mini`, `o3-mini`, and `o1-pro` models in `getModelParams()` in `model-params.ts`.
>     - Adds tests in `openai-native.spec.ts` to verify `temperature` handling for these models.
>   - **Testing**:
>     - Switches from Jest to Vitest in `ollama.spec.ts`, `openai-native.spec.ts`, `openai-usage-tracking.spec.ts`, and `openai.spec.ts`.
>     - Updates mock implementations to use `vitest.fn()` and `vitest.mock()`.
>   - **Misc**:
>     - Updates `vitest.config.ts` to include global test settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for efa6a56de1a357cc81004f01c136ba2c87dee463. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->