### PR TITLE
releasing memory in apply diff

### DIFF
--- a/src/core/tools/applyDiffTool.ts
+++ b/src/core/tools/applyDiffTool.ts
@@ -87,7 +87,7 @@ export async function applyDiffTool(
 				return
 			}
 
-			const originalContent = await fs.readFile(absolutePath, "utf-8")
+			let originalContent: string | null = await fs.readFile(absolutePath, "utf-8")
 
 			// Apply the diff to the original content
 			const diffResult = (await cline.diffStrategy?.applyDiff(
@@ -98,6 +98,9 @@ export async function applyDiffTool(
 				success: false,
 				error: "No diff strategy available",
 			}
+
+			// Release the original content from memory as it's no longer needed
+			originalContent = null
 
 			if (!diffResult.success) {
 				cline.consecutiveMistakeCount++


### PR DESCRIPTION
### Related GitHub Issue
Closes: nothing, simply a memory optimization to avoid greyscreens.

### Description
This PR addresses a potential memory leak in the applyDiffTool by explicitly releasing the `originalContent` buffer after it's used for diff application.

### Type of Change
- [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize memory usage in `applyDiffTool` by releasing `originalContent` after use.
> 
>   - **Memory Optimization**:
>     - In `applyDiffTool` function in `applyDiffTool.ts`, release `originalContent` variable by setting it to `null` after diff application to prevent memory leaks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 95c005bb89b83da4a24162db2ad6d23b8fb1c1d3. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->