### PR TITLE
Add `appName` to `TelemetryProperties`

### DIFF
--- a/packages/cloud/src/__tests__/RooCodeTelemetryClient.test.ts
+++ b/packages/cloud/src/__tests__/RooCodeTelemetryClient.test.ts
@@ -181,6 +181,7 @@ describe("RooCodeTelemetryClient", () => {
 			const client = new RooCodeTelemetryClient(mockAuthService)
 
 			const providerProperties = {
+				appName: "roo-code",
 				appVersion: "1.0.0",
 				vscodeVersion: "1.60.0",
 				platform: "darwin",

--- a/packages/cloud/src/__tests__/TelemetryClient.test.ts
+++ b/packages/cloud/src/__tests__/TelemetryClient.test.ts
@@ -181,6 +181,7 @@ describe("TelemetryClient", () => {
 			const client = new TelemetryClient(mockAuthService)
 
 			const providerProperties = {
+				appName: "roo-code",
 				appVersion: "1.0.0",
 				vscodeVersion: "1.60.0",
 				platform: "darwin",

--- a/packages/types/src/telemetry.ts
+++ b/packages/types/src/telemetry.ts
@@ -52,6 +52,7 @@ export enum TelemetryEventName {
  */
 
 export const appPropertiesSchema = z.object({
+	appName: z.string(),
 	appVersion: z.string(),
 	vscodeVersion: z.string(),
 	platform: z.string(),

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1633,8 +1633,11 @@ export class ClineProvider
 		const { mode, apiConfiguration, language } = await this.getState()
 		const task = this.getCurrentCline()
 
+		const packageJSON = this.context.extension?.packageJSON
+
 		return {
-			appVersion: this.context.extension?.packageJSON?.version,
+			appName: packageJSON?.name ?? Package.name,
+			appVersion: packageJSON?.version ?? Package.version,
 			vscodeVersion: vscode.version,
 			platform: process.platform,
 			editorName: vscode.env.appName,

--- a/webview-ui/src/utils/TelemetryClient.ts
+++ b/webview-ui/src/utils/TelemetryClient.ts
@@ -1,4 +1,5 @@
 import posthog from "posthog-js"
+
 import { TelemetrySetting } from "@roo/TelemetrySetting"
 
 class TelemetryClient {
@@ -28,6 +29,7 @@ class TelemetryClient {
 		if (!TelemetryClient.instance) {
 			TelemetryClient.instance = new TelemetryClient()
 		}
+
 		return TelemetryClient.instance
 	}
 


### PR DESCRIPTION
### Description

To disambiguate between `roo-cline` and `roo-code-nightly`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `appName` to telemetry properties to distinguish between app versions, updating schema and tests accordingly.
> 
>   - **Telemetry Properties**:
>     - Add `appName` to `appPropertiesSchema` in `telemetry.ts`.
>     - Update `getTelemetryProperties()` in `ClineProvider.ts` to include `appName`.
>   - **Tests**:
>     - Add `appName: "roo-code"` to `providerProperties` in `RooCodeTelemetryClient.test.ts` and `TelemetryClient.test.ts`.
>   - **Misc**:
>     - Minor formatting changes in `TelemetryClient.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 2545bbd5cb5c91025e90dd15c737a1b29ab8df60. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->