### PR TITLE
Add handling for external settings changes

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -824,6 +824,11 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 					this.contextProxy.setProviderSettings(providerSettings),
 				])
 
+				// Notify CodeIndexManager about the settings change
+				if (this.codeIndexManager) {
+					await this.codeIndexManager.handleExternalSettingsChange()
+				}
+
 				// Change the provider for the current task.
 				// TODO: We should rename `buildApiHandler` for clarity (e.g. `getProviderClient`).
 				const task = this.getCurrentCline()

--- a/src/services/code-index/config-manager.ts
+++ b/src/services/code-index/config-manager.ts
@@ -103,7 +103,6 @@ export class CodeIndexConfigManager {
 	 * Checks if the service is properly configured based on the embedder type.
 	 */
 	public isConfigured(): boolean {
-		console.log("[CodeIndexConfigManager.isConfigured] Entry. EmbedderProvider:", this.embedderProvider)
 
 		if (this.embedderProvider === "openai") {
 			const openAiKey = this.openAiOptions?.openAiNativeApiKey

--- a/src/services/code-index/config-manager.ts
+++ b/src/services/code-index/config-manager.ts
@@ -14,7 +14,7 @@ export class CodeIndexConfigManager {
 	private modelId?: string
 	private openAiOptions?: ApiHandlerOptions
 	private ollamaOptions?: ApiHandlerOptions
-	private qdrantUrl?: string
+	private qdrantUrl?: string = "http://localhost:6333"
 	private qdrantApiKey?: string
 	private searchMinScore?: number
 
@@ -103,11 +103,19 @@ export class CodeIndexConfigManager {
 	 * Checks if the service is properly configured based on the embedder type.
 	 */
 	public isConfigured(): boolean {
+		console.log("[CodeIndexConfigManager.isConfigured] Entry. EmbedderProvider:", this.embedderProvider)
+
 		if (this.embedderProvider === "openai") {
-			return !!(this.openAiOptions?.openAiNativeApiKey && this.qdrantUrl)
+			const openAiKey = this.openAiOptions?.openAiNativeApiKey
+			const qdrantUrl = this.qdrantUrl
+			const isConfigured = !!(openAiKey && qdrantUrl)
+			return isConfigured
 		} else if (this.embedderProvider === "ollama") {
 			// Ollama model ID has a default, so only base URL is strictly required for config
-			return !!(this.ollamaOptions?.ollamaBaseUrl && this.qdrantUrl)
+			const ollamaBaseUrl = this.ollamaOptions?.ollamaBaseUrl
+			const qdrantUrl = this.qdrantUrl
+			const isConfigured = !!(ollamaBaseUrl && qdrantUrl)
+			return isConfigured
 		}
 		return false // Should not happen if embedderProvider is always set correctly
 	}

--- a/src/services/code-index/manager.ts
+++ b/src/services/code-index/manager.ts
@@ -244,4 +244,15 @@ export class CodeIndexManager {
 		this.assertInitialized()
 		return this._searchService!.searchIndex(query, directoryPrefix)
 	}
+
+	/**
+	 * Handles external settings changes by reloading configuration.
+	 * This method should be called when API provider settings are updated
+	 * to ensure the CodeIndexConfigManager picks up the new configuration.
+	 */
+	public async handleExternalSettingsChange(): Promise<void> {
+		if (this._configManager) {
+			await this._configManager.loadConfiguration()
+		}
+	}
 }

--- a/webview-ui/src/components/settings/CodeIndexSettings.tsx
+++ b/webview-ui/src/components/settings/CodeIndexSettings.tsx
@@ -300,7 +300,7 @@ export const CodeIndexSettings: React.FC<CodeIndexSettingsProps> = ({
 						</div>
 						<div>
 							<VSCodeTextField
-								value={codebaseIndexConfig.codebaseIndexQdrantUrl}
+								value={codebaseIndexConfig.codebaseIndexQdrantUrl || "http://localhost:6333"}
 								onInput={(e: any) =>
 									setCachedStateField("codebaseIndexConfig", {
 										...codebaseIndexConfig,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add handling for external settings changes in code indexing, including default `qdrantUrl` and configuration reloads.
> 
>   - **Behavior**:
>     - `ClineProvider.ts`: Notifies `CodeIndexManager` of external settings changes via `handleExternalSettingsChange()`.
>     - `config-manager.ts`: Sets default `qdrantUrl` to `http://localhost:6333`.
>     - `manager.ts`: Adds `handleExternalSettingsChange()` to reload configuration on settings update.
>   - **UI**:
>     - `CodeIndexSettings.tsx`: Sets default `codebaseIndexQdrantUrl` to `http://localhost:6333` if undefined.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5a4faebab8a71e24251da7e401313b0d9fc7b567. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->