### PR TITLE
Fix Posthog by correctly copying .env in the build process

### DIFF
--- a/src/esbuild.mjs
+++ b/src/esbuild.mjs
@@ -52,6 +52,7 @@ async function main() {
 							["../README.md", "README.md"],
 							["../CHANGELOG.md", "CHANGELOG.md"],
 							["../LICENSE", "LICENSE"],
+							["../.env", ".env"],
 							["node_modules/vscode-material-icons/generated", "assets/vscode-material-icons"],
 							["../webview-ui/audio", "webview-ui/audio"],
 						],


### PR DESCRIPTION
### Description

I also noticed that the CI action that validates the package doesn't seem to be working:
<img width="824" alt="Screenshot 2025-05-27 at 9 26 36 AM" src="https://github.com/user-attachments/assets/db710a5e-c86e-4474-8d57-aaadc1d0c3d6" />
