### PR TITLE
Fix: Use EMBEDDING_MODEL_PROFILES as default in the state

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1351,10 +1351,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 			historyPreviewCollapsed: historyPreviewCollapsed ?? false,
 			condensingApiConfigId,
 			customCondensingPrompt,
-			codebaseIndexModels: codebaseIndexModels ?? {
-				openai: {},
-				ollama: {},
-			},
+			codebaseIndexModels: codebaseIndexModels ?? EMBEDDING_MODEL_PROFILES,
 			codebaseIndexConfig: codebaseIndexConfig ?? {
 				codebaseIndexEnabled: false,
 				codebaseIndexQdrantUrl: "http://localhost:6333",
@@ -1456,10 +1453,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 			// Explicitly add condensing settings
 			condensingApiConfigId: stateValues.condensingApiConfigId,
 			customCondensingPrompt: stateValues.customCondensingPrompt,
-			codebaseIndexModels: stateValues.codebaseIndexModels ?? {
-				openai: {},
-				ollama: {},
-			},
+			codebaseIndexModels: stateValues.codebaseIndexModels ?? EMBEDDING_MODEL_PROFILES,
 			codebaseIndexConfig: stateValues.codebaseIndexConfig ?? {
 				codebaseIndexEnabled: false,
 				codebaseIndexQdrantUrl: "http://localhost:6333",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces default `codebaseIndexModels` with `EMBEDDING_MODEL_PROFILES` in `ClineProvider`.
> 
>   - **Behavior**:
>     - Default value for `codebaseIndexModels` in `ClineProvider` is now `EMBEDDING_MODEL_PROFILES` instead of an empty object for `openai` and `ollama`.
>     - Affects initialization and state retrieval in `ClineProvider`.
>   - **Misc**:
>     - No other functional changes or new features added.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 53df999345ea2bf46e1c9f0969e7bafb4f974c98. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->