### PR TITLE
Improve the prompt for the "modes" e2e test

### DIFF
--- a/.changeset/fine-eels-find.md
+++ b/.changeset/fine-eels-find.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Improve the prompt for the "modes" e2e test

--- a/apps/vscode-e2e/src/suite/modes.test.ts
+++ b/apps/vscode-e2e/src/suite/modes.test.ts
@@ -1,40 +1,24 @@
 import * as assert from "assert"
 
-import type { ClineMessage } from "@roo-code/types"
-
 import { waitUntilCompleted } from "./utils"
 
 suite("Roo Code Modes", () => {
 	test("Should handle switching modes correctly", async () => {
-		const api = globalThis.api
+		const modes: string[] = []
 
-		const switchModesPrompt =
-			"For each mode (Architect, Ask, Debug) respond with the mode name and what it specializes in after switching to that mode."
+		globalThis.api.on("taskModeSwitched", (_taskId, mode) => modes.push(mode))
 
-		const messages: ClineMessage[] = []
-		const modeSwitches: string[] = []
-
-		api.on("taskModeSwitched", (_taskId, mode) => {
-			console.log("taskModeSwitched", mode)
-			modeSwitches.push(mode)
-		})
-
-		api.on("message", ({ message }) => {
-			if (message.type === "say" && message.partial === false) {
-				messages.push(message)
-			}
-		})
-
-		const switchModesTaskId = await api.startNewTask({
+		const switchModesTaskId = await globalThis.api.startNewTask({
 			configuration: { mode: "code", alwaysAllowModeSwitch: true, autoApprovalEnabled: true },
-			text: switchModesPrompt,
+			text: "For each of `architect`, `ask`, and `debug` use the `switch_mode` tool to switch to that mode.",
 		})
 
-		await waitUntilCompleted({ api, taskId: switchModesTaskId })
-		await api.cancelCurrentTask()
+		await waitUntilCompleted({ api: globalThis.api, taskId: switchModesTaskId })
+		await globalThis.api.cancelCurrentTask()
 
-		assert.ok(modeSwitches.includes("architect"))
-		assert.ok(modeSwitches.includes("ask"))
-		assert.ok(modeSwitches.includes("debug"))
+		assert.ok(modes.includes("architect"))
+		assert.ok(modes.includes("ask"))
+		assert.ok(modes.includes("debug"))
+		assert.ok(modes.length === 3)
 	})
 })


### PR DESCRIPTION
### Description

This test seems to flake a lot, but this prompt seems a bit more stable.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves stability of "modes" e2e test by updating the prompt and simplifying test logic in `modes.test.ts`.
> 
>   - **Test Stability**:
>     - Update prompt in `modes.test.ts` to "For each of `architect`, `ask`, and `debug` use the `switch_mode` tool to switch to that mode."
>     - Simplifies test logic by removing unused variables and listeners.
>   - **Assertions**:
>     - Verifies `modes` array includes "architect", "ask", "debug" and has length 3.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3c4f355b404988cdac56ecdaf7082a7ad7d14032. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->