### PR TITLE
Pr/githubguy132010/3954

### DIFF
--- a/src/core/config/__tests__/importExport.test.ts
+++ b/src/core/config/__tests__/importExport.test.ts
@@ -227,7 +227,7 @@ describe("importExport", () => {
 
 			expect(result).toEqual({
 				success: false,
-				error: "Expected property name or '}' in JSON at position 2",
+				error: "Expected property name or '}' in JSON at position 2 (line 1 column 3)",
 			})
 			expect(fs.readFile).toHaveBeenCalledWith("/mock/path/settings.json", "utf-8")
 			expect(mockProviderSettingsManager.import).not.toHaveBeenCalled()

--- a/src/core/config/__tests__/importExport.test.ts
+++ b/src/core/config/__tests__/importExport.test.ts
@@ -227,7 +227,7 @@ describe("importExport", () => {
 
 			expect(result).toEqual({
 				success: false,
-				error: "Expected property name or '}' in JSON at position 2 (line 1 column 3)",
+				error: "Expected property name or '}' in JSON at position 2",
 			})
 			expect(fs.readFile).toHaveBeenCalledWith("/mock/path/settings.json", "utf-8")
 			expect(mockProviderSettingsManager.import).not.toHaveBeenCalled()

--- a/src/integrations/terminal/__tests__/ExecaTerminal.spec.ts
+++ b/src/integrations/terminal/__tests__/ExecaTerminal.spec.ts
@@ -22,7 +22,7 @@ describe("ExecaTerminal", () => {
 			onShellExecutionComplete: vi.fn(),
 		}
 
-		const subprocess = terminal.runCommand("ls -al", callbacks)
+		const subprocess = terminal.runCommand("LANG=C ls -al", callbacks)
 		await subprocess
 
 		expect(callbacks.onLine).toHaveBeenCalled()

--- a/webview-ui/eslint.config.mjs
+++ b/webview-ui/eslint.config.mjs
@@ -18,6 +18,15 @@ export default [
 			"@typescript-eslint/no-explicit-any": "off",
 			"react/prop-types": "off",
 			"react/display-name": "off",
+			"@typescript-eslint/no-unused-expressions": [
+				"error",
+				{
+					"allowShortCircuit": true,
+					"allowTernary": true,
+					"allowTaggedTemplates": true,
+					"enforceForJSX": false
+				}
+			],
 		},
 	},
 	{

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -3,7 +3,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"lint": "eslint src --ext=ts,tsx --max-warnings=0",
+		"lint": "eslint src --max-warnings=0",
 		"check-types": "tsc",
 		"test": "jest -w=40%",
 		"format": "prettier --write src",

--- a/webview-ui/src/components/chat/AutoApproveMenu.tsx
+++ b/webview-ui/src/components/chat/AutoApproveMenu.tsx
@@ -134,7 +134,7 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 					display: "flex",
 					alignItems: "center",
 					gap: "8px",
-					padding: isExpanded ? "8px 0" : "8px 0 0 0",
+					padding: "8px 0 0 0", // Ensure consistent padding for the toggle header
 					cursor: "pointer",
 				}}
 				onClick={toggleExpanded}>
@@ -207,8 +207,8 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 							display: "flex",
 							alignItems: "center",
 							gap: "8px",
-							marginTop: "10px",
-							marginBottom: "8px",
+							// marginTop: "10px", // Removed to use parent's gap for spacing
+							// marginBottom: "8px", // Removed to use parent's gap for spacing
 							color: "var(--vscode-descriptionForeground)",
 						}}>
 						<span style={{ flexShrink: 1, minWidth: 0 }}>


### PR DESCRIPTION
Fix tests
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes tests by setting locale in `ExecaTerminal.spec.ts` and updates ESLint rules and UI styles.
> 
>   - **Tests**:
>     - In `ExecaTerminal.spec.ts`, added `LANG=C` to `runCommand` to ensure consistent locale output.
>   - **Linting**:
>     - Updated ESLint rule `@typescript-eslint/no-unused-expressions` in `eslint.config.mjs` to allow short circuit, ternary, and tagged templates.
>     - Removed `--ext=ts,tsx` from `lint` script in `package.json`.
>   - **UI**:
>     - In `AutoApproveMenu.tsx`, adjusted padding and removed margin styles for consistent spacing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3c01788a4ec7c22aac709e2ae4ef1d166f50a39d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->