### PR TITLE
Simplify CloudService callbacks

### DIFF
--- a/packages/cloud/src/__tests__/CloudService.test.ts
+++ b/packages/cloud/src/__tests__/CloudService.test.ts
@@ -128,11 +128,14 @@ describe("CloudService", () => {
 
 	describe("createInstance", () => {
 		it("should create and initialize CloudService instance", async () => {
-			const callbacks = { userChanged: vi.fn(), settingsChanged: vi.fn() }
+			const callbacks = {
+				stateChanged: vi.fn(),
+			}
+
 			const cloudService = await CloudService.createInstance(mockContext, callbacks)
 
 			expect(cloudService).toBeInstanceOf(CloudService)
-			expect(AuthService.createInstance).toHaveBeenCalledWith(mockContext, expect.any(Function))
+			expect(AuthService.createInstance).toHaveBeenCalledWith(mockContext)
 			expect(SettingsService.createInstance).toHaveBeenCalledWith(mockContext, expect.any(Function))
 		})
 
@@ -150,7 +153,7 @@ describe("CloudService", () => {
 		let callbacks: CloudServiceCallbacks
 
 		beforeEach(async () => {
-			callbacks = { userChanged: vi.fn(), settingsChanged: vi.fn() }
+			callbacks = { stateChanged: vi.fn() }
 			cloudService = await CloudService.createInstance(mockContext, callbacks)
 		})
 

--- a/packages/cloud/src/types.ts
+++ b/packages/cloud/src/types.ts
@@ -1,6 +1,3 @@
-import { CloudUserInfo } from "@roo-code/types"
-
 export interface CloudServiceCallbacks {
-	userChanged?: (userInfo: CloudUserInfo | undefined) => void
-	settingsChanged?: () => void
+	stateChanged?: () => void
 }

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -23,6 +23,7 @@ import {
 	type TerminalActionPromptType,
 	type HistoryItem,
 	ORGANIZATION_ALLOW_ALL,
+	CloudUserInfo,
 } from "@roo-code/types"
 import { TelemetryService } from "@roo-code/telemetry"
 import { CloudService } from "@roo-code/cloud"
@@ -1296,6 +1297,7 @@ export class ClineProvider
 			maxReadFileLine,
 			terminalCompressProgressBar,
 			historyPreviewCollapsed,
+			cloudUserInfo,
 			organizationAllowList,
 			condensingApiConfigId,
 			customCondensingPrompt,
@@ -1391,6 +1393,7 @@ export class ClineProvider
 			terminalCompressProgressBar: terminalCompressProgressBar ?? true,
 			hasSystemPromptOverride,
 			historyPreviewCollapsed: historyPreviewCollapsed ?? false,
+			cloudUserInfo,
 			organizationAllowList,
 			condensingApiConfigId,
 			customCondensingPrompt,
@@ -1433,6 +1436,16 @@ export class ClineProvider
 		} catch (error) {
 			console.error(
 				`[getState] failed to get organization allow list: ${error instanceof Error ? error.message : String(error)}`,
+			)
+		}
+
+		let cloudUserInfo: CloudUserInfo | null = null
+
+		try {
+			cloudUserInfo = CloudService.instance.getUserInfo()
+		} catch (error) {
+			console.error(
+				`[getState] failed to get cloud user info: ${error instanceof Error ? error.message : String(error)}`,
 			)
 		}
 
@@ -1504,6 +1517,7 @@ export class ClineProvider
 			showRooIgnoredFiles: stateValues.showRooIgnoredFiles ?? true,
 			maxReadFileLine: stateValues.maxReadFileLine ?? -1,
 			historyPreviewCollapsed: stateValues.historyPreviewCollapsed ?? false,
+			cloudUserInfo,
 			organizationAllowList,
 			// Explicitly add condensing settings
 			condensingApiConfigId: stateValues.condensingApiConfigId,

--- a/src/core/webview/__tests__/ClineProvider.test.ts
+++ b/src/core/webview/__tests__/ClineProvider.test.ts
@@ -423,6 +423,7 @@ describe("ClineProvider", () => {
 			showRooIgnoredFiles: true,
 			renderContext: "sidebar",
 			maxReadFileLine: 500,
+			cloudUserInfo: null,
 			organizationAllowList: ORGANIZATION_ALLOW_ALL,
 			autoCondenseContext: true,
 			autoCondenseContextPercent: 100,

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -106,16 +106,6 @@ export const webviewMessageHandler = async (provider: ClineProvider, message: We
 					await Promise.all([
 						await updateGlobalState("listApiConfigMeta", listApiConfig),
 						await provider.postMessageToWebview({ type: "listApiConfig", listApiConfig }),
-						async () => {
-							try {
-								if (CloudService.instance.hasActiveSession()) {
-									const userInfo = await CloudService.instance.getUserInfo()
-									provider.postMessageToWebview({ type: "authenticatedUser", userInfo })
-								}
-							} catch (error) {
-								provider.log(`AuthService#getUserInfo failed: ${error}`)
-							}
-						},
 					])
 				})
 				.catch((error) =>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,9 +70,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// Initialize Roo Code Cloud service.
 	await CloudService.createInstance(context, {
-		userChanged: (userInfo) =>
-			ClineProvider.getVisibleInstance()?.postMessageToWebview({ type: "authenticatedUser", userInfo }),
-		settingsChanged: () => ClineProvider.getVisibleInstance()?.postStateToWebview(),
+		stateChanged: () => ClineProvider.getVisibleInstance()?.postStateToWebview(),
 	})
 
 	// Initialize i18n for internationalization support

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -217,6 +217,7 @@ export type ExtensionState = Pick<
 	settingsImportedAt?: number
 	historyPreviewCollapsed?: boolean
 
+	cloudUserInfo: CloudUserInfo | null
 	organizationAllowList: OrganizationAllowList
 
 	autoCondenseContext: boolean

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { useEvent } from "react-use"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 
-import type { CloudUserInfo } from "@roo-code/types"
 import { ExtensionMessage } from "@roo/ExtensionMessage"
 
 import TranslationProvider from "./i18n/TranslationContext"
@@ -30,12 +29,18 @@ const tabsByMessageAction: Partial<Record<NonNullable<ExtensionMessage["action"]
 }
 
 const App = () => {
-	const { didHydrateState, showWelcome, shouldShowAnnouncement, telemetrySetting, telemetryKey, machineId } =
-		useExtensionState()
+	const {
+		didHydrateState,
+		showWelcome,
+		shouldShowAnnouncement,
+		telemetrySetting,
+		telemetryKey,
+		machineId,
+		cloudUserInfo,
+	} = useExtensionState()
 
 	const [showAnnouncement, setShowAnnouncement] = useState(false)
 	const [tab, setTab] = useState<Tab>("chat")
-	const [userInfo, setUserInfo] = useState<CloudUserInfo | null>(null)
 
 	const [humanRelayDialogState, setHumanRelayDialogState] = useState<{
 		isOpen: boolean
@@ -84,10 +89,6 @@ const App = () => {
 			if (message.type === "acceptInput") {
 				chatViewRef.current?.acceptInput()
 			}
-
-			if (message.type === "authenticatedUser") {
-				setUserInfo(message.userInfo || null)
-			}
 		},
 		[switchTab],
 	)
@@ -126,7 +127,7 @@ const App = () => {
 			{tab === "settings" && (
 				<SettingsView ref={settingsRef} onDone={() => setTab("chat")} targetSection={currentSection} />
 			)}
-			{tab === "account" && <AccountView userInfo={userInfo} onDone={() => switchTab("chat")} />}
+			{tab === "account" && <AccountView userInfo={cloudUserInfo} onDone={() => switchTab("chat")} />}
 			<ChatView
 				ref={chatViewRef}
 				isHidden={tab !== "chat"}

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -196,6 +196,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		terminalZdotdir: false, // Default ZDOTDIR handling setting
 		terminalCompressProgressBar: true, // Default to compress progress bar output
 		historyPreviewCollapsed: false, // Initialize the new state (default to expanded)
+		cloudUserInfo: null,
 		organizationAllowList: ORGANIZATION_ALLOW_ALL,
 		autoCondenseContext: true,
 		autoCondenseContextPercent: 100,

--- a/webview-ui/src/context/__tests__/ExtensionStateContext.test.tsx
+++ b/webview-ui/src/context/__tests__/ExtensionStateContext.test.tsx
@@ -203,6 +203,7 @@ describe("mergeExtensionState", () => {
 			showRooIgnoredFiles: true,
 			renderContext: "sidebar",
 			maxReadFileLine: 500,
+			cloudUserInfo: null,
 			organizationAllowList: { allowAll: true, providers: {} },
 			autoCondenseContext: true,
 			autoCondenseContextPercent: 100,


### PR DESCRIPTION
This is incremental, but slightly reduces the surface area between the core extension and cloud.

- Remove AuthService callbacks, add user-info event
- Store userInfo on AuthService and fetch it when sessions go active
- Simplify CloudService callbacks to just stateChanged
- Add cloudUserInfo to state and remove authenticatedUser message
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplifies CloudService callbacks and updates user info handling across components and state management.
> 
>   - **Behavior**:
>     - Simplifies `CloudService` callbacks to only use `stateChanged` in `CloudService.ts`.
>     - Removes `userChanged` and `settingsChanged` callbacks from `types.ts`.
>     - Adds `user-info` event to `AuthServiceEvents` in `AuthService.ts`.
>     - Stores `userInfo` in `AuthService` and fetches it when sessions activate.
>     - Removes `authenticatedUser` message handling in `webviewMessageHandler.ts`.
>   - **State Management**:
>     - Adds `cloudUserInfo` to `ExtensionState` in `ExtensionMessage.ts` and `ExtensionStateContext.tsx`.
>     - Updates `ClineProvider.ts` to include `cloudUserInfo` in state management.
>   - **UI Components**:
>     - Updates `App.tsx` to use `cloudUserInfo` for `AccountView`.
>     - Removes `userInfo` state from `App.tsx`.
>   - **Tests**:
>     - Updates tests in `CloudService.test.ts` and `ClineProvider.test.ts` to reflect callback changes.
>     - Adds tests for `cloudUserInfo` in `ExtensionStateContext.test.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a03ff77df1cb29b697522efd0cb58470c2caba9a. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->