### PR TITLE
fix: Correct path resolution for .vite-port file in ClineProvider

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -557,7 +557,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 		try {
 			const fs = require("fs")
 			const path = require("path")
-			const portFilePath = path.resolve(__dirname, "../.vite-port")
+			const portFilePath = path.resolve(__dirname, "../../.vite-port")
 
 			if (fs.existsSync(portFilePath)) {
 				localPort = fs.readFileSync(portFilePath, "utf8").trim()


### PR DESCRIPTION
## Context

This PR fixes the issue where ClineProvider was looking for the .vite-port file in the wrong location, causing it to always fall back to the default port.

When multiple development servers are launched in different repositories, each Vite server uses a different port:



Without correctly reading the .vite-port file, the application cannot connect to the right Vite server instance.

## Implementation

Updated the path resolution in ClineProvider.ts to correctly point to the project root where the Vite development server creates the .vite-port file.

## How to Test

1. Start multiple development servers in different repositories
2. Verify that the console no longer shows the error message about the port file not being found
3. Verify that the application connects to the correct Vite server using the port specified in the .vite-port file

Fixes #4006