### PR TITLE
fix: ensure types are built before launching extension

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
 	"tasks": [
 		{
 			"label": "watch",
-			"dependsOn": ["webview", "watch:tsc", "watch:esbuild"],
+			"dependsOn": ["webview", "watch:tsc", "watch:esbuild", "watch:roo-code-types"],
 			"presentation": {
 				"reveal": "never"
 			},
@@ -64,6 +64,28 @@
 			"command": "pnpm --filter roo-cline watch:tsc",
 			"group": "build",
 			"problemMatcher": "$tsc-watch",
+			"isBackground": true,
+			"presentation": {
+				"group": "watch",
+				"reveal": "always"
+			}
+		},
+		{
+			"label": "watch:roo-code-types",
+			"type": "shell",
+			"command": "pnpm --filter @roo-code/types watch",
+			"group": "build",
+			"problemMatcher": {
+				"owner": "tsup",
+				"pattern": {
+					"regexp": "^$"
+				},
+				"background": {
+					"activeOnStart": true,
+					"beginsPattern": ".*Build start.*",
+					"endsPattern": ".*Build success.*|.*Build failed.*"
+				}
+			},
 			"isBackground": true,
 			"presentation": {
 				"group": "watch",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -22,6 +22,7 @@
 		"check-types": "tsc --noEmit",
 		"test": "vitest --globals --run",
 		"build": "tsup",
+		"watch": "tsup --watch",
 		"clean": "rimraf dist .turbo"
 	},
 	"dependencies": {


### PR DESCRIPTION
## Context

When doing a fresh clone and running the extension with F5, it currently fails because the types package is not built before the watchers start. This causes errors when trying to import from packages that depend on the built types.

## Implementation

This PR adds a new task called `build:roo-code-types` that builds the types package once. The `watch` task is then updated to depend on this build task, ensuring the types are properly built before any watchers start.

The solution is minimal and ensures proper initialization sequence when launching the extension.

## How to Test

1. Clone the repository fresh: 
```sh
git clone https://github.com/RooVetGit/Roo-Cline.git
```
2. Change directory: 
```sh
cd Roo-Cline
```
3. Install dependencies: 
```sh
pnpm install
```
4. Press F5 in VS Code to launch the extension - it should now work properly without errors

Fixes #4011