### PR TITLE
Handle partial messages in the codebase search tool

### DIFF
--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -357,12 +357,19 @@ export const ChatRowContent = ({
 					<div style={headerStyle}>
 						{toolIcon("search")}
 						<span style={{ fontWeight: "bold" }}>
-							{tool.path
-								? t("chat:codebaseSearch.wantsToSearchWithPath", {
-										query: tool.query,
-										path: tool.path,
-									})
-								: t("chat:codebaseSearch.wantsToSearch", { query: tool.query })}
+							{tool.path ? (
+								<Trans
+									i18nKey="chat:codebaseSearch.wantsToSearchWithPath"
+									components={{ code: <code></code> }}
+									values={{ query: tool.query, path: tool.path }}
+								/>
+							) : (
+								<Trans
+									i18nKey="chat:codebaseSearch.wantsToSearch"
+									components={{ code: <code></code> }}
+									values={{ query: tool.query }}
+								/>
+							)}
 						</span>
 					</div>
 				)

--- a/webview-ui/src/i18n/locales/ca/chat.json
+++ b/webview-ui/src/i18n/locales/ca/chat.json
@@ -262,8 +262,8 @@
 		}
 	},
 	"codebaseSearch": {
-		"wantsToSearch": "Roo vol cercar a la base de codi '{{query}}':",
-		"wantsToSearchWithPath": "Roo vol cercar a la base de codi '{{query}}' a '{{path}}':",
-		"didSearch": "S'han trobat {{count}} resultat(s) per a '{{query}}':"
+		"wantsToSearch": "Roo vol cercar a la base de codi <code>{{query}}</code>:",
+		"wantsToSearchWithPath": "Roo vol cercar a la base de codi <code>{{query}}</code> a <code>{{path}}</code>:",
+		"didSearch": "S'han trobat {{count}} resultat(s) per a <code>{{query}}</code>:"
 	}
 }

--- a/webview-ui/src/i18n/locales/de/chat.json
+++ b/webview-ui/src/i18n/locales/de/chat.json
@@ -262,8 +262,8 @@
 		}
 	},
 	"codebaseSearch": {
-		"wantsToSearch": "Roo möchte den Codebase nach '{{query}}' durchsuchen:",
-		"wantsToSearchWithPath": "Roo möchte den Codebase nach '{{query}}' in '{{path}}' durchsuchen:",
-		"didSearch": "{{count}} Ergebnis(se) für '{{query}}' gefunden:"
+		"wantsToSearch": "Roo möchte den Codebase nach <code>{{query}}</code> durchsuchen:",
+		"wantsToSearchWithPath": "Roo möchte den Codebase nach <code>{{query}}</code> in <code>{{path}}</code> durchsuchen:",
+		"didSearch": "{{count}} Ergebnis(se) für <code>{{query}}</code> gefunden:"
 	}
 }

--- a/webview-ui/src/i18n/locales/en/chat.json
+++ b/webview-ui/src/i18n/locales/en/chat.json
@@ -162,9 +162,9 @@
 		"didSearch": "Roo searched this directory for <code>{{regex}}</code>:"
 	},
 	"codebaseSearch": {
-		"wantsToSearch": "Roo wants to search the codebase for '{{query}}':",
-		"wantsToSearchWithPath": "Roo wants to search the codebase for '{{query}}' in '{{path}}':",
-		"didSearch": "Found {{count}} result(s) for '{{query}}':"
+		"wantsToSearch": "Roo wants to search the codebase for <code>{{query}}</code>:",
+		"wantsToSearchWithPath": "Roo wants to search the codebase for <code>{{query}}</code> in <code>{{path}}</code>:",
+		"didSearch": "Found {{count}} result(s) for <code>{{query}}</code>:"
 	},
 	"commandOutput": "Command Output",
 	"response": "Response",

--- a/webview-ui/src/i18n/locales/es/chat.json
+++ b/webview-ui/src/i18n/locales/es/chat.json
@@ -262,8 +262,8 @@
 		}
 	},
 	"codebaseSearch": {
-		"wantsToSearch": "Roo quiere buscar en la base de código '{{query}}':",
-		"wantsToSearchWithPath": "Roo quiere buscar en la base de código '{{query}}' en '{{path}}':",
-		"didSearch": "Se encontraron {{count}} resultado(s) para '{{query}}':"
+		"wantsToSearch": "Roo quiere buscar en la base de código <code>{{query}}</code>:",
+		"wantsToSearchWithPath": "Roo quiere buscar en la base de código <code>{{query}}</code> en <code>{{path}}</code>:",
+		"didSearch": "Se encontraron {{count}} resultado(s) para <code>{{query}}</code>:"
 	}
 }

