### PR TITLE
Fix the build_extension step of the evals setup script

### DIFF
--- a/evals/scripts/setup.sh
+++ b/evals/scripts/setup.sh
@@ -28,7 +28,7 @@ build_extension() {
   echo "🔨 Building the Roo Code extension..."
   cd ..
   mkdir -p bin
-  pnpm build --out ../bin/roo-code-$(git rev-parse --short HEAD).vsix || exit 1
+  pnpm build -- --out ../bin/roo-code-$(git rev-parse --short HEAD).vsix || exit 1
   code --install-extension bin/roo-code-$(git rev-parse --short HEAD).vsix || exit 1
   cd evals
 }


### PR DESCRIPTION
### Description

Regression from the monorepo switch.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `pnpm build` command syntax in `build_extension()` in `setup.sh` by adding missing `--` before `--out` argument.
> 
>   - **Fix**:
>     - Corrects `pnpm build` command syntax in `build_extension()` in `setup.sh` by adding missing `--` before `--out` argument.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 632152509fa3dd9d465ef0320ffa01f0e8f172e8. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->