### PR TITLE
fix: resolve Windows 10 F5 debugging issues by removing await from HMR server check

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -575,7 +575,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 
 		// Check if local dev server is running.
 		try {
-			await axios.get(`http://${localServerUrl}`)
+			axios.get(`http://${localServerUrl}`)
 		} catch (error) {
 			vscode.window.showErrorMessage(t("common:errors.hmr_not_running"))
 


### PR DESCRIPTION
## Summary
This PR fixes a Windows 10 specific issue where F5 debugging was being blocked by an unnecessary await in the HMR (Hot Module Replacement) server check.

## Problem
On Windows 10, the F5 debugging workflow was experiencing delays due to an awaited axios call when checking if the local development server was running. This caused unnecessary blocking behavior during the debugging process.

## Solution
Removed the `await` keyword from the `axios.get()` call in the HMR server check, allowing the check to run asynchronously without blocking the debugging workflow.

## Changes Made
- **File Modified**: `src/core/webview/ClineProvider.ts`
- **Change**: Removed `await` from `axios.get(\`http://${localServerUrl}\`)` call
- **Impact**: Non-blocking HMR server check during F5 debugging

## Technical Details

### Before
```typescript
try {
    await axios.get(`http://${localServerUrl}`)
} catch (error) {
    vscode.window.showErrorMessage(t("common:errors.hmr_not_running"))
}
```

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Removes `await` from `axios.get()` in `ClineProvider.ts` to fix F5 debugging delays on Windows 10.
> 
>   - **Behavior**:
>     - Removes `await` from `axios.get()` call in `ClineProvider.ts` to prevent blocking during HMR server check.
>     - Specifically resolves F5 debugging delays on Windows 10.
>   - **Impact**:
>     - Allows non-blocking HMR server check, improving debugging workflow.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1103930c2cb3a894915dc153b345eea0f4c06ef1. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->