--- a/webview-ui/src/i18n/locales/fr/chat.json
+++ b/webview-ui/src/i18n/locales/fr/chat.json
@@ -262,8 +262,8 @@
 		}
 	},
 	"codebaseSearch": {
-		"wantsToSearch": "Roo veut rechercher dans la base de code '{{query}}' :",
-		"wantsToSearchWithPath": "Roo veut rechercher dans la base de code '{{query}}' dans '{{path}}' :",
-		"didSearch": "{{count}} résultat(s) trouvé(s) pour '{{query}}' :"
+		"wantsToSearch": "Roo veut rechercher dans la base de code <code>{{query}}</code> :",
+		"wantsToSearchWithPath": "Roo veut rechercher dans la base de code <code>{{query}}</code> dans <code>{{path}}</code> :",
+		"didSearch": "{{count}} résultat(s) trouvé(s) pour <code>{{query}}</code> :"
 	}
 }

--- a/webview-ui/src/i18n/locales/hi/chat.json
+++ b/webview-ui/src/i18n/locales/hi/chat.json
@@ -262,8 +262,8 @@
 		}
 	},
 	"codebaseSearch": {
-		"wantsToSearch": "Roo कोडबेस में '{{query}}' खोजना चाहता है:",
-		"wantsToSearchWithPath": "Roo '{{path}}' में कोडबेस में '{{query}}' खोजना चाहता है:",
-		"didSearch": "'{{query}}' के लिए {{count}} परिणाम मिले:"
+		"wantsToSearch": "Roo कोडबेस में <code>{{query}}</code> खोजना चाहता है:",
+		"wantsToSearchWithPath": "Roo <code>{{path}}</code> में कोडबेस में <code>{{query}}</code> खोजना चाहता है:",
+		"didSearch": "<code>{{query}}</code> के लिए {{count}} परिणाम मिले:"
 	}
 }

--- a/webview-ui/src/i18n/locales/it/chat.json
+++ b/webview-ui/src/i18n/locales/it/chat.json
@@ -262,8 +262,8 @@
 		}
 	},
 	"codebaseSearch": {
-		"wantsToSearch": "Roo vuole cercare nella base di codice '{{query}}':",
-		"wantsToSearchWithPath": "Roo vuole cercare nella base di codice '{{query}}' in '{{path}}':",
-		"didSearch": "Trovato {{count}} risultato/i per '{{query}}':"
+		"wantsToSearch": "Roo vuole cercare nella base di codice <code>{{query}}</code>:",
+		"wantsToSearchWithPath": "Roo vuole cercare nella base di codice <code>{{query}}</code> in <code>{{path}}</code>:",
+		"didSearch": "Trovato {{count}} risultato/i per <code>{{query}}</code>:"
 	}
 }

--- a/webview-ui/src/i18n/locales/ja/chat.json
+++ b/webview-ui/src/i18n/locales/ja/chat.json
@@ -262,8 +262,8 @@
 		}
 	},
 	"codebaseSearch": {
-		"wantsToSearch": "Rooはコードベースで '{{query}}' を検索したい:",
-		"wantsToSearchWithPath": "Rooは '{{path}}' 内のコードベースで '{{query}}' を検索したい:",
-		"didSearch": "'{{query}}' の検索結果: {{count}} 件"
+		"wantsToSearch": "Rooはコードベースで <code>{{query}}</code> を検索したい:",
+		"wantsToSearchWithPath": "Rooは <code>{{path}}</code> 内のコードベースで <code>{{query}}</code> を検索したい:",
+		"didSearch": "<code>{{query}}</code> の検索結果: {{count}} 件"
 	}
 }

