### PR TITLE
Fix link to CONTRIBUTING.md in Feature Request Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,7 +7,7 @@ body:
       value: |
         **Thank you for proposing a detailed feature for Roo Code!**
 
-        This template is for submitting specific, actionable proposals that you or others intend to implement after discussion and approval. It's a key part of our [Issue-First Approach](../../CONTRIBUTING.md).
+        This template is for submitting specific, actionable proposals that you or others intend to implement after discussion and approval. It's a key part of our [Issue-First Approach](https://github.com/RooCodeInc/Roo-Code/blob/main/CONTRIBUTING.md).
 
         - **For general ideas or less defined suggestions**, please use [GitHub Discussions](https://github.com/RooCodeInc/Roo-Code/discussions/categories/feature-requests?discussions_q=is%3Aopen+category%3A%22Feature+Requests%22+sort%3Atop) first.
         - **Before submitting**, please search existing [GitHub Issues](https://github.com/RooCodeInc/Roo-Code/issues) and [Discussions](https://github.com/RooCodeInc/Roo-Code/discussions) to avoid duplicates.


### PR DESCRIPTION
The link to `CONTRIBUTING.md` was not working correctly. Probably because it was a relative link and the file in which it's been defined is a YAML file. Have used `https://github.com/RooCodeInc/Roo-Code/blob/main/CONTRIBUTING.md` now. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix broken link to `CONTRIBUTING.md` in `feature_request.yml` by using an absolute URL.
> 
>   - **Fix**:
>     - Update link to `CONTRIBUTING.md` in `feature_request.yml` from relative to absolute URL to ensure it works correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 6e98453223b98bc7db822757d9bd5f772482604d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->