### PR TITLE
Fix reasoning budget for Gemini 2.5 Flash on OpenRouter

### DIFF
--- a/.changeset/dry-ducks-report.md
+++ b/.changeset/dry-ducks-report.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix reasoning budget for Gemini 2.5 Flash on OpenRouter

--- a/src/api/providers/fetchers/__tests__/litellm.test.ts
+++ b/src/api/providers/fetchers/__tests__/litellm.test.ts
@@ -1,6 +1,6 @@
 import axios from "axios"
 import { getLiteLLMModels } from "../litellm"
-import { COMPUTER_USE_MODELS } from "../../../../shared/api"
+import { OPEN_ROUTER_COMPUTER_USE_MODELS } from "../../../../shared/api"
 
 // Mock axios
 jest.mock("axios")
@@ -105,7 +105,7 @@ describe("getLiteLLMModels", () => {
 	})
 
 	it("handles computer use models correctly", async () => {
-		const computerUseModel = Array.from(COMPUTER_USE_MODELS)[0]
+		const computerUseModel = Array.from(OPEN_ROUTER_COMPUTER_USE_MODELS)[0]
 		const mockResponse = {
 			data: {
 				data: [

--- a/src/api/providers/fetchers/__tests__/openrouter.spec.ts
+++ b/src/api/providers/fetchers/__tests__/openrouter.spec.ts
@@ -4,7 +4,12 @@ import * as path from "path"
 
 import { back as nockBack } from "nock"
 
-import { PROMPT_CACHING_MODELS } from "../../../../shared/api"
+import {
+	OPEN_ROUTER_PROMPT_CACHING_MODELS,
+	OPEN_ROUTER_COMPUTER_USE_MODELS,
+	OPEN_ROUTER_REASONING_BUDGET_MODELS,
+	OPEN_ROUTER_REQUIRED_REASONING_BUDGET_MODELS,
+} from "../../../../shared/api"
 
 import { getOpenRouterModelEndpoints, getOpenRouterModels } from "../openrouter"
 
@@ -23,22 +28,14 @@ describe("OpenRouter API", () => {
 					.filter(([_, model]) => model.supportsPromptCache)
 					.map(([id, _]) => id)
 					.sort(),
-			).toEqual(Array.from(PROMPT_CACHING_MODELS).sort())
+			).toEqual(Array.from(OPEN_ROUTER_PROMPT_CACHING_MODELS).sort())
 
 			expect(
 				Object.entries(models)
 					.filter(([_, model]) => model.supportsComputerUse)
 					.map(([id, _]) => id)
 					.sort(),
-			).toEqual([
-				"anthropic/claude-3.5-sonnet",
-				"anthropic/claude-3.5-sonnet:beta",
-				"anthropic/claude-3.7-sonnet",
-				"anthropic/claude-3.7-sonnet:beta",
-				"anthropic/claude-3.7-sonnet:thinking",
-				"anthropic/claude-opus-4",
-				"anthropic/claude-sonnet-4",
-			])
+			).toEqual(Array.from(OPEN_ROUTER_COMPUTER_USE_MODELS).sort())
 
 			expect(
 				Object.entries(models)
@@ -108,19 +105,14 @@ describe("OpenRouter API", () => {
 					.filter(([_, model]) => model.supportsReasoningBudget)
 					.map(([id, _]) => id)
 					.sort(),
-			).toEqual([
-				"anthropic/claude-3.7-sonnet:beta",
-				"anthropic/claude-3.7-sonnet:thinking",
-				"anthropic/claude-opus-4",
-				"anthropic/claude-sonnet-4",
-			])
+			).toEqual(Array.from(OPEN_ROUTER_REASONING_BUDGET_MODELS).sort())
 
 			expect(
 				Object.entries(models)
 					.filter(([_, model]) => model.requiredReasoningBudget)
 					.map(([id, _]) => id)
 					.sort(),
-			).toEqual(["anthropic/claude-3.7-sonnet:thinking"])
+			).toEqual(Array.from(OPEN_ROUTER_REQUIRED_REASONING_BUDGET_MODELS).sort())
 
 			expect(models["anthropic/claude-3.7-sonnet"]).toEqual({
 				maxTokens: 8192,
@@ -154,6 +146,8 @@ describe("OpenRouter API", () => {
 				supportsReasoningEffort: true,
 				supportedParameters: ["max_tokens", "temperature", "reasoning", "include_reasoning"],
 			})
+
+			expect(models["google/gemini-2.5-flash-preview-05-20"].maxTokens).toEqual(65535)
 
 			const anthropicModels = Object.entries(models)
 				.filter(([id, _]) => id.startsWith("anthropic/claude-3"))
@@ -200,7 +194,6 @@ describe("OpenRouter API", () => {
 					cacheWritesPrice: 1.625,
 					cacheReadsPrice: 0.31,
 					description: undefined,
-					supportsReasoningBudget: false,
 					supportsReasoningEffort: undefined,
 					supportedParameters: undefined,
 				},
@@ -214,7 +207,6 @@ describe("OpenRouter API", () => {
 					cacheWritesPrice: 1.625,
 					cacheReadsPrice: 0.31,
 					description: undefined,
-					supportsReasoningBudget: false,
 					supportsReasoningEffort: undefined,
 					supportedParameters: undefined,
 				},

--- a/src/api/providers/fetchers/litellm.ts
+++ b/src/api/providers/fetchers/litellm.ts
@@ -1,5 +1,5 @@
 import axios from "axios"
-import { COMPUTER_USE_MODELS, ModelRecord } from "../../../shared/api"
+import { OPEN_ROUTER_COMPUTER_USE_MODELS, ModelRecord } from "../../../shared/api"
 
 /**
  * Fetches available models from a LiteLLM server
@@ -22,7 +22,7 @@ export async function getLiteLLMModels(apiKey: string, baseUrl: string): Promise
 		const response = await axios.get(`${baseUrl}/v1/model/info`, { headers, timeout: 5000 })
 		const models: ModelRecord = {}
 
-		const computerModels = Array.from(COMPUTER_USE_MODELS)
+		const computerModels = Array.from(OPEN_ROUTER_COMPUTER_USE_MODELS)
 
 		// Process the model info from the response
 		if (response.data && response.data.data && Array.isArray(response.data.data)) {

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -6,7 +6,7 @@ import {
 	ModelRecord,
 	openRouterDefaultModelId,
 	openRouterDefaultModelInfo,
-	PROMPT_CACHING_MODELS,
+	OPEN_ROUTER_PROMPT_CACHING_MODELS,
 } from "../../shared/api"
 
 import { convertToOpenAiMessages } from "../transform/openai-format"
@@ -87,7 +87,7 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 
 		// https://openrouter.ai/docs/features/prompt-caching
 		// TODO: Add a `promptCacheStratey` field to `ModelInfo`.
-		if (PROMPT_CACHING_MODELS.has(modelId)) {
+		if (OPEN_ROUTER_PROMPT_CACHING_MODELS.has(modelId)) {
 			if (modelId.startsWith("google")) {
 				addGeminiCacheBreakpoints(systemPrompt, openAiMessages)
 			} else {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1836,7 +1836,7 @@ export const chutesModels = {
  */
 
 // These models support prompt caching.
-export const PROMPT_CACHING_MODELS = new Set([
+export const OPEN_ROUTER_PROMPT_CACHING_MODELS = new Set([
 	"anthropic/claude-3-haiku",
 	"anthropic/claude-3-haiku:beta",
 	"anthropic/claude-3-opus",
@@ -1867,7 +1867,7 @@ export const PROMPT_CACHING_MODELS = new Set([
 ])
 
 // https://www.anthropic.com/news/3-5-models-and-computer-use
-export const COMPUTER_USE_MODELS = new Set([
+export const OPEN_ROUTER_COMPUTER_USE_MODELS = new Set([
 	"anthropic/claude-3.5-sonnet",
 	"anthropic/claude-3.5-sonnet:beta",
 	"anthropic/claude-3.7-sonnet",
@@ -1875,6 +1875,20 @@ export const COMPUTER_USE_MODELS = new Set([
 	"anthropic/claude-3.7-sonnet:thinking",
 	"anthropic/claude-sonnet-4",
 	"anthropic/claude-opus-4",
+])
+
+export const OPEN_ROUTER_REASONING_BUDGET_MODELS = new Set([
+	"anthropic/claude-3.7-sonnet:beta",
+	"anthropic/claude-3.7-sonnet:thinking",
+	"anthropic/claude-opus-4",
+	"anthropic/claude-sonnet-4",
+	"google/gemini-2.5-flash-preview-05-20",
+	"google/gemini-2.5-flash-preview-05-20:thinking",
+])
+
+export const OPEN_ROUTER_REQUIRED_REASONING_BUDGET_MODELS = new Set([
+	"anthropic/claude-3.7-sonnet:thinking",
+	"google/gemini-2.5-flash-preview-05-20:thinking",
 ])
 
 const routerNames = ["openrouter", "requesty", "glama", "unbound", "litellm"] as const

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -458,8 +458,6 @@ const ApiOptions = ({
 				modelInfo={selectedModelInfo}
 			/>
 
-			<pre>{JSON.stringify(selectedModelInfo, null, 2)}</pre>
-
 			{!fromWelcomeView && (
 				<>
 					<DiffSettingsControl

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -458,6 +458,8 @@ const ApiOptions = ({
 				modelInfo={selectedModelInfo}
 			/>
 
+			<pre>{JSON.stringify(selectedModelInfo, null, 2)}</pre>
+
 			{!fromWelcomeView && (
 				<>
 					<DiffSettingsControl

--- a/webview-ui/src/components/settings/constants.ts
+++ b/webview-ui/src/components/settings/constants.ts
@@ -13,8 +13,6 @@ import {
 	chutesModels,
 } from "@roo/shared/api"
 
-export { PROMPT_CACHING_MODELS } from "@roo/shared/api"
-
 export { AWS_REGIONS } from "@roo/shared/aws_regions"
 
 export const MODELS_BY_PROVIDER: Partial<Record<ProviderName, Record<string, ModelInfo>>> = {


### PR DESCRIPTION
### Description

OpenRouter only tells you if a model supports the `reasoning` parameter in the API; it doesn't tell you if the model honors a token budget for thinking. As such we need to continue to maintain a hardcoded list.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes reasoning budget handling for Gemini 2.5 Flash on OpenRouter by updating model constants and processing logic.
> 
>   - **Behavior**:
>     - Fixes reasoning budget handling for `google/gemini-2.5-flash-preview-05-20` in `openrouter.ts` and `litellm.ts`.
>     - Updates `parseOpenRouterModel()` to correctly set `maxTokens` and reasoning budget flags.
>   - **Constants**:
>     - Renames `PROMPT_CACHING_MODELS` to `OPEN_ROUTER_PROMPT_CACHING_MODELS` and `COMPUTER_USE_MODELS` to `OPEN_ROUTER_COMPUTER_USE_MODELS`.
>     - Adds `OPEN_ROUTER_REASONING_BUDGET_MODELS` and `OPEN_ROUTER_REQUIRED_REASONING_BUDGET_MODELS` to `api.ts`.
>   - **Tests**:
>     - Updates tests in `litellm.test.ts` and `openrouter.spec.ts` to reflect new model constants and reasoning budget handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a7cba79d624b6202cbe34a2ed2105fd5b3f94c61. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->