--- a/webview-ui/src/i18n/locales/ko/chat.json
+++ b/webview-ui/src/i18n/locales/ko/chat.json
@@ -262,8 +262,8 @@
 		}
 	},
 	"codebaseSearch": {
-		"wantsToSearch": "Roo가 코드베이스에서 '{{query}}'을(를) 검색하고 싶어합니다:",
-		"wantsToSearchWithPath": "Roo가 '{{path}}'에서 '{{query}}'을(를) 검색하고 싶어합니다:",
-		"didSearch": "'{{query}}'에 대한 검색 결과 {{count}}개 찾음:"
+		"wantsToSearch": "Roo가 코드베이스에서 <code>{{query}}</code>을(를) 검색하고 싶어합니다:",
+		"wantsToSearchWithPath": "Roo가 <code>{{path}}</code>에서 <code>{{query}}</code>을(를) 검색하고 싶어합니다:",
+		"didSearch": "<code>{{query}}</code>에 대한 검색 결과 {{count}}개 찾음:"
 	}
 }

--- a/webview-ui/src/i18n/locales/nl/chat.json
+++ b/webview-ui/src/i18n/locales/nl/chat.json
@@ -262,8 +262,8 @@
 		}
 	},
 	"codebaseSearch": {
-		"wantsToSearch": "Roo wil de codebase doorzoeken op '{{query}}':",
-		"wantsToSearchWithPath": "Roo wil de codebase doorzoeken op '{{query}}' in '{{path}}':",
-		"didSearch": "{{count}} resultaat/resultaten gevonden voor '{{query}}':"
+		"wantsToSearch": "Roo wil de codebase doorzoeken op <code>{{query}}</code>:",
+		"wantsToSearchWithPath": "Roo wil de codebase doorzoeken op <code>{{query}}</code> in <code>{{path}}</code>:",
+		"didSearch": "{{count}} resultaat/resultaten gevonden voor <code>{{query}}</code>:"
 	}
 }

--- a/webview-ui/src/i18n/locales/pl/chat.json
+++ b/webview-ui/src/i18n/locales/pl/chat.json
@@ -262,8 +262,8 @@
 		}
 	},
 	"codebaseSearch": {
-		"wantsToSearch": "Roo chce przeszukać bazę kodu w poszukiwaniu '{{query}}':",
-		"wantsToSearchWithPath": "Roo chce przeszukać bazę kodu w poszukiwaniu '{{query}}' w '{{path}}':",
-		"didSearch": "Znaleziono {{count}} wynik(ów) dla '{{query}}':"
+		"wantsToSearch": "Roo chce przeszukać bazę kodu w poszukiwaniu <code>{{query}}</code>:",
+		"wantsToSearchWithPath": "Roo chce przeszukać bazę kodu w poszukiwaniu <code>{{query}}</code> w <code>{{path}}</code>:",
+		"didSearch": "Znaleziono {{count}} wynik(ów) dla <code>{{query}}</code>:"
 	}
 }

--- a/webview-ui/src/i18n/locales/pt-BR/chat.json
+++ b/webview-ui/src/i18n/locales/pt-BR/chat.json
@@ -262,8 +262,8 @@
 		}
 	},
 	"codebaseSearch": {
-		"wantsToSearch": "Roo quer pesquisar na base de código por '{{query}}':",
-		"wantsToSearchWithPath": "Roo quer pesquisar na base de código por '{{query}}' em '{{path}}':",
-		"didSearch": "Encontrado {{count}} resultado(s) para '{{query}}':"
+		"wantsToSearch": "Roo quer pesquisar na base de código por <code>{{query}}</code>:",
+		"wantsToSearchWithPath": "Roo quer pesquisar na base de código por <code>{{query}}</code> em <code>{{path}}</code>:",
+		"didSearch": "Encontrado {{count}} resultado(s) para <code>{{query}}</code>:"
 	}
 }

--- a/webview-ui/src/i18n/locales/ru/chat.json
+++ b/webview-ui/src/i18n/locales/ru/chat.json
@@ -262,8 +262,8 @@
 		}
 	},
 	"codebaseSearch": {
-		"wantsToSearch": "Roo хочет выполнить поиск в кодовой базе по '{{query}}':",
-		"wantsToSearchWithPath": "Roo хочет выполнить поиск в кодовой базе по '{{query}}' в '{{path}}':",
-		"didSearch": "Найдено {{count}} результат(ов) для '{{query}}':"
+		"wantsToSearch": "Roo хочет выполнить поиск в кодовой базе по <code>{{query}}</code>:",
+		"wantsToSearchWithPath": "Roo хочет выполнить поиск в кодовой базе по <code>{{query}}</code> в <code>{{path}}</code>:",
+		"didSearch": "Найдено {{count}} результат(ов) для <code>{{query}}</code>:"
 	}
 }

