### PR TITLE
Add `dependsOn` for watch:esbuild script

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
 	"tasks": [
 		{
 			"label": "watch",
-			"dependsOn": ["webview", "watch:tsc", "watch:esbuild"],
+			"dependsOn": ["watch:webview", "watch:bundle", "watch:tsc"],
 			"presentation": {
 				"reveal": "never"
 			},
@@ -15,7 +15,7 @@
 			}
 		},
 		{
-			"label": "webview",
+			"label": "watch:webview",
 			"type": "shell",
 			"command": "pnpm --filter @roo-code/vscode-webview dev",
 			"group": "build",
@@ -37,9 +37,9 @@
 			}
 		},
 		{
-			"label": "watch:esbuild",
+			"label": "watch:bundle",
 			"type": "shell",
-			"command": "pnpm --filter roo-cline watch:esbuild",
+			"command": "npx turbo watch:bundle",
 			"group": "build",
 			"problemMatcher": {
 				"owner": "esbuild",
@@ -61,7 +61,7 @@
 		{
 			"label": "watch:tsc",
 			"type": "shell",
-			"command": "pnpm --filter roo-cline watch:tsc",
+			"command": "npx turbo watch:tsc",
 			"group": "build",
 			"problemMatcher": "$tsc-watch",
 			"isBackground": true,

--- a/src/package.json
+++ b/src/package.json
@@ -327,7 +327,7 @@
 		"vscode:prepublish": "pnpm bundle --production",
 		"vsix": "mkdirp ../bin && npx vsce package --no-dependencies --out ../bin",
 		"publish:marketplace": "vsce publish --no-dependencies && ovsx publish --no-dependencies",
-		"watch:esbuild": "pnpm bundle --watch",
+		"watch:bundle": "pnpm bundle --watch",
 		"watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
 		"clean": "rimraf README.md CHANGELOG.md LICENSE dist webview-ui out mock .turbo"
 	},

--- a/turbo.json
+++ b/turbo.json
@@ -30,6 +30,13 @@
 		"vsix:nightly": {
 			"dependsOn": ["bundle:nightly", "@roo-code/vscode-webview#build:nightly"],
 			"cache": false
+		},
+		"watch:bundle": {
+			"dependsOn": ["@roo-code/build#build", "@roo-code/types#build"],
+			"cache": false
+		},
+		"watch:tsc": {
+			"cache": false
 		}
 	}
 }


### PR DESCRIPTION
### Related GitHub Issue

Closes: #4011

### Description

The `watch:esbuild` task has dependencies that we need to specify in turborepo. Thanks for catching this @KJ7LNW!
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Rename `watch:esbuild` to `watch:bundle` and add dependencies in `turbo.json` for correct task execution.
> 
>   - **Scripts**:
>     - Rename `watch:esbuild` to `watch:bundle` in `package.json`.
>   - **Configuration**:
>     - Add `dependsOn` for `watch:bundle` task in `turbo.json` to include `@roo-code/build#build` and `@roo-code/types#build`.
>     - Ensure `watch:bundle` task does not use cache in `turbo.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7f56e2ffa1167dd1946acaca78e39444632736c2. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->