### PR TITLE
Fix order of message events

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -396,7 +396,7 @@ export class Task extends EventEmitter<ClineEvents> {
 					// data or one whole message at a time so ignore partial for
 					// saves, and only post parts of partial message instead of
 					// whole array in new listener.
-					this.updateClineMessage(lastMessage)
+					await this.updateClineMessage(lastMessage)
 					throw new Error("Current ask promise was ignored (#1)")
 				} else {
 					// This is a new partial message, so add it with partial
@@ -431,7 +431,7 @@ export class Task extends EventEmitter<ClineEvents> {
 					lastMessage.partial = false
 					lastMessage.progressStatus = progressStatus
 					await this.saveClineMessages()
-					this.updateClineMessage(lastMessage)
+					await this.updateClineMessage(lastMessage)
 				} else {
 					// This is a new and complete message, so add it like normal.
 					this.askResponse = undefined
@@ -570,7 +570,7 @@ export class Task extends EventEmitter<ClineEvents> {
 					lastMessage.images = images
 					lastMessage.partial = partial
 					lastMessage.progressStatus = progressStatus
-					this.updateClineMessage(lastMessage)
+					await this.updateClineMessage(lastMessage)
 				} else {
 					// This is a new partial message, so add it with partial state.
 					const sayTs = Date.now()
@@ -608,7 +608,7 @@ export class Task extends EventEmitter<ClineEvents> {
 					await this.saveClineMessages()
 
 					// More performant than an entire `postStateToWebview`.
-					this.updateClineMessage(lastMessage)
+					await this.updateClineMessage(lastMessage)
 				} else {
 					// This is a new and complete message, so add it like normal.
 					const sayTs = Date.now()


### PR DESCRIPTION
### Related GitHub Issue

Closes: #4034

### Description

Both `Task.addToClineMessages` and `Task.updateClineMessage` are async functions.
However, when `addToClineMessages` is called, it is awaited,
and when `updateClineMessage` is called, it is not awaited.

This can result in reordering the execution of these functions,
and thus reordering the `this.emit("message", ...)` calls (and also messages sent to webview probably).

The solution is to await on `updateClineMessage`. It should not introduce much performance penalty, as it only sends message to webview and emits an event (`addToClineMessages` does much more and it is awaited).

### Test Procedure

Subscribe to `message` event, run a task and watch the order of message events.
The procedure must be run multiple times — not always the events are emitted in wrong order.

However, probably as the change is very small and obvious, it does not need additional testing.

### Type of Change

<!-- Mark all applicable boxes with an 'x'. -->

- [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [ ] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [ ] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [ ] There are no new linting errors or warnings (`npm run lint`)¹.
    - [x] All debug code (e.g., `console.log`) has been removed.
- [x] **Testing**:
    - [x] New and/or updated tests have been added to cover my changes.
    - [x] All tests pass locally (`npm test`).
    - [x] The application builds successfully with my changes.
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [ ] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.²
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

¹ Getting `Invalid option '--ext' - perhaps you meant '-c'?` from eslint.
² Getting `Missing script: changeset`

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->

### Documentation Updates

Does this PR necessitate updates to user-facing documentation?
- [x] No documentation updates are required.
- [ ] Yes, documentation updates are required.

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->

### Get in Touch

Discord handle: wkordalski