--- a/webview-ui/src/i18n/locales/tr/chat.json
+++ b/webview-ui/src/i18n/locales/tr/chat.json
@@ -262,8 +262,8 @@
 		}
 	},
 	"codebaseSearch": {
-		"wantsToSearch": "Roo kod tabanında '{{query}}' aramak istiyor:",
-		"wantsToSearchWithPath": "Roo '{{path}}' içinde kod tabanında '{{query}}' aramak istiyor:",
-		"didSearch": "'{{query}}' için {{count}} sonuç bulundu:"
+		"wantsToSearch": "Roo kod tabanında <code>{{query}}</code> aramak istiyor:",
+		"wantsToSearchWithPath": "Roo <code>{{path}}</code> içinde kod tabanında <code>{{query}}</code> aramak istiyor:",
+		"didSearch": "<code>{{query}}</code> için {{count}} sonuç bulundu:"
 	}
 }

--- a/webview-ui/src/i18n/locales/vi/chat.json
+++ b/webview-ui/src/i18n/locales/vi/chat.json
@@ -262,8 +262,8 @@
 		}
 	},
 	"codebaseSearch": {
-		"wantsToSearch": "Roo muốn tìm kiếm trong cơ sở mã cho '{{query}}':",
-		"wantsToSearchWithPath": "Roo muốn tìm kiếm trong cơ sở mã cho '{{query}}' trong '{{path}}':",
-		"didSearch": "Đã tìm thấy {{count}} kết quả cho '{{query}}':"
+		"wantsToSearch": "Roo muốn tìm kiếm trong cơ sở mã cho <code>{{query}}</code>:",
+		"wantsToSearchWithPath": "Roo muốn tìm kiếm trong cơ sở mã cho <code>{{query}}</code> trong <code>{{path}}</code>:",
+		"didSearch": "Đã tìm thấy {{count}} kết quả cho <code>{{query}}</code>:"
 	}
 }

--- a/webview-ui/src/i18n/locales/zh-CN/chat.json
+++ b/webview-ui/src/i18n/locales/zh-CN/chat.json
@@ -262,8 +262,8 @@
 		}
 	},
 	"codebaseSearch": {
-		"wantsToSearch": "Roo 需要搜索代码库: '{{query}}'",
-		"wantsToSearchWithPath": "Roo 需要在 '{{path}}' 中搜索: '{{query}}'",
-		"didSearch": "找到 {{count}} 个结果: '{{query}}'"
+		"wantsToSearch": "Roo 需要搜索代码库: <code>{{query}}</code>",
+		"wantsToSearchWithPath": "Roo 需要在 <code>{{path}}</code> 中搜索: <code>{{query}}</code>",
+		"didSearch": "找到 {{count}} 个结果: <code>{{query}}</code>"
 	}
 }

--- a/webview-ui/src/i18n/locales/zh-TW/chat.json
+++ b/webview-ui/src/i18n/locales/zh-TW/chat.json
@@ -262,8 +262,8 @@
 		}
 	},
 	"codebaseSearch": {
-		"wantsToSearch": "Roo 想要搜尋程式碼庫：「{{query}}」",
-		"wantsToSearchWithPath": "Roo 想要在「{{path}}」中搜尋：「{{query}}」",
-		"didSearch": "找到 {{count}} 個結果：「{{query}}」"
+		"wantsToSearch": "Roo 想要搜尋程式碼庫：<code>{{query}}</code>",
+		"wantsToSearchWithPath": "Roo 想要在 <code>{{path}}</code> 中搜尋：<code>{{query}}</code>",
+		"didSearch": "找到 {{count}} 個結果：<code>{{query}}</code>"
 	}
 }


### PR DESCRIPTION
This fixes partial message handling and tweaks the UI to look more like the other search tool
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances partial message handling in `codebaseSearchTool` and updates UI and i18n for consistency across search tools.
> 
>   - **Behavior**:
>     - `codebaseSearchTool` in `codebaseSearchTool.ts` now handles partial messages by calling `cline.ask()` and returning early.
>     - UI in `ChatRow.tsx` updated to use `Trans` for i18n in search messages.
>   - **Internationalization**:
>     - Updated `chat.json` files in 20 locales to wrap search queries and paths in `<code>` tags for consistency.
>   - **Misc**:
>     - Minor UI tweaks to align with another search tool.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ff25616252e0d769618708606c3fb448e7f6cb8a. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->