### PR TITLE
Added a hardcoded list of computer use models for litellm as a fallba…

### DIFF
--- a/src/api/providers/fetchers/__tests__/litellm.test.ts
+++ b/src/api/providers/fetchers/__tests__/litellm.test.ts
@@ -248,4 +248,203 @@ describe("getLiteLLMModels", () => {
 
 		expect(result).toEqual({})
 	})
+
+	it("uses fallback computer use detection when supports_computer_use is not available", async () => {
+		const mockResponse = {
+			data: {
+				data: [
+					{
+						model_name: "claude-3-5-sonnet-latest",
+						model_info: {
+							max_tokens: 4096,
+							max_input_tokens: 200000,
+							supports_vision: true,
+							supports_prompt_caching: false,
+							// Note: no supports_computer_use field
+						},
+						litellm_params: {
+							model: "anthropic/claude-3-5-sonnet-latest", // This should match the fallback list
+						},
+					},
+					{
+						model_name: "gpt-4-turbo",
+						model_info: {
+							max_tokens: 8192,
+							max_input_tokens: 128000,
+							supports_vision: false,
+							supports_prompt_caching: false,
+							// Note: no supports_computer_use field
+						},
+						litellm_params: {
+							model: "openai/gpt-4-turbo", // This should NOT match the fallback list
+						},
+					},
+				],
+			},
+		}
+
+		mockedAxios.get.mockResolvedValue(mockResponse)
+
+		const result = await getLiteLLMModels("test-api-key", "http://localhost:4000")
+
+		expect(result["claude-3-5-sonnet-latest"]).toEqual({
+			maxTokens: 4096,
+			contextWindow: 200000,
+			supportsImages: true,
+			supportsComputerUse: true, // Should be true due to fallback
+			supportsPromptCache: false,
+			inputPrice: undefined,
+			outputPrice: undefined,
+			description: "claude-3-5-sonnet-latest via LiteLLM proxy",
+		})
+
+		expect(result["gpt-4-turbo"]).toEqual({
+			maxTokens: 8192,
+			contextWindow: 128000,
+			supportsImages: false,
+			supportsComputerUse: false, // Should be false as it's not in fallback list
+			supportsPromptCache: false,
+			inputPrice: undefined,
+			outputPrice: undefined,
+			description: "gpt-4-turbo via LiteLLM proxy",
+		})
+	})
+
+	it("prioritizes explicit supports_computer_use over fallback detection", async () => {
+		const mockResponse = {
+			data: {
+				data: [
+					{
+						model_name: "claude-3-5-sonnet-latest",
+						model_info: {
+							max_tokens: 4096,
+							max_input_tokens: 200000,
+							supports_vision: true,
+							supports_prompt_caching: false,
+							supports_computer_use: false, // Explicitly set to false
+						},
+						litellm_params: {
+							model: "anthropic/claude-3-5-sonnet-latest", // This matches fallback list but should be ignored
+						},
+					},
+					{
+						model_name: "custom-model",
+						model_info: {
+							max_tokens: 8192,
+							max_input_tokens: 128000,
+							supports_vision: false,
+							supports_prompt_caching: false,
+							supports_computer_use: true, // Explicitly set to true
+						},
+						litellm_params: {
+							model: "custom/custom-model", // This would NOT match fallback list
+						},
+					},
+					{
+						model_name: "another-custom-model",
+						model_info: {
+							max_tokens: 8192,
+							max_input_tokens: 128000,
+							supports_vision: false,
+							supports_prompt_caching: false,
+							supports_computer_use: false, // Explicitly set to false
+						},
+						litellm_params: {
+							model: "custom/another-custom-model", // This would NOT match fallback list
+						},
+					},
+				],
+			},
+		}
+
+		mockedAxios.get.mockResolvedValue(mockResponse)
+
+		const result = await getLiteLLMModels("test-api-key", "http://localhost:4000")
+
+		expect(result["claude-3-5-sonnet-latest"]).toEqual({
+			maxTokens: 4096,
+			contextWindow: 200000,
+			supportsImages: true,
+			supportsComputerUse: false, // False because explicitly set to false (fallback ignored)
+			supportsPromptCache: false,
+			inputPrice: undefined,
+			outputPrice: undefined,
+			description: "claude-3-5-sonnet-latest via LiteLLM proxy",
+		})
+
+		expect(result["custom-model"]).toEqual({
+			maxTokens: 8192,
+			contextWindow: 128000,
+			supportsImages: false,
+			supportsComputerUse: true, // True because explicitly set to true
+			supportsPromptCache: false,
+			inputPrice: undefined,
+			outputPrice: undefined,
+			description: "custom-model via LiteLLM proxy",
+		})
+
+		expect(result["another-custom-model"]).toEqual({
+			maxTokens: 8192,
+			contextWindow: 128000,
+			supportsImages: false,
+			supportsComputerUse: false, // False because explicitly set to false
+			supportsPromptCache: false,
+			inputPrice: undefined,
+			outputPrice: undefined,
+			description: "another-custom-model via LiteLLM proxy",
+		})
+	})
+
+	it("handles fallback detection with various model name formats", async () => {
+		const mockResponse = {
+			data: {
+				data: [
+					{
+						model_name: "vertex-claude",
+						model_info: {
+							max_tokens: 4096,
+							max_input_tokens: 200000,
+							supports_vision: true,
+							supports_prompt_caching: false,
+						},
+						litellm_params: {
+							model: "vertex_ai/claude-3-5-sonnet", // Should match fallback list
+						},
+					},
+					{
+						model_name: "openrouter-claude",
+						model_info: {
+							max_tokens: 4096,
+							max_input_tokens: 200000,
+							supports_vision: true,
+							supports_prompt_caching: false,
+						},
+						litellm_params: {
+							model: "openrouter/anthropic/claude-3.5-sonnet", // Should match fallback list
+						},
+					},
+					{
+						model_name: "bedrock-claude",
+						model_info: {
+							max_tokens: 4096,
+							max_input_tokens: 200000,
+							supports_vision: true,
+							supports_prompt_caching: false,
+						},
+						litellm_params: {
+							model: "anthropic.claude-3-5-sonnet-20241022-v2:0", // Should match fallback list
+						},
+					},
+				],
+			},
+		}
+
+		mockedAxios.get.mockResolvedValue(mockResponse)
+
+		const result = await getLiteLLMModels("test-api-key", "http://localhost:4000")
+
+		expect(result["vertex-claude"].supportsComputerUse).toBe(true)
+		expect(result["openrouter-claude"].supportsComputerUse).toBe(true)
+		expect(result["bedrock-claude"].supportsComputerUse).toBe(true)
+	})
 })

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1260,6 +1260,39 @@ export const litellmDefaultModelInfo: ModelInfo = {
 	cacheWritesPrice: 3.75,
 	cacheReadsPrice: 0.3,
 }
+
+export const LITELLM_COMPUTER_USE_MODELS = new Set([
+	"claude-3-5-sonnet-latest",
+	"claude-opus-4-20250514",
+	"claude-sonnet-4-20250514",
+	"claude-3-7-sonnet-latest",
+	"claude-3-7-sonnet-20250219",
+	"claude-3-5-sonnet-20241022",
+	"vertex_ai/claude-3-5-sonnet",
+	"vertex_ai/claude-3-5-sonnet-v2",
+	"vertex_ai/claude-3-5-sonnet-v2@20241022",
+	"vertex_ai/claude-3-7-sonnet@20250219",
+	"vertex_ai/claude-opus-4@20250514",
+	"vertex_ai/claude-sonnet-4@20250514",
+	"openrouter/anthropic/claude-3.5-sonnet",
+	"openrouter/anthropic/claude-3.5-sonnet:beta",
+	"openrouter/anthropic/claude-3.7-sonnet",
+	"openrouter/anthropic/claude-3.7-sonnet:beta",
+	"anthropic.claude-opus-4-20250514-v1:0",
+	"anthropic.claude-sonnet-4-20250514-v1:0",
+	"anthropic.claude-3-7-sonnet-20250219-v1:0",
+	"anthropic.claude-3-5-sonnet-20241022-v2:0",
+	"us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+	"us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+	"us.anthropic.claude-opus-4-20250514-v1:0",
+	"us.anthropic.claude-sonnet-4-20250514-v1:0",
+	"eu.anthropic.claude-3-5-sonnet-20241022-v2:0",
+	"eu.anthropic.claude-3-7-sonnet-20250219-v1:0",
+	"eu.anthropic.claude-opus-4-20250514-v1:0",
+	"eu.anthropic.claude-sonnet-4-20250514-v1:0",
+	"snowflake/claude-3-5-sonnet",
+])
+
 // xAI
 // https://docs.x.ai/docs/api-reference
 export type XAIModelId = keyof typeof xaiModels


### PR DESCRIPTION
### Description

This adds a hardcoded list of litellm computer use models as a fallback for users still on an older litellm verison before supports_computer_use was added to the v1/model/info endpoint

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a hardcoded fallback list for computer use models in LiteLLM to handle older versions lacking `supports_computer_use`.
> 
>   - **Behavior**:
>     - Adds a hardcoded list `LITELLM_COMPUTER_USE_MODELS` in `api.ts` for fallback in older LiteLLM versions.
>     - Updates `getLiteLLMModels` in `litellm.ts` to use fallback list when `supports_computer_use` is missing.
>     - Prioritizes explicit `supports_computer_use` over fallback.
>   - **Tests**:
>     - Adds tests in `litellm.test.ts` for fallback detection and prioritization of explicit `supports_computer_use`.
>     - Tests various model name formats for fallback detection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 870b0a06421e50fe938787c8d4638f3d09a76cc6. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->