### PR TITLE
Chat input clearing during running task

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -327,14 +327,6 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 							break
 						case "api_req_started":
 							if (secondLastMessage?.ask === "command_output") {
-								// If the last ask is a command_output, and we
-								// receive an api_req_started, then that means
-								// the command has finished and we don't need
-								// input from the user anymore (in every other
-								// case, the user has to interact with input
-								// field or buttons to continue, which does the
-								// following automatically).
-								setInputValue("")
 								setSendingDisabled(true)
 								setSelectedImages([])
 								setClineAsk(undefined)


### PR DESCRIPTION
Here is REPRO step!!

https://github.com/user-attachments/assets/cd81398c-240c-4487-bfe7-809c92bc9f84



### Description
Fixes an issue raised by both myself and hannes.
Previously the chat input cleared each time an api requesst was fired, hannes noticed it also accidentally cleared inputs within settings while a task was running.


### Test Procedure
1. Type a message in the input box while a task is running
2. When an API request is sent the input box gets cleared (no longer happens.)


### Type of Change
- [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes input clearing on `api_req_started` in `ChatView.tsx` to prevent chat input from being cleared during ongoing tasks.
> 
>   - **Behavior**:
>     - Removes input clearing when `api_req_started` is received in `ChatView.tsx`, preventing chat input from being cleared during ongoing tasks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c2e1754afc867845b07b3b77ed93efdcd247c693. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->