### PR TITLE
@directory not respecting .rooIgnore Fix

### DIFF
--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -17,6 +17,8 @@ import { UrlContentFetcher } from "../../services/browser/UrlContentFetcher"
 
 import { FileContextTracker } from "../context-tracking/FileContextTracker"
 
+import { RooIgnoreController } from "../ignore/RooIgnoreController"
+
 export async function openMention(mention?: string): Promise<void> {
 	if (!mention) {
 		return

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -50,6 +50,8 @@ export async function parseMentions(
 	cwd: string,
 	urlContentFetcher: UrlContentFetcher,
 	fileContextTracker?: FileContextTracker,
+	rooIgnoreController?: any,
+	showRooIgnoredFiles: boolean = true,
 ): Promise<string> {
 	const mentions: Set<string> = new Set()
 	let parsedText = text.replace(mentionRegexGlobal, (match, mention) => {
@@ -102,12 +104,11 @@ export async function parseMentions(
 		} else if (mention.startsWith("/")) {
 			const mentionPath = mention.slice(1)
 			try {
-				const content = await getFileOrFolderContent(mentionPath, cwd)
+				const content = await getFileOrFolderContent(mentionPath, cwd, rooIgnoreController, showRooIgnoredFiles)
 				if (mention.endsWith("/")) {
 					parsedText += `\n\n<folder_content path="${mentionPath}">\n${content}\n</folder_content>`
 				} else {
 					parsedText += `\n\n<file_content path="${mentionPath}">\n${content}\n</file_content>`
-					// Track that this file was mentioned and its content was included
 					if (fileContextTracker) {
 						await fileContextTracker.trackFileContext(mentionPath, "file_mentioned")
 					}
@@ -161,8 +162,12 @@ export async function parseMentions(
 	return parsedText
 }
 
-async function getFileOrFolderContent(mentionPath: string, cwd: string): Promise<string> {
-	// Unescape spaces in the path before resolving it
+async function getFileOrFolderContent(
+	mentionPath: string,
+	cwd: string,
+	rooIgnoreController?: any,
+	showRooIgnoredFiles: boolean = true,
+): Promise<string> {
 	const unescapedPath = unescapeSpaces(mentionPath)
 	const absPath = path.resolve(cwd, unescapedPath)
 
@@ -170,6 +175,9 @@ async function getFileOrFolderContent(mentionPath: string, cwd: string): Promise
 		const stats = await fs.stat(absPath)
 
 		if (stats.isFile()) {
+			if (rooIgnoreController && !rooIgnoreController.validateAccess(absPath)) {
+				return `(File ${mentionPath} is ignored by .rooignore)`
+			}
 			try {
 				const content = await extractTextFromFile(absPath)
 				return content
@@ -180,33 +188,51 @@ async function getFileOrFolderContent(mentionPath: string, cwd: string): Promise
 			const entries = await fs.readdir(absPath, { withFileTypes: true })
 			let folderContent = ""
 			const fileContentPromises: Promise<string | undefined>[] = []
-			entries.forEach((entry, index) => {
+			const LOCK_SYMBOL = "🔒"
+
+			for (let index = 0; index < entries.length; index++) {
+				const entry = entries[index]
 				const isLast = index === entries.length - 1
 				const linePrefix = isLast ? "└── " : "├── "
+				const entryPath = path.join(absPath, entry.name)
+
+				let isIgnored = false
+				if (rooIgnoreController) {
+					isIgnored = !rooIgnoreController.validateAccess(entryPath)
+				}
+
+				if (isIgnored && !showRooIgnoredFiles) {
+					continue
+				}
+
+				const displayName = isIgnored ? `${LOCK_SYMBOL} ${entry.name}` : entry.name
+
 				if (entry.isFile()) {
-					folderContent += `${linePrefix}${entry.name}\n`
-					const filePath = path.join(mentionPath, entry.name)
-					const absoluteFilePath = path.resolve(absPath, entry.name)
-					fileContentPromises.push(
-						(async () => {
-							try {
-								const isBinary = await isBinaryFile(absoluteFilePath).catch(() => false)
-								if (isBinary) {
+					folderContent += `${linePrefix}${displayName}\n`
+					if (!isIgnored) {
+						const filePath = path.join(mentionPath, entry.name)
+						const absoluteFilePath = path.resolve(absPath, entry.name)
+						fileContentPromises.push(
+							(async () => {
+								try {
+									const isBinary = await isBinaryFile(absoluteFilePath).catch(() => false)
+									if (isBinary) {
+										return undefined
+									}
+									const content = await extractTextFromFile(absoluteFilePath)
+									return `<file_content path="${filePath.toPosix()}">\n${content}\n</file_content>`
+								} catch (error) {
 									return undefined
 								}
-								const content = await extractTextFromFile(absoluteFilePath)
-								return `<file_content path="${filePath.toPosix()}">\n${content}\n</file_content>`
-							} catch (error) {
-								return undefined
-							}
-						})(),
-					)
+							})(),
+						)
+					}
 				} else if (entry.isDirectory()) {
-					folderContent += `${linePrefix}${entry.name}/\n`
+					folderContent += `${linePrefix}${displayName}/\n`
 				} else {
-					folderContent += `${linePrefix}${entry.name}\n`
+					folderContent += `${linePrefix}${displayName}\n`
 				}
-			})
+			}
 			const fileContents = (await Promise.all(fileContentPromises)).filter((content) => content)
 			return `${folderContent}\n${fileContents.join("\n\n")}`.trim()
 		} else {

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -50,7 +50,7 @@ export async function parseMentions(
 	cwd: string,
 	urlContentFetcher: UrlContentFetcher,
 	fileContextTracker?: FileContextTracker,
-	rooIgnoreController?: any,
+	rooIgnoreController?: RooIgnoreController,
 	showRooIgnoredFiles: boolean = true,
 ): Promise<string> {
 	const mentions: Set<string> = new Set()

--- a/src/core/mentions/processUserContentMentions.ts
+++ b/src/core/mentions/processUserContentMentions.ts
@@ -11,11 +11,15 @@ export async function processUserContentMentions({
 	cwd,
 	urlContentFetcher,
 	fileContextTracker,
+	rooIgnoreController,
+	showRooIgnoredFiles = true,
 }: {
 	userContent: Anthropic.Messages.ContentBlockParam[]
 	cwd: string
 	urlContentFetcher: UrlContentFetcher
 	fileContextTracker: FileContextTracker
+	rooIgnoreController?: any
+	showRooIgnoredFiles?: boolean
 }) {
 	// Process userContent array, which contains various block types:
 	// TextBlockParam, ImageBlockParam, ToolUseBlockParam, and ToolResultBlockParam.
@@ -35,7 +39,14 @@ export async function processUserContentMentions({
 				if (shouldProcessMentions(block.text)) {
 					return {
 						...block,
-						text: await parseMentions(block.text, cwd, urlContentFetcher, fileContextTracker),
+						text: await parseMentions(
+							block.text,
+							cwd,
+							urlContentFetcher,
+							fileContextTracker,
+							rooIgnoreController,
+							showRooIgnoredFiles,
+						),
 					}
 				}
 
@@ -45,7 +56,14 @@ export async function processUserContentMentions({
 					if (shouldProcessMentions(block.content)) {
 						return {
 							...block,
-							content: await parseMentions(block.content, cwd, urlContentFetcher, fileContextTracker),
+							content: await parseMentions(
+								block.content,
+								cwd,
+								urlContentFetcher,
+								fileContextTracker,
+								rooIgnoreController,
+								showRooIgnoredFiles,
+							),
 						}
 					}
 
@@ -61,6 +79,8 @@ export async function processUserContentMentions({
 										cwd,
 										urlContentFetcher,
 										fileContextTracker,
+										rooIgnoreController,
+										showRooIgnoredFiles,
 									),
 								}
 							}

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1096,11 +1096,15 @@ export class Task extends EventEmitter<ClineEvents> {
 			}),
 		)
 
+		const { showRooIgnoredFiles = true } = (await this.providerRef.deref()?.getState()) ?? {}
+
 		const parsedUserContent = await processUserContentMentions({
 			userContent,
 			cwd: this.cwd,
 			urlContentFetcher: this.urlContentFetcher,
 			fileContextTracker: this.fileContextTracker,
+			rooIgnoreController: this.rooIgnoreController,
+			showRooIgnoredFiles,
 		})
 
 		const environmentDetails = await getEnvironmentDetails(this, includeFileDetails)


### PR DESCRIPTION

### Related GitHub Issue
Closes: #3598

### Description
Fixed @directory attachments to respect .rooignore files by integrating RooIgnoreController into the mentions processing pipeline

### Test Procedure
See linked issue.

### Type of Change
- [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.

### Additional Notes
Will be creating a pr to docs shortly


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `@directory` mentions to respect `.rooignore` files by integrating `RooIgnoreController` into the mentions processing pipeline.
> 
>   - **Behavior**:
>     - `@directory` mentions now respect `.rooignore` files by integrating `RooIgnoreController` into the mentions processing pipeline in `index.ts`.
>     - Adds `rooIgnoreController` and `showRooIgnoredFiles` parameters to `parseMentions()` and `getFileOrFolderContent()` in `index.ts`.
>     - Updates `processUserContentMentions()` in `processUserContentMentions.ts` to handle `rooIgnoreController` and `showRooIgnoredFiles`.
>   - **Task Class**:
>     - Updates `Task` class in `Task.ts` to pass `rooIgnoreController` and `showRooIgnoredFiles` to `processUserContentMentions()`.
>   - **Misc**:
>     - Adds handling for ignored files in directory listings, marking them with a lock symbol if `showRooIgnoredFiles` is true.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 48857824dbbff4450f109608f8d0734b5632c69b. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->