### PR TITLE
Appease changests

### DIFF
--- a/.changeset/heavy-snakes-flow.md
+++ b/.changeset/heavy-snakes-flow.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Appease changesets

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@roo-code/cloud",
 	"description": "Roo Code Cloud VSCode integration.",
-	"private": true,
+	"version": "0.0.0",
 	"type": "module",
 	"exports": "./src/index.ts",
 	"scripts": {

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@roo-code/telemetry",
 	"description": "Roo Code telemetry service and clients.",
-	"private": true,
+	"version": "0.0.0",
 	"type": "module",
 	"exports": "./src/index.ts",
 	"scripts": {


### PR DESCRIPTION
### Description

For some reason private internal packages don't play nice with the changesets cli when bumping the version.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds version `0.0.0` to `cloud` and `telemetry` packages to resolve changesets CLI issues.
> 
>   - **Behavior**:
>     - Adds version `0.0.0` to `package.json` in `cloud` and `telemetry` packages to resolve issues with changesets CLI.
>   - **Changesets**:
>     - Adds `.changeset/heavy-snakes-flow.md` to document the patch change for `roo-cline`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 78389cdff2f6dfcc74edf385c527e391ef12170e. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->