### PR TITLE
[Condense] Move condense button out of expanded task menu

### DIFF
--- a/webview-ui/src/components/chat/TaskActions.tsx
+++ b/webview-ui/src/components/chat/TaskActions.tsx
@@ -12,10 +12,9 @@ import { IconButton } from "./IconButton"
 interface TaskActionsProps {
 	item?: HistoryItem
 	buttonsDisabled: boolean
-	handleCondenseContext: (taskId: string) => void
 }
 
-export const TaskActions = ({ item, buttonsDisabled, handleCondenseContext }: TaskActionsProps) => {
+export const TaskActions = ({ item, buttonsDisabled }: TaskActionsProps) => {
 	const [deleteTaskId, setDeleteTaskId] = useState<string | null>(null)
 	const { t } = useTranslation()
 
@@ -29,12 +28,6 @@ export const TaskActions = ({ item, buttonsDisabled, handleCondenseContext }: Ta
 			/>
 			{!!item?.size && item.size > 0 && (
 				<>
-					<IconButton
-						iconClass="codicon-fold"
-						title={t("chat:task.condenseContext")}
-						disabled={buttonsDisabled}
-						onClick={() => handleCondenseContext(item.id)}
-					/>
 					<div className="flex items-center">
 						<IconButton
 							iconClass="codicon-trash"

--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -113,8 +113,7 @@ const TaskHeader = ({
 							title={t("chat:task.condenseContext")}
 							disabled={buttonsDisabled}
 							onClick={() => currentTaskItem && handleCondenseContext(currentTaskItem.id)}
-							className="shrink-0"
-							style={{ minHeight: "20px", minWidth: "20px", padding: "2px" }}
+							className="shrink-0 min-h-[20px] min-w-[20px] p-[2px]"
 						/>
 						{!!totalCost && <VSCodeBadge>${totalCost.toFixed(2)}</VSCodeBadge>}
 					</div>

--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -19,6 +19,7 @@ import Thumbnails from "../common/Thumbnails"
 import { TaskActions } from "./TaskActions"
 import { ContextWindowProgress } from "./ContextWindowProgress"
 import { Mention } from "./Mention"
+import { IconButton } from "./IconButton"
 
 export interface TaskHeaderProps {
 	task: ClineMessage
@@ -97,7 +98,7 @@ const TaskHeader = ({
 				</div>
 				{/* Collapsed state: Track context and cost if we have any */}
 				{!isTaskExpanded && contextWindow > 0 && (
-					<div className={`w-full flex flex-row gap-1 h-auto`}>
+					<div className={`w-full flex flex-row items-center gap-1 h-auto`}>
 						<ContextWindowProgress
 							contextWindow={contextWindow}
 							contextTokens={contextTokens || 0}
@@ -106,6 +107,14 @@ const TaskHeader = ({
 									? getModelMaxOutputTokens({ modelId, model, settings: apiConfiguration })
 									: undefined
 							}
+						/>
+						<IconButton
+							iconClass="codicon-fold"
+							title={t("chat:task.condenseContext")}
+							disabled={buttonsDisabled}
+							onClick={() => currentTaskItem && handleCondenseContext(currentTaskItem.id)}
+							className="shrink-0"
+							style={{ minHeight: "20px", minWidth: "20px", padding: "2px" }}
 						/>
 						{!!totalCost && <VSCodeBadge>${totalCost.toFixed(2)}</VSCodeBadge>}
 					</div>
@@ -169,13 +178,7 @@ const TaskHeader = ({
 										</span>
 									)}
 								</div>
-								{!totalCost && (
-									<TaskActions
-										item={currentTaskItem}
-										buttonsDisabled={buttonsDisabled}
-										handleCondenseContext={handleCondenseContext}
-									/>
-								)}
+								{!totalCost && <TaskActions item={currentTaskItem} buttonsDisabled={buttonsDisabled} />}
 							</div>
 
 							{doesModelSupportPromptCache &&
@@ -204,11 +207,7 @@ const TaskHeader = ({
 										<span className="font-bold">{t("chat:task.apiCost")}</span>
 										<span>${totalCost?.toFixed(2)}</span>
 									</div>
-									<TaskActions
-										item={currentTaskItem}
-										buttonsDisabled={buttonsDisabled}
-										handleCondenseContext={handleCondenseContext}
-									/>
+									<TaskActions item={currentTaskItem} buttonsDisabled={buttonsDisabled} />
 								</div>
 							)}
 						</div>

--- a/webview-ui/src/components/chat/__tests__/TaskHeader.test.tsx
+++ b/webview-ui/src/components/chat/__tests__/TaskHeader.test.tsx
@@ -1,12 +1,19 @@
 // npx jest src/components/chat/__tests__/TaskHeader.test.tsx
 
 import React from "react"
-import { render, screen } from "@testing-library/react"
+import { render, screen, fireEvent } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 
 import type { ProviderSettings } from "@roo-code/types"
 
 import TaskHeader, { TaskHeaderProps } from "../TaskHeader"
+
+// Mock i18n
+jest.mock("react-i18next", () => ({
+	useTranslation: () => ({
+		t: (key: string) => key, // Simple mock that returns the key
+	}),
+}))
 
 // Mock the vscode API
 jest.mock("@/utils/vscode", () => ({
@@ -28,7 +35,7 @@ jest.mock("@src/context/ExtensionStateContext", () => ({
 			apiKey: "test-api-key", // Add relevant fields
 			apiModelId: "claude-3-opus-20240229", // Add relevant fields
 		} as ProviderSettings, // Optional: Add type assertion if ProviderSettings is imported
-		currentTaskItem: null,
+		currentTaskItem: { id: "test-task-id" }, // Add a mock currentTaskItem for the condense button
 	}),
 }))
 
@@ -78,5 +85,24 @@ describe("TaskHeader", () => {
 	it("should not display cost when totalCost is NaN", () => {
 		renderTaskHeader({ totalCost: NaN })
 		expect(screen.queryByText(/\$/)).not.toBeInTheDocument()
+	})
+
+	it("should render the condense context button", () => {
+		renderTaskHeader()
+		expect(screen.getByTitle("chat:task.condenseContext")).toBeInTheDocument()
+	})
+
+	it("should call handleCondenseContext when condense context button is clicked", () => {
+		const handleCondenseContext = jest.fn()
+		renderTaskHeader({ handleCondenseContext })
+		const condenseButton = screen.getByTitle("chat:task.condenseContext")
+		fireEvent.click(condenseButton)
+		expect(handleCondenseContext).toHaveBeenCalledWith("test-task-id")
+	})
+
+	it("should disable the condense context button when buttonsDisabled is true", () => {
+		renderTaskHeader({ buttonsDisabled: true })
+		const condenseButton = screen.getByTitle("chat:task.condenseContext")
+		expect(condenseButton).toBeDisabled()
 	})
 })

--- a/webview-ui/src/components/chat/__tests__/TaskHeader.test.tsx
+++ b/webview-ui/src/components/chat/__tests__/TaskHeader.test.tsx
@@ -13,6 +13,11 @@ jest.mock("react-i18next", () => ({
 	useTranslation: () => ({
 		t: (key: string) => key, // Simple mock that returns the key
 	}),
+	// Mock initReactI18next to prevent initialization errors in tests
+	initReactI18next: {
+		type: "3rdParty",
+		init: jest.fn(),
+	},
 }))
 
 // Mock the vscode API
@@ -35,7 +40,7 @@ jest.mock("@src/context/ExtensionStateContext", () => ({
 			apiKey: "test-api-key", // Add relevant fields
 			apiModelId: "claude-3-opus-20240229", // Add relevant fields
 		} as ProviderSettings, // Optional: Add type assertion if ProviderSettings is imported
-		currentTaskItem: { id: "test-task-id" }, // Add a mock currentTaskItem for the condense button
+		currentTaskItem: { id: "test-task-id" },
 	}),
 }))
 

--- a/webview-ui/src/components/chat/__tests__/TaskHeader.test.tsx
+++ b/webview-ui/src/components/chat/__tests__/TaskHeader.test.tsx
@@ -106,8 +106,10 @@ describe("TaskHeader", () => {
 	})
 
 	it("should disable the condense context button when buttonsDisabled is true", () => {
-		renderTaskHeader({ buttonsDisabled: true })
+		const handleCondenseContext = jest.fn()
+		renderTaskHeader({ buttonsDisabled: true, handleCondenseContext })
 		const condenseButton = screen.getByTitle("chat:task.condenseContext")
-		expect(condenseButton).toBeDisabled()
+		fireEvent.click(condenseButton)
+		expect(handleCondenseContext).not.toHaveBeenCalled()
 	})
 })


### PR DESCRIPTION
### Description
Moves the condense context button out of the expanded task menu so that you can click it without having to open the menu up.
Requested by @hannesrudolph 

### Test Procedure
Tried clicking the button and it works

### Type of Change
- [ ] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [ ] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [x] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist
- [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [x] **Testing**:
    - [x] New and/or updated tests have been added to cover my changes.
    - [x] All tests pass locally (`npm test`).
    - [x] The application builds successfully with my changes.
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [ ] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos
![image](https://github.com/user-attachments/assets/4e8df868-dbbd-40a5-bdaa-f2a52eedf341)

### Documentation Updates
- [x] Yes, documentation updates are required.

Update docs that mention the manual context condense button
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor UI to move condense button from `TaskActions` to `TaskHeader`, improving accessibility and updating tests accordingly.
> 
>   - **UI Changes**:
>     - Move condense button from `TaskActions` to `TaskHeader` for easier access without expanding the task menu.
>     - Update `TaskHeader` to include condense button in collapsed state.
>   - **Code Changes**:
>     - Remove `handleCondenseContext` prop from `TaskActions` in `TaskActions.tsx`.
>     - Add `IconButton` for condense action in `TaskHeader.tsx`.
>   - **Testing**:
>     - Update `TaskHeader.test.tsx` to test new condense button location and behavior.
>     - Add tests for button click and disabled state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3753f3fdf6b5ed0cac51a713e304795a83103df2. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->