### PR TITLE
Try adding a version to @roo-code/types

### DIFF
--- a/.changeset/puny-beans-join.md
+++ b/.changeset/puny-beans-join.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Add version to @roo-code/types

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@roo-code/types",
 	"description": "Roo Code foundational types and schemas.",
-	"private": true,
+	"version": "0.0.0",
 	"type": "module",
 	"main": "./dist/index.cjs",
 	"exports": {


### PR DESCRIPTION
### Description

I was only able to get `npx changeset version` to work if `@roo-code/types` has a version.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add version `0.0.0` to `@roo-code/types` in `package.json` to enable `npx changeset version`.
> 
>   - **Versioning**:
>     - Adds `"version": "0.0.0"` to `package.json` of `@roo-code/types`.
>   - **Changeset**:
>     - Creates `.changeset/puny-beans-join.md` to document the version addition as a patch for `roo-cline`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1714a32849aa9d53ee014f3e1ed646726052e88f. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->