### PR TITLE
bugfix: Update PAGER env for Windows compatibility in Terminal

### DIFF
--- a/src/integrations/terminal/Terminal.ts
+++ b/src/integrations/terminal/Terminal.ts
@@ -152,7 +152,7 @@ export class Terminal extends BaseTerminal {
 
 	public static getEnv(): Record<string, string> {
 		const env: Record<string, string> = {
-			PAGER: "cat",
+			PAGER: process.platform === "win32" ? "" : "cat",
 
 			// VTE must be disabled because it prevents the prompt command from executing
 			// See https://wiki.gnome.org/Apps/Terminal/VTE

--- a/src/integrations/terminal/__tests__/TerminalRegistry.test.ts
+++ b/src/integrations/terminal/__tests__/TerminalRegistry.test.ts
@@ -3,6 +3,8 @@
 import { Terminal } from "../Terminal"
 import { TerminalRegistry } from "../TerminalRegistry"
 
+const PAGER = process.platform === "win32" ? "" : "cat"
+
 // Mock vscode.window.createTerminal
 const mockCreateTerminal = jest.fn()
 
@@ -29,7 +31,7 @@ describe("TerminalRegistry", () => {
 	})
 
 	describe("createTerminal", () => {
-		it("creates terminal with PAGER set to cat", () => {
+		it("creates terminal with PAGER set appropriately for platform", () => {
 			TerminalRegistry.createTerminal("/test/path", "vscode")
 
 			expect(mockCreateTerminal).toHaveBeenCalledWith({
@@ -37,7 +39,7 @@ describe("TerminalRegistry", () => {
 				name: "Roo Code",
 				iconPath: expect.any(Object),
 				env: {
-					PAGER: "cat",
+					PAGER,
 					VTE_VERSION: "0",
 					PROMPT_EOL_MARK: "",
 				},
@@ -57,7 +59,7 @@ describe("TerminalRegistry", () => {
 					name: "Roo Code",
 					iconPath: expect.any(Object),
 					env: {
-						PAGER: "cat",
+						PAGER,
 						PROMPT_COMMAND: "sleep 0.05",
 						VTE_VERSION: "0",
 						PROMPT_EOL_MARK: "",
@@ -79,7 +81,7 @@ describe("TerminalRegistry", () => {
 					name: "Roo Code",
 					iconPath: expect.any(Object),
 					env: {
-						PAGER: "cat",
+						PAGER,
 						VTE_VERSION: "0",
 						PROMPT_EOL_MARK: "",
 						ITERM_SHELL_INTEGRATION_INSTALLED: "Yes",
@@ -100,7 +102,7 @@ describe("TerminalRegistry", () => {
 					name: "Roo Code",
 					iconPath: expect.any(Object),
 					env: {
-						PAGER: "cat",
+						PAGER,
 						VTE_VERSION: "0",
 						PROMPT_EOL_MARK: "",
 						POWERLEVEL9K_TERM_SHELL_INTEGRATION: "true",


### PR DESCRIPTION
Fixes 
```console
PS C:\Users\smart\Desktop\GD\Roo-Code> aws sts get-caller-identity

'cat' is not recognized as an internal or external command,
operable program or batch file.
```
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes Windows compatibility by conditionally setting `PAGER` environment variable in `Terminal.ts` and updating tests accordingly.
> 
>   - **Behavior**:
>     - Update `PAGER` in `Terminal.ts` to be empty on Windows (`process.platform === "win32"`) and "cat" otherwise.
>     - Fixes issue where `cat` command was not recognized on Windows.
>   - **Tests**:
>     - Update `TerminalRegistry.test.ts` to use a platform-specific `PAGER` value in tests.
>     - Modify test descriptions to reflect platform-specific behavior for `PAGER`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 88f64b5fd56582ac79ea6d7c4f690c765a83d01d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->