### PR TITLE
Custom LLM API timeout instead of default 10 minutes for self-hosted LLMs

### DIFF
--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -123,7 +123,7 @@ const openAiSchema = baseProviderSettingsSchema.extend({
 	openAiStreamingEnabled: z.boolean().optional(),
 	openAiHostHeader: z.string().optional(), // Keep temporarily for backward compatibility during migration.
 	openAiHeaders: z.record(z.string(), z.string()).optional(),
-	openAiApiTimeout: z.number().optional().describe("Timeout in milliseconds for OpenAI API requests"),
+	openAiApiTimeout: z.number().optional(),
 })
 
 const ollamaSchema = baseProviderSettingsSchema.extend({

--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -129,7 +129,7 @@ const openAiSchema = baseProviderSettingsSchema.extend({
 const ollamaSchema = baseProviderSettingsSchema.extend({
 	ollamaModelId: z.string().optional(),
 	ollamaBaseUrl: z.string().optional(),
-	ollamaApiTimeout: z.number().optional().describe("Timeout in minutes for Ollama API requests"),
+	ollamaApiTimeout: z.number().optional(),
 })
 
 const vsCodeLmSchema = baseProviderSettingsSchema.extend({

--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -123,11 +123,13 @@ const openAiSchema = baseProviderSettingsSchema.extend({
 	openAiStreamingEnabled: z.boolean().optional(),
 	openAiHostHeader: z.string().optional(), // Keep temporarily for backward compatibility during migration.
 	openAiHeaders: z.record(z.string(), z.string()).optional(),
+	openAiApiTimeout: z.number().optional().describe("Timeout in milliseconds for OpenAI API requests"),
 })
 
 const ollamaSchema = baseProviderSettingsSchema.extend({
 	ollamaModelId: z.string().optional(),
 	ollamaBaseUrl: z.string().optional(),
+	ollamaApiTimeout: z.number().optional().describe("Timeout in minutes for Ollama API requests"),
 })
 
 const vsCodeLmSchema = baseProviderSettingsSchema.extend({
@@ -146,6 +148,7 @@ const lmStudioSchema = baseProviderSettingsSchema.extend({
 	lmStudioBaseUrl: z.string().optional(),
 	lmStudioDraftModelId: z.string().optional(),
 	lmStudioSpeculativeDecodingEnabled: z.boolean().optional(),
+	lmStudioApiTimeout: z.number().optional().describe("Timeout in minutes for LMStudio API requests"),
 })
 
 const geminiSchema = apiModelIdProviderModelSchema.extend({
@@ -265,9 +268,12 @@ export const MODEL_ID_KEYS: Partial<keyof ProviderSettings>[] = [
 	"glamaModelId",
 	"openRouterModelId",
 	"openAiModelId",
+	"openAiApiTimeout",
 	"ollamaModelId",
+	"ollamaApiTimeout",
 	"lmStudioModelId",
 	"lmStudioDraftModelId",
+	"lmStudioApiTimeout",
 	"unboundModelId",
 	"requestyModelId",
 	"litellmModelId",

--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -148,7 +148,7 @@ const lmStudioSchema = baseProviderSettingsSchema.extend({
 	lmStudioBaseUrl: z.string().optional(),
 	lmStudioDraftModelId: z.string().optional(),
 	lmStudioSpeculativeDecodingEnabled: z.boolean().optional(),
-	lmStudioApiTimeout: z.number().optional().describe("Timeout in minutes for LMStudio API requests"),
+	lmStudioApiTimeout: z.number().optional(),
 })
 
 const geminiSchema = apiModelIdProviderModelSchema.extend({

--- a/src/api/providers/__tests__/openai.spec.ts
+++ b/src/api/providers/__tests__/openai.spec.ts
@@ -101,6 +101,7 @@ describe("OpenAiHandler", () => {
 			expect(vi.mocked(OpenAI)).toHaveBeenCalledWith({
 				baseURL: expect.any(String),
 				apiKey: expect.any(String),
+				timeout: expect.any(Number),
 				defaultHeaders: {
 					"HTTP-Referer": "https://github.com/RooVetGit/Roo-Cline",
 					"X-Title": "Roo Code",

--- a/src/api/providers/lm-studio.ts
+++ b/src/api/providers/lm-studio.ts
@@ -21,9 +21,11 @@ export class LmStudioHandler extends BaseProvider implements SingleCompletionHan
 	constructor(options: ApiHandlerOptions) {
 		super()
 		this.options = options
+		const timeoutMs = (this.options.lmStudioApiTimeout ?? 10) * 60 * 1000
 		this.client = new OpenAI({
 			baseURL: (this.options.lmStudioBaseUrl || "http://localhost:1234") + "/v1",
 			apiKey: "noop",
+			timeout: timeoutMs,
 		})
 	}
 

--- a/src/api/providers/ollama.ts
+++ b/src/api/providers/ollama.ts
@@ -24,9 +24,11 @@ export class OllamaHandler extends BaseProvider implements SingleCompletionHandl
 	constructor(options: ApiHandlerOptions) {
 		super()
 		this.options = options
+		const timeoutMs = (this.options.ollamaApiTimeout ?? 10) * 60 * 1000
 		this.client = new OpenAI({
 			baseURL: (this.options.ollamaBaseUrl || "http://localhost:11434") + "/v1",
 			apiKey: "ollama",
+			timeout: timeoutMs,
 		})
 	}
 

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -40,6 +40,7 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 		const isAzureAiInference = this._isAzureAiInference(this.options.openAiBaseUrl)
 		const urlHost = this._getUrlHost(this.options.openAiBaseUrl)
 		const isAzureOpenAi = urlHost === "azure.com" || urlHost.endsWith(".azure.com") || options.openAiUseAzure
+		const timeoutMs = (this.options.openAiApiTimeout ?? 10) * 60 * 1000 // Timeout is provided in minutes, convert to ms
 
 		const headers = {
 			...DEFAULT_HEADERS,
@@ -52,6 +53,7 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 				baseURL,
 				apiKey,
 				defaultHeaders: headers,
+				timeout: timeoutMs,
 				defaultQuery: { "api-version": this.options.azureApiVersion || "2024-05-01-preview" },
 			})
 		} else if (isAzureOpenAi) {
@@ -62,12 +64,14 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 				apiKey,
 				apiVersion: this.options.azureApiVersion || azureOpenAiDefaultApiVersion,
 				defaultHeaders: headers,
+				timeout: timeoutMs,
 			})
 		} else {
 			this.client = new OpenAI({
 				baseURL,
 				apiKey,
 				defaultHeaders: headers,
+				timeout: timeoutMs,
 			})
 		}
 	}

--- a/webview-ui/src/components/settings/providers/LMStudio.tsx
+++ b/webview-ui/src/components/settings/providers/LMStudio.tsx
@@ -72,7 +72,7 @@ export const LMStudio = ({ apiConfiguration, setApiConfigurationField }: LMStudi
 				})}
 				type="text"
 				inputMode="numeric"
-				placeholder={t("settings:placeholders.numbers.maxTokens")}
+				placeholder="10"
 				style={{
 					borderColor: (() => {
 						const value = apiConfiguration?.lmStudioApiTimeout

--- a/webview-ui/src/components/settings/providers/LMStudio.tsx
+++ b/webview-ui/src/components/settings/providers/LMStudio.tsx
@@ -64,6 +64,28 @@ export const LMStudio = ({ apiConfiguration, setApiConfigurationField }: LMStudi
 				className="w-full">
 				<label className="block font-medium mb-1">{t("settings:providers.lmStudio.modelId")}</label>
 			</VSCodeTextField>
+			<VSCodeTextField
+				value={apiConfiguration?.lmStudioApiTimeout?.toString() || "10"}
+				onInput={handleInputChange("lmStudioApiTimeout", (e) => {
+					const value = parseInt((e.target as HTMLInputElement).value)
+					return isNaN(value) ? undefined : value
+				})}
+				type="text"
+				inputMode="numeric"
+				placeholder={t("settings:placeholders.numbers.maxTokens")}
+				style={{
+					borderColor: (() => {
+						const value = apiConfiguration?.lmStudioApiTimeout
+						if (!value) return "var(--vscode-input-border)"
+						return value > 0 ? "var(--vscode-charts-green)" : "var(--vscode-errorForeground)"
+					})(),
+				}}
+				className="w-full mt-4">
+				<label className="block font-medium mb-1">{t("settings:providers.openAiApiTimeout")}</label>
+			</VSCodeTextField>
+			<div className="text-sm text-vscode-descriptionForeground -mt-2 mb-2">
+				{t("settings:providers.openAiApiTimeoutDescription")}
+			</div>
 			{lmStudioModels.length > 0 && (
 				<VSCodeRadioGroup
 					value={

--- a/webview-ui/src/components/settings/providers/Ollama.tsx
+++ b/webview-ui/src/components/settings/providers/Ollama.tsx
@@ -63,6 +63,28 @@ export const Ollama = ({ apiConfiguration, setApiConfigurationField }: OllamaPro
 				className="w-full">
 				<label className="block font-medium mb-1">{t("settings:providers.ollama.modelId")}</label>
 			</VSCodeTextField>
+			<VSCodeTextField
+				value={apiConfiguration?.ollamaApiTimeout?.toString() || "10"}
+				onInput={handleInputChange("ollamaApiTimeout", (e) => {
+					const value = parseInt((e.target as HTMLInputElement).value)
+					return isNaN(value) ? undefined : value
+				})}
+				type="text"
+				inputMode="numeric"
+				placeholder={t("settings:placeholders.numbers.maxTokens")}
+				style={{
+					borderColor: (() => {
+						const value = apiConfiguration?.ollamaApiTimeout
+						if (!value) return "var(--vscode-input-border)"
+						return value > 0 ? "var(--vscode-charts-green)" : "var(--vscode-errorForeground)"
+					})(),
+				}}
+				className="w-full mt-4">
+				<label className="block font-medium mb-1">{t("settings:providers.openAiApiTimeout")}</label>
+			</VSCodeTextField>
+			<div className="text-sm text-vscode-descriptionForeground -mt-2 mb-2">
+				{t("settings:providers.openAiApiTimeoutDescription")}
+			</div>
 			{ollamaModels.length > 0 && (
 				<VSCodeRadioGroup
 					value={

--- a/webview-ui/src/components/settings/providers/Ollama.tsx
+++ b/webview-ui/src/components/settings/providers/Ollama.tsx
@@ -71,7 +71,7 @@ export const Ollama = ({ apiConfiguration, setApiConfigurationField }: OllamaPro
 				})}
 				type="text"
 				inputMode="numeric"
-				placeholder={t("settings:placeholders.numbers.maxTokens")}
+				placeholder="10"
 				style={{
 					borderColor: (() => {
 						const value = apiConfiguration?.ollamaApiTimeout

--- a/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
+++ b/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
@@ -624,7 +624,7 @@ export const OpenAICompatible = ({
 				})}
 				type="text"
 				inputMode="numeric"
-				placeholder={t("settings:placeholders.numbers.maxTokens")}
+				placeholder="10"
 				style={{
 					borderColor: (() => {
 						const value = apiConfiguration?.openAiApiTimeout

--- a/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
+++ b/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
@@ -616,6 +616,28 @@ export const OpenAICompatible = ({
 					{t("settings:providers.customModel.resetDefaults")}
 				</Button>
 			</div>
+			<VSCodeTextField
+				value={apiConfiguration?.openAiApiTimeout?.toString() || "10"}
+				onInput={handleInputChange("openAiApiTimeout", (e) => {
+					const value = parseInt((e.target as HTMLInputElement).value)
+					return isNaN(value) ? undefined : value
+				})}
+				type="text"
+				inputMode="numeric"
+				placeholder={t("settings:placeholders.numbers.maxTokens")}
+				style={{
+					borderColor: (() => {
+						const value = apiConfiguration?.openAiApiTimeout
+						if (!value) return "var(--vscode-input-border)"
+						return value > 0 ? "var(--vscode-charts-green)" : "var(--vscode-errorForeground)"
+					})(),
+				}}
+				className="w-full mt-4">
+				<label className="block font-medium mb-1">{t("settings:providers.openAiApiTimeout")}</label>
+			</VSCodeTextField>
+			<div className="text-sm text-vscode-descriptionForeground -mt-2">
+				{t("settings:providers.openAiApiTimeoutDescription")}
+			</div>
 		</>
 	)
 }

--- a/webview-ui/src/i18n/locales/ca/settings.json
+++ b/webview-ui/src/i18n/locales/ca/settings.json
@@ -184,6 +184,8 @@
 		"apiKey": "Clau API",
 		"openAiBaseUrl": "URL base",
 		"getOpenAiApiKey": "Obtenir clau API d'OpenAI",
+		"openAiApiTimeout": "Temps d'espera (minuts)",
+		"openAiApiTimeoutDescription": "Temps d'espera per a sol·licituds d'API al proveïdor (mín. 5 min). Si no hi ha resposta en aquest període, la sol·licitud es reintenta. Augmenta el valor per a models més lents.",
 		"mistralApiKey": "Clau API de Mistral",
 		"getMistralApiKey": "Obtenir clau API de Mistral / Codestral",
 		"codestralBaseUrl": "URL base de Codestral (opcional)",

--- a/webview-ui/src/i18n/locales/de/settings.json
+++ b/webview-ui/src/i18n/locales/de/settings.json
@@ -184,6 +184,8 @@
 		"apiKey": "API-Schlüssel",
 		"openAiBaseUrl": "Basis-URL",
 		"getOpenAiApiKey": "OpenAI API-Schlüssel erhalten",
+		"openAiApiTimeout": "Zeitlimit (Minuten)",
+		"openAiApiTimeoutDescription": "Zeitlimit für API-Anfragen an den Anbieter (mind. 5 Min.). Wenn innerhalb dieses Zeitraums keine Antwort erfolgt, wird die Anfrage wiederholt. Erhöhen Sie den Wert für langsamere Modelle.",
 		"mistralApiKey": "Mistral API-Schlüssel",
 		"getMistralApiKey": "Mistral / Codestral API-Schlüssel erhalten",
 		"codestralBaseUrl": "Codestral Basis-URL (Optional)",

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -183,6 +183,8 @@
 		"openAiApiKey": "OpenAI API Key",
 		"apiKey": "API Key",
 		"openAiBaseUrl": "Base URL",
+		"openAiApiTimeout": "Timeout (minutes)",
+		"openAiApiTimeoutDescription": "Timeout for API requests to Provider (min 5 min). if no response within this period, the request is retried. Increase for slower models.",
 		"getOpenAiApiKey": "Get OpenAI API Key",
 		"mistralApiKey": "Mistral API Key",
 		"getMistralApiKey": "Get Mistral / Codestral API Key",

--- a/webview-ui/src/i18n/locales/es/settings.json
+++ b/webview-ui/src/i18n/locales/es/settings.json
@@ -183,6 +183,8 @@
 		"openAiApiKey": "Clave API de OpenAI",
 		"apiKey": "Clave API",
 		"openAiBaseUrl": "URL base",
+		"openAiApiTimeout": "Tiempo de espera (minutos)",
+		"openAiApiTimeoutDescription": "Tiempo de espera para solicitudes de API al proveedor (mín. 5 min). Si no hay respuesta en este período, la solicitud se reintentará. Aumente este valor para modelos más lentos.",
 		"getOpenAiApiKey": "Obtener clave API de OpenAI",
 		"mistralApiKey": "Clave API de Mistral",
 		"getMistralApiKey": "Obtener clave API de Mistral / Codestral",

--- a/webview-ui/src/i18n/locales/fr/settings.json
+++ b/webview-ui/src/i18n/locales/fr/settings.json
@@ -183,6 +183,8 @@
 		"openAiApiKey": "Clé API OpenAI",
 		"apiKey": "Clé API",
 		"openAiBaseUrl": "URL de base",
+		"openAiApiTimeout": "Délai d'attente (minutes)",
+		"openAiApiTimeoutDescription": "Délai d'attente pour les requêtes API au fournisseur (min. 5 min). Si aucune réponse dans ce délai, la requête sera réessayée. Augmentez cette valeur pour les modèles plus lents.",
 		"getOpenAiApiKey": "Obtenir la clé API OpenAI",
 		"mistralApiKey": "Clé API Mistral",
 		"getMistralApiKey": "Obtenir la clé API Mistral / Codestral",

--- a/webview-ui/src/i18n/locales/hi/settings.json
+++ b/webview-ui/src/i18n/locales/hi/settings.json
@@ -184,7 +184,7 @@
 		"apiKey": "API कुंजी",
 		"openAiBaseUrl": "बेस URL",
 		"openAiApiTimeout": "Timeout (मिनट)",
-		"openAiApiTimeoutDescription": "Timeout for API requests to Provider (min 5 min). if no response within this period, the request is retried. Increase for slower models.",
+		"openAiApiTimeoutDescription": "प्रदाता को API अनुरोधों के लिए समय सीमा (न्यूनतम 5 मिनट)। यदि इस अवधि के भीतर कोई प्रतिक्रिया नहीं मिलती है, तो अनुरोध को फिर से भेजा जाता है। धीमे मॉडल के लिए समय सीमा बढ़ाएं।",
 		"getOpenAiApiKey": "OpenAI API कुंजी प्राप्त करें",
 		"mistralApiKey": "Mistral API कुंजी",
 		"getMistralApiKey": "Mistral / Codestral API कुंजी प्राप्त करें",

--- a/webview-ui/src/i18n/locales/hi/settings.json
+++ b/webview-ui/src/i18n/locales/hi/settings.json
@@ -183,6 +183,8 @@
 		"openAiApiKey": "OpenAI API कुंजी",
 		"apiKey": "API कुंजी",
 		"openAiBaseUrl": "बेस URL",
+		"openAiApiTimeout": "Timeout (मिनट)",
+		"openAiApiTimeoutDescription": "Timeout for API requests to Provider (min 5 min). if no response within this period, the request is retried. Increase for slower models.",
 		"getOpenAiApiKey": "OpenAI API कुंजी प्राप्त करें",
 		"mistralApiKey": "Mistral API कुंजी",
 		"getMistralApiKey": "Mistral / Codestral API कुंजी प्राप्त करें",

--- a/webview-ui/src/i18n/locales/id/settings.json
+++ b/webview-ui/src/i18n/locales/id/settings.json
@@ -187,6 +187,8 @@
 		"openAiApiKey": "OpenAI API Key",
 		"apiKey": "API Key",
 		"openAiBaseUrl": "Base URL",
+		"openAiApiTimeout": "Batas waktu (menit)",
+		"openAiApiTimeoutDescription": "Batas waktu untuk permintaan API ke Provider (minimal 5 menit). Jika tidak ada respons dalam periode ini, permintaan akan dicoba lagi. Tingkatkan untuk model yang lebih lambat.",
 		"getOpenAiApiKey": "Dapatkan OpenAI API Key",
 		"mistralApiKey": "Mistral API Key",
 		"getMistralApiKey": "Dapatkan Mistral / Codestral API Key",

--- a/webview-ui/src/i18n/locales/it/settings.json
+++ b/webview-ui/src/i18n/locales/it/settings.json
@@ -183,6 +183,8 @@
 		"openAiApiKey": "Chiave API OpenAI",
 		"apiKey": "Chiave API",
 		"openAiBaseUrl": "URL base",
+		"openAiApiTimeout": "Timeout (minuti)",
+		"openAiApiTimeoutDescription": "Timeout per le richieste API al provider (min. 5 min). Se non c'è risposta entro questo periodo, la richiesta viene ripetuta. Aumentare per modelli più lenti.",
 		"getOpenAiApiKey": "Ottieni chiave API OpenAI",
 		"mistralApiKey": "Chiave API Mistral",
 		"getMistralApiKey": "Ottieni chiave API Mistral / Codestral",

--- a/webview-ui/src/i18n/locales/ja/settings.json
+++ b/webview-ui/src/i18n/locales/ja/settings.json
@@ -184,6 +184,8 @@
 		"apiKey": "APIキー",
 		"openAiBaseUrl": "ベースURL",
 		"getOpenAiApiKey": "OpenAI APIキーを取得",
+		"openAiApiTimeout": "タイムアウト（分）",
+		"openAiApiTimeoutDescription": "プロバイダーへのAPIリクエストのタイムアウト（最小5分）。この期間内に応答がない場合、リクエストが再試行されます。遅いモデルの場合は値を増やしてください。",
 		"mistralApiKey": "Mistral APIキー",
 		"getMistralApiKey": "Mistral / Codestral APIキーを取得",
 		"codestralBaseUrl": "Codestral ベースURL（オプション）",

--- a/webview-ui/src/i18n/locales/ko/settings.json
+++ b/webview-ui/src/i18n/locales/ko/settings.json
@@ -184,6 +184,8 @@
 		"openAiApiKey": "OpenAI API 키",
 		"openAiBaseUrl": "기본 URL",
 		"getOpenAiApiKey": "OpenAI API 키 받기",
+		"openAiApiTimeout": "타임아웃(분)",
+		"openAiApiTimeoutDescription": "제공자에 대한 API 요청의 타임아웃(최소 5분). 이 기간 내에 응답이 없으면 요청이 재시도됩니다. 느린 모델의 경우 값을 늘리세요.",
 		"mistralApiKey": "Mistral API 키",
 		"getMistralApiKey": "Mistral / Codestral API 키 받기",
 		"codestralBaseUrl": "Codestral 기본 URL (선택사항)",

--- a/webview-ui/src/i18n/locales/nl/settings.json
+++ b/webview-ui/src/i18n/locales/nl/settings.json
@@ -183,6 +183,8 @@
 		"apiKey": "API-sleutel",
 		"openAiApiKey": "OpenAI API-sleutel",
 		"openAiBaseUrl": "Basis-URL",
+		"openAiApiTimeout": "Timeout (minuten)",
+		"openAiApiTimeoutDescription": "Timeout voor API-verzoeken aan de provider (min. 5 min). Als er binnen deze periode geen antwoord is, wordt het verzoek opnieuw geprobeerd. Verhoog deze waarde voor tragere modellen.",
 		"getOpenAiApiKey": "OpenAI API-sleutel ophalen",
 		"mistralApiKey": "Mistral API-sleutel",
 		"getMistralApiKey": "Mistral / Codestral API-sleutel ophalen",

--- a/webview-ui/src/i18n/locales/pl/settings.json
+++ b/webview-ui/src/i18n/locales/pl/settings.json
@@ -184,6 +184,8 @@
 		"openAiApiKey": "Klucz API OpenAI",
 		"openAiBaseUrl": "URL bazowy",
 		"getOpenAiApiKey": "Uzyskaj klucz API OpenAI",
+		"openAiApiTimeout": "Limit czasu (minuty)",
+		"openAiApiTimeoutDescription": "Limit czasu dla zapytań API do dostawcy (min. 5 min). Jeśli w tym czasie nie ma odpowiedzi, zapytanie jest ponawiane. Zwiększ dla wolniejszych modeli.",
 		"mistralApiKey": "Klucz API Mistral",
 		"getMistralApiKey": "Uzyskaj klucz API Mistral / Codestral",
 		"codestralBaseUrl": "URL bazowy Codestral (opcjonalnie)",

--- a/webview-ui/src/i18n/locales/pt-BR/settings.json
+++ b/webview-ui/src/i18n/locales/pt-BR/settings.json
@@ -183,6 +183,8 @@
 		"apiKey": "Chave de API",
 		"openAiApiKey": "Chave de API OpenAI",
 		"openAiBaseUrl": "URL Base",
+		"openAiApiTimeout": "Tempo limite (minutos)",
+		"openAiApiTimeoutDescription": "Tempo limite para solicitações de API ao provedor (mín. 5 min). Se não houver resposta neste período, a solicitação será repetida. Aumente este valor para modelos mais lentos.",
 		"getOpenAiApiKey": "Obter chave de API OpenAI",
 		"mistralApiKey": "Chave de API Mistral",
 		"getMistralApiKey": "Obter chave de API Mistral / Codestral",

--- a/webview-ui/src/i18n/locales/ru/settings.json
+++ b/webview-ui/src/i18n/locales/ru/settings.json
@@ -183,6 +183,8 @@
 		"apiKey": "API-ключ",
 		"openAiApiKey": "OpenAI API-ключ",
 		"openAiBaseUrl": "Базовый URL",
+		"openAiApiTimeout": "Таймаут (минуты)",
+		"openAiApiTimeoutDescription": "Таймаут для запросов к провайдеру API (минимум 5 мин). Если нет ответа за это время, запрос будет повторён. Увеличьте значение для медленных моделей.",
 		"getOpenAiApiKey": "Получить OpenAI API-ключ",
 		"mistralApiKey": "Mistral API-ключ",
 		"getMistralApiKey": "Получить Mistral / Codestral API-ключ",

--- a/webview-ui/src/i18n/locales/tr/settings.json
+++ b/webview-ui/src/i18n/locales/tr/settings.json
@@ -183,6 +183,8 @@
 		"openAiApiKey": "OpenAI API Anahtarı",
 		"apiKey": "API Anahtarı",
 		"openAiBaseUrl": "Temel URL",
+		"openAiApiTimeout": "Zaman aşımı (dakika)",
+		"openAiApiTimeoutDescription": "Sağlayıcıya yapılan API istekleri için zaman aşımı (min. 5 dk). Bu süre içinde yanıt yoksa, istek yeniden denenir. Daha yavaş modeller için bu değeri artırın.",
 		"getOpenAiApiKey": "OpenAI API Anahtarı Al",
 		"mistralApiKey": "Mistral API Anahtarı",
 		"getMistralApiKey": "Mistral / Codestral API Anahtarı Al",

--- a/webview-ui/src/i18n/locales/vi/settings.json
+++ b/webview-ui/src/i18n/locales/vi/settings.json
@@ -183,6 +183,8 @@
 		"openAiApiKey": "Khóa API OpenAI",
 		"apiKey": "Khóa API",
 		"openAiBaseUrl": "URL cơ sở",
+		"openAiApiTimeout": "Thời gian chờ (phút)",
+		"openAiApiTimeoutDescription": "Thời gian chờ cho các yêu cầu API đến nhà cung cấp (tối thiểu 5 phút). Nếu không có phản hồi trong khoảng thời gian này, yêu cầu sẽ được thử lại. Tăng giá trị này cho các mô hình chậm hơn.",
 		"getOpenAiApiKey": "Lấy khóa API OpenAI",
 		"mistralApiKey": "Khóa API Mistral",
 		"getMistralApiKey": "Lấy khóa API Mistral / Codestral",

--- a/webview-ui/src/i18n/locales/zh-CN/settings.json
+++ b/webview-ui/src/i18n/locales/zh-CN/settings.json
@@ -184,6 +184,8 @@
 		"apiKey": "API 密钥",
 		"openAiBaseUrl": "OpenAI 基础 URL",
 		"getOpenAiApiKey": "获取 OpenAI API 密钥",
+		"openAiApiTimeout": "超时时间（分钟）",
+		"openAiApiTimeoutDescription": "对提供者的 API 请求超时时间（最少 5 分钟）。若在此期间无响应，将重试请求。对于较慢的模型请增加此值。",
 		"mistralApiKey": "Mistral API 密钥",
 		"getMistralApiKey": "获取 Mistral / Codestral API 密钥",
 		"codestralBaseUrl": "Codestral 基础 URL（可选）",

--- a/webview-ui/src/i18n/locales/zh-TW/settings.json
+++ b/webview-ui/src/i18n/locales/zh-TW/settings.json
@@ -184,6 +184,8 @@
 		"apiKey": "API 金鑰",
 		"openAiBaseUrl": "基礎 URL",
 		"getOpenAiApiKey": "取得 OpenAI API 金鑰",
+		"openAiApiTimeout": "逾時（分鐘）",
+		"openAiApiTimeoutDescription": "對提供者的 API 請求逾時（最少 5 分鐘）。若在此期間無回應，請求將會重試。對於較慢的模型請增加此值。",
 		"mistralApiKey": "Mistral API 金鑰",
 		"getMistralApiKey": "取得 Mistral/Codestral API 金鑰",
 		"codestralBaseUrl": "Codestral 基礎 URL（選用）",


### PR DESCRIPTION

<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->
 ##
Closes: #3621

### Description

**Why:** Roo Code often emits API socket-timeout errors when using self-hosted, slow LLMs — either while reading a large file or even during the initial prompt phase. Yet these slow models can be usable in autonomous scenarios for working on some private code source. It would be great to have a user-tunable setting to configure the API timeout for self-hosted providers (OpenAI-compatible, Ollama, LMStudio, etc.). The timeout can be up to 30 minutes to allow big file chunks or prompts to be fully processed. This way, even an older laptop could produce meaningful results overnight with roo code.

**What**  This PR adds a timeout option to the settings for LMStudio, Ollama, and OpenAI-Сompatible providers, and forwards this value into the OpenAI class constructor. Translations for all supported languages have been included.

<!--
Briefly summarize the changes in this PR and how they address the linked issue.
The issue should cover the "what" and "why"; this section should focus on:
- The "how": key implementation details, design choices, or trade-offs made.
- Anything specific reviewers should pay attention to in this PR.
-->

### Test Procedure
Connected an OpenAI-compatible client to a local slow LLM and tested timeout settings of 5, 10, and 20 minutes.

Observed socket-timeout errors and retries occurring according to the configured timeout.

Repeated manual testing for LMStudio provider with the same timeout values.
<!--
Detail the steps to test your changes. This helps reviewers verify your work.
- How did you test this specific implementation? (e.g., unit tests, manual testing steps)
- How can reviewers reproduce your tests or verify the fix/feature?
- Include relevant testing environment details if applicable.
-->

### Type of Change

<!-- Mark all applicable boxes with an 'x'. -->

- [ ] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [X] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [X] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [X] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [X] **Self-Review**: I have performed a thorough self-review of my code.
- [X] **Code Quality**:
    - [X] My code adheres to the project's style guidelines.
    - [X] There are no new linting errors or warnings (`npm run lint`).
    - [X] All debug code (e.g., `console.log`) has been removed.
- [X] **Testing**:
    - [ ] New and/or updated tests have been added to cover my changes.
    - [X] All tests pass locally (`npm test`).
    - [X] The application builds successfully with my changes.
- [X] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [X] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [ ] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [X] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos
Before
![image](https://github.com/user-attachments/assets/77c1c76b-789a-49c1-8078-e513b60bd1d5)

After
![image](https://github.com/user-attachments/assets/251d7caf-fcb6-44fd-aa80-50b6e8d80b1d)

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->

### Documentation Updates
The UI guide should include:

Timeout for API requests to provider (min 5 min). If no response is received within this period, the request is retried. Increase this value for slower models.

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [X] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

### Additional Notes
This is my first PR ever. So... do what you must.
Also, I am not a frontend developer, these code changes were done by LLM with my revisions.
<!-- Add any other context, questions, or information for reviewers here. -->

### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces customizable API timeout settings for self-hosted LLMs, updates UI components for user input, and adds translations in multiple languages.
> 
>   - **Behavior**:
>     - Adds customizable API timeout setting for LMStudio, Ollama, and OpenAI-Compatible providers in `provider-settings.ts`.
>     - Applies timeout setting in `lm-studio.ts`, `ollama.ts`, and `openai.ts` by converting minutes to milliseconds.
>   - **UI Components**:
>     - Updates `LMStudio.tsx`, `Ollama.tsx`, and `OpenAICompatible.tsx` to include input fields for API timeout settings.
>   - **Translations**:
>     - Adds translations for API timeout settings in multiple language files, including `settings.json` for `ca`, `de`, `en`, `es`, `fr`, `hi`, `id`, `it`, `ja`, `ko`, `nl`, `pl`, `pt-BR`, `ru`, `tr`, `vi`, `zh-CN`, and `zh-TW`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 70e9ab6e16df766aff8ed7381a2c69259dd9afd6. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->