### PR TITLE
Fix Roo Code Nightly package.json generation

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -8,7 +8,7 @@
 	"scripts": {
 		"lint": "eslint src --ext=ts --max-warnings=0",
 		"check-types": "tsc --noEmit",
-		"test": "vitest --globals --run",
+		"test": "vitest run",
 		"build": "tsc",
 		"clean": "rimraf dist .turbo"
 	},

--- a/packages/build/src/__tests__/index.test.ts
+++ b/packages/build/src/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-// npx vitest --globals run src/__tests__/index.test.ts
+// npx vitest run src/__tests__/index.test.ts
 
 import { generatePackageJson } from "../index.js"
 
@@ -66,6 +66,11 @@ describe("generatePackageJson", () => {
 								command: "roo-cline.settingsButtonClicked",
 								group: "navigation@6",
 								when: "activeWebviewPanelId == roo-cline.TabPanelProvider",
+							},
+							{
+								command: "roo-cline.accountButtonClicked",
+								group: "navigation@6",
+								when: "activeWebviewPanelId == roo-cline.TabPanelProvider && config.roo-cline.rooCodeCloudEnabled",
 							},
 						],
 					},
@@ -174,6 +179,11 @@ describe("generatePackageJson", () => {
 							command: "roo-code-nightly.settingsButtonClicked",
 							group: "navigation@6",
 							when: "activeWebviewPanelId == roo-code-nightly.TabPanelProvider",
+						},
+						{
+							command: "roo-code-nightly.accountButtonClicked",
+							group: "navigation@6",
+							when: "activeWebviewPanelId == roo-code-nightly.TabPanelProvider && config.roo-code-nightly.rooCodeCloudEnabled",
 						},
 					],
 				},

--- a/packages/build/src/esbuild.ts
+++ b/packages/build/src/esbuild.ts
@@ -213,12 +213,12 @@ function transformArrayRecord<T>(obj: Record<string, any[]>, from: string, to: s
 	return Object.entries(obj).reduce(
 		(acc, [key, ary]) => ({
 			...acc,
-			[key.replace(from, to)]: ary.map((item) => {
+			[key.replaceAll(from, to)]: ary.map((item) => {
 				const transformedItem = { ...item }
 
 				for (const prop of props) {
 					if (prop in item && typeof item[prop] === "string") {
-						transformedItem[prop] = item[prop].replace(from, to)
+						transformedItem[prop] = item[prop].replaceAll(from, to)
 					}
 				}
 
@@ -232,7 +232,7 @@ function transformArrayRecord<T>(obj: Record<string, any[]>, from: string, to: s
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function transformArray<T>(arr: any[], from: string, to: string, idProp: string): T[] {
 	return arr.map(({ [idProp]: id, ...rest }) => ({
-		[idProp]: id.replace(from, to),
+		[idProp]: id.replaceAll(from, to),
 		...rest,
 	}))
 }
@@ -242,7 +242,7 @@ function transformRecord<T>(obj: Record<string, any>, from: string, to: string):
 	return Object.entries(obj).reduce(
 		(acc, [key, value]) => ({
 			...acc,
-			[key.replace(from, to)]: value,
+			[key.replaceAll(from, to)]: value,
 		}),
 		{} as T,
 	)

--- a/packages/build/vitest.config.ts
+++ b/packages/build/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: "node",
+	},
+})

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"lint": "eslint src --ext=ts --max-warnings=0",
 		"check-types": "tsc --noEmit",
-		"test": "vitest --globals --run",
+		"test": "vitest run",
 		"clean": "rimraf dist .turbo"
 	},
 	"dependencies": {

--- a/packages/cloud/src/__tests__/RefreshTimer.test.ts
+++ b/packages/cloud/src/__tests__/RefreshTimer.test.ts
@@ -1,4 +1,4 @@
-// npx vitest run --globals src/__tests__/RefreshTimer.test.ts
+// npx vitest run src/__tests__/RefreshTimer.test.ts
 
 import { Mock } from "vitest"
 

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"lint": "eslint src --ext=ts --max-warnings=0",
 		"check-types": "tsc --noEmit",
-		"test": "vitest --globals --run",
+		"test": "vitest run",
 		"clean": "rimraf dist .turbo"
 	},
 	"dependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -16,7 +16,7 @@
 	"scripts": {
 		"lint": "eslint src --ext=ts --max-warnings=0",
 		"check-types": "tsc --noEmit",
-		"test": "vitest --globals --run",
+		"test": "vitest run",
 		"build": "tsup",
 		"npm:publish:test": "tsup --outDir npm/dist && cd npm && npm publish --dry-run",
 		"npm:publish": "tsup --outDir npm/dist && cd npm && npm publish",

--- a/src/api/providers/fetchers/__tests__/openrouter.spec.ts
+++ b/src/api/providers/fetchers/__tests__/openrouter.spec.ts
@@ -1,4 +1,4 @@
-// npx vitest run --globals api/providers/fetchers/__tests__/openrouter.spec.ts
+// npx vitest run api/providers/fetchers/__tests__/openrouter.spec.ts
 
 import * as path from "path"
 

--- a/src/package.json
+++ b/src/package.json
@@ -342,7 +342,7 @@
 		"lint": "eslint . --ext=ts --max-warnings=0",
 		"check-types": "tsc --noEmit",
 		"pretest": "turbo run bundle --cwd ..",
-		"test": "jest -w=40% && vitest run --globals",
+		"test": "jest -w=40% && vitest run",
 		"format": "prettier --write .",
 		"bundle": "node esbuild.mjs",
 		"vscode:prepublish": "pnpm bundle --production",


### PR DESCRIPTION
### Description

We weren't substituting `roo-cline` with `roo-code-nightly` in the generated `package.json` file if `roo-cline` appeared multiple times in a JSON node.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix substitution issue in `generatePackageJson` and update test scripts and configurations for consistent `vitest` usage.
> 
>   - **Behavior**:
>     - Fix substitution issue in `generatePackageJson` in `esbuild.ts` to replace all instances of `roo-cline` with `roo-code-nightly`.
>   - **Testing**:
>     - Update test cases in `index.test.ts` to verify multiple substitutions in `generatePackageJson`.
>     - Add `vitest.config.ts` for Vitest configuration.
>   - **Scripts**:
>     - Change `test` script in `package.json` files to `vitest run` from `vitest --globals --run` in `build`, `cloud`, `telemetry`, and `types` packages.
>     - Update comments in test files to reflect new `vitest` command usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for fcb60cfaa49e5acb8a8289ee5fd6343a18bc4b53. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->