### PR TITLE
Publish @roo-code/types to npm

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,16 +1,35 @@
 {
 	"name": "@roo-code/types",
-	"description": "Roo Code foundational types and schemas.",
-	"version": "0.0.0",
-	"type": "module",
+	"version": "1.15.0",
+	"description": "TypeScript type definitions for Roo Code.",
+	"publishConfig": {
+		"access": "public"
+	},
+	"author": "Roo Code Team",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/RooCodeInc/Roo-Code.git"
+	},
+	"bugs": {
+		"url": "https://github.com/RooCodeInc/Roo-Code/issues"
+	},
+	"homepage": "https://github.com/RooCodeInc/Roo-Code/tree/main/packages/types",
+	"keywords": [
+		"roo",
+		"roo-code",
+		"ai"
+	],
 	"main": "./dist/index.cjs",
+	"module": "./dist/index.mjs",
+	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
-			"types": "./src/index.ts",
-			"import": "./src/index.ts",
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.mjs",
 			"require": {
-				"types": "./dist/index.d.cts",
-				"default": "./dist/index.cjs"
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.js"
 			}
 		}
 	},
@@ -22,6 +41,9 @@
 		"check-types": "tsc --noEmit",
 		"test": "vitest --globals --run",
 		"build": "tsup",
+		"prepublishOnly": "pnpm run build",
+		"publish:test": "pnpm publish --dry-run",
+		"publish": "pnpm publish",
 		"clean": "rimraf dist .turbo"
 	},
 	"dependencies": {


### PR DESCRIPTION
### Description

Now that we have a monorepo we can publish the `@roo-code/types` workspace to NPM. I delete the `Roo-Code-Types` repository.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prepare `@roo-code/types` package for NPM publishing by updating `package.json` with version, metadata, scripts, and dependencies.
> 
>   - **NPM Publishing**:
>     - Set `version` to `1.15.0` in `package.json`.
>     - Added `publishConfig` with `access: public`.
>     - Added `prepublishOnly`, `publish:test`, and `publish` scripts for build and publish processes.
>   - **Metadata**:
>     - Updated `description`, `author`, `license`, `repository`, `bugs`, `homepage`, and `keywords` fields in `package.json`.
>   - **Exports and Entry Points**:
>     - Updated `main`, `module`, `types`, and `exports` fields to point to `dist` directory.
>   - **Dependencies**:
>     - Added `zod` as a dependency.
>     - Updated `devDependencies` with `@roo-code/config-eslint`, `@roo-code/config-typescript`, `@types/node`, `tsup`, and `vitest`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 51f876dad8b011133d0ae43cf8644e31adce7800. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->