### PR TITLE
Add DeepSeek R1 0528 to the Chutes provider

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1687,6 +1687,7 @@ export const groqModels = {
 // Chutes AI
 // https://llm.chutes.ai/v1 (OpenAI compatible)
 export type ChutesModelId =
+	| "deepseek-ai/DeepSeek-R1-0528"
 	| "deepseek-ai/DeepSeek-R1"
 	| "deepseek-ai/DeepSeek-V3"
 	| "unsloth/Llama-3.3-70B-Instruct"
@@ -1708,8 +1709,18 @@ export type ChutesModelId =
 	| "Qwen/Qwen3-8B"
 	| "microsoft/MAI-DS-R1-FP8"
 	| "tngtech/DeepSeek-R1T-Chimera"
-export const chutesDefaultModelId: ChutesModelId = "deepseek-ai/DeepSeek-R1"
+
+export const chutesDefaultModelId: ChutesModelId = "deepseek-ai/DeepSeek-R1-0528"
 export const chutesModels = {
+	"deepseek-ai/DeepSeek-R1-0528": {
+		maxTokens: 32768,
+		contextWindow: 163840,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0,
+		outputPrice: 0,
+		description: "DeepSeek R1 0528 model.",
+	},
 	"deepseek-ai/DeepSeek-R1": {
 		maxTokens: 32768,
 		contextWindow: 163840,


### PR DESCRIPTION
New model for the Chutes provider, surpasses the old DeepSeek R1 and is free so it is also set to be the default model now.

<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #4103 

### Description

Add the new DeepSeek R1 0528 checkpoint to the Chutes provider.

### Test Procedure

Both the new and the old checkpoint work.

### Type of Change

<!-- Mark all applicable boxes with an 'x'. -->

- [ ] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [x] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [x] **Testing**:
    - [ ] New and/or updated tests have been added to cover my changes.
    - [x] All tests pass locally (`npm test`).
    - [x] The application builds successfully with my changes.
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [ ] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [ ] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

![image](https://github.com/user-attachments/assets/75f51fa2-7488-4c76-9802-7763dbfcffc4)

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [x] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

### Additional Notes

This is a free model, so it will also be the new default model for the Chutes provider, as it greatly surpasses the old checkpoint and all the other models.

### Get in Touch

discord: @fluffyzeo