### PR TITLE
Improve zh-TW Traditional Chinese locale

### DIFF
--- a/src/package.nls.zh-TW.json
+++ b/src/package.nls.zh-TW.json
@@ -5,11 +5,11 @@
 	"command.explainCode.title": "解釋程式碼",
 	"command.fixCode.title": "修復程式碼",
 	"command.improveCode.title": "改進程式碼",
-	"command.addToContext.title": "添加到上下文",
+	"command.addToContext.title": "新增到上下文",
 	"command.openInNewTab.title": "在新分頁中開啟",
 	"command.focusInput.title": "聚焦輸入框",
 	"command.setCustomStoragePath.title": "設定自訂儲存路徑",
-	"command.terminal.addToContext.title": "將終端內容添加到上下文",
+	"command.terminal.addToContext.title": "將終端內容新增到上下文",
 	"command.terminal.fixCommand.title": "修復此命令",
 	"command.terminal.explainCommand.title": "解釋此命令",
 	"command.acceptInput.title": "接受輸入/建議",
@@ -25,7 +25,7 @@
 	"configuration.title": "Roo Code",
 	"commands.allowedCommands.description": "當啟用'始終批准執行操作'時可以自動執行的命令",
 	"settings.vsCodeLmModelSelector.description": "VSCode 語言模型 API 的設定",
-	"settings.vsCodeLmModelSelector.vendor.description": "語言模型的供應商（例如：copilot）",
-	"settings.vsCodeLmModelSelector.family.description": "語言模型的系列（例如：gpt-4）",
+	"settings.vsCodeLmModelSelector.vendor.description": "語言模型供應商（例如：copilot）",
+	"settings.vsCodeLmModelSelector.family.description": "語言模型系列（例如：gpt-4）",
 	"settings.customStoragePath.description": "自訂儲存路徑。留空以使用預設位置。支援絕對路徑（例如：'D:\\RooCodeStorage'）"
 }


### PR DESCRIPTION
Hello Roo Team! We received this contribution on the Kilo side and thought it might be useful to you!

These changes were originally submitted by a (presumably) native speaker of the language: https://github.com/Kilo-Org/kilocode/pull/516
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improve Traditional Chinese locale by refining translations in `package.nls.zh-TW.json`.
> 
>   - **Locale Improvements**:
>     - Change "添加到上下文" to "新增到上下文" in `command.addToContext.title` and `command.terminal.addToContext.title`.
>     - Remove redundant characters in `settings.vsCodeLmModelSelector.vendor.description` and `settings.vsCodeLmModelSelector.family.description`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for afe6a87ed685ea49f6cea0a8ac6813677b93714b. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->