### PR TITLE
v3.18.3

### DIFF
--- a/.changeset/v3.18.3.md
+++ b/.changeset/v3.18.3.md
@@ -1,0 +1,15 @@
+---
+"roo-cline": patch
+---
+
+- Default to Claude Sonnet 4 model
+- Enable prompt caching for Gemini 2.5 Flash Preview (thanks @shariqriazz!)
+- Fix reasoning budget for Gemini 2.5 Flash on OpenRouter
+- Fix o1-pro on OpenRouter
+- Preserve model settings when selecting a specific OpenRouter provider
+- Add ability to refresh LiteLLM models list
+- Improve tool descriptions to guide proper file editing tool selection
+- Fix MCP Server error loading config when running with npx and bunx (thanks @devxpain!)
+- Improve pnpm bootstrapping and add compile script (thanks @KJ7LNW!)
+- Simplify object assignment & use startsWith (thanks @noritaka1166!)
+- Remove deprecated claude-3.7-sonnet models from vscodelm (thanks @shariqriazz!)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update to default Claude Sonnet 4 model, enable prompt caching, fix OpenRouter issues, and improve tool descriptions and configuration handling.
> 
>   - **Models**:
>     - Default to Claude Sonnet 4 model.
>     - Remove deprecated claude-3.7-sonnet models from vscodelm.
>   - **Features**:
>     - Enable prompt caching for Gemini 2.5 Flash Preview.
>     - Add ability to refresh LiteLLM models list.
>   - **Fixes**:
>     - Fix reasoning budget for Gemini 2.5 Flash on OpenRouter.
>     - Fix o1-pro on OpenRouter.
>     - Fix MCP Server error loading config with npx and bunx.
>   - **Improvements**:
>     - Preserve model settings when selecting OpenRouter provider.
>     - Improve tool descriptions for file editing tool selection.
>     - Improve pnpm bootstrapping and add compile script.
>     - Simplify object assignment & use startsWith.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1128d18fe3e95192251e79b67553c08b6295c780. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->