### PR TITLE
Fix typo in tool use prompt

### DIFF
--- a/src/core/prompts/__tests__/__snapshots__/system.test.ts.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system.test.ts.snap
@@ -25,7 +25,7 @@ Tool uses are formatted using XML-style tags. The tool name itself becomes the X
 ...
 </actual_tool_name>
 
-For example, to use the read_file tool:
+For example, to use the new_task tool:
 
 <new_task>
 <mode>code</mode>
@@ -519,7 +519,7 @@ Tool uses are formatted using XML-style tags. The tool name itself becomes the X
 ...
 </actual_tool_name>
 
-For example, to use the read_file tool:
+For example, to use the new_task tool:
 
 <new_task>
 <mode>code</mode>
@@ -1013,7 +1013,7 @@ Tool uses are formatted using XML-style tags. The tool name itself becomes the X
 ...
 </actual_tool_name>
 
-For example, to use the read_file tool:
+For example, to use the new_task tool:
 
 <new_task>
 <mode>code</mode>
@@ -1507,7 +1507,7 @@ Tool uses are formatted using XML-style tags. The tool name itself becomes the X
 ...
 </actual_tool_name>
 
-For example, to use the read_file tool:
+For example, to use the new_task tool:
 
 <new_task>
 <mode>code</mode>
@@ -2057,7 +2057,7 @@ Tool uses are formatted using XML-style tags. The tool name itself becomes the X
 ...
 </actual_tool_name>
 
-For example, to use the read_file tool:
+For example, to use the new_task tool:
 
 <new_task>
 <mode>code</mode>
@@ -2619,7 +2619,7 @@ Tool uses are formatted using XML-style tags. The tool name itself becomes the X
 ...
 </actual_tool_name>
 
-For example, to use the read_file tool:
+For example, to use the new_task tool:
 
 <new_task>
 <mode>code</mode>
@@ -3169,7 +3169,7 @@ Tool uses are formatted using XML-style tags. The tool name itself becomes the X
 ...
 </actual_tool_name>
 
-For example, to use the read_file tool:
+For example, to use the new_task tool:
 
 <new_task>
 <mode>code</mode>
@@ -3751,7 +3751,7 @@ Tool uses are formatted using XML-style tags. The tool name itself becomes the X
 ...
 </actual_tool_name>
 
-For example, to use the read_file tool:
+For example, to use the new_task tool:
 
 <new_task>
 <mode>code</mode>
@@ -4287,7 +4287,7 @@ Tool uses are formatted using XML-style tags. The tool name itself becomes the X
 ...
 </actual_tool_name>
 
-For example, to use the read_file tool:
+For example, to use the new_task tool:
 
 <new_task>
 <mode>code</mode>
@@ -4858,7 +4858,7 @@ Tool uses are formatted using XML-style tags. The tool name itself becomes the X
 ...
 </actual_tool_name>
 
-For example, to use the read_file tool:
+For example, to use the new_task tool:
 
 <new_task>
 <mode>code</mode>
@@ -5343,7 +5343,7 @@ Tool uses are formatted using XML-style tags. The tool name itself becomes the X
 ...
 </actual_tool_name>
 
-For example, to use the read_file tool:
+For example, to use the new_task tool:
 
 <new_task>
 <mode>code</mode>
@@ -5745,7 +5745,7 @@ Tool uses are formatted using XML-style tags. The tool name itself becomes the X
 ...
 </actual_tool_name>
 
-For example, to use the read_file tool:
+For example, to use the new_task tool:
 
 <new_task>
 <mode>code</mode>
@@ -6325,7 +6325,7 @@ Tool uses are formatted using XML-style tags. The tool name itself becomes the X
 ...
 </actual_tool_name>
 
-For example, to use the read_file tool:
+For example, to use the new_task tool:
 
 <new_task>
 <mode>code</mode>

--- a/src/core/prompts/sections/tool-use.ts
+++ b/src/core/prompts/sections/tool-use.ts
@@ -15,7 +15,7 @@ Tool uses are formatted using XML-style tags. The tool name itself becomes the X
 ...
 </actual_tool_name>
 
-For example, to use the read_file tool:
+For example, to use the new_task tool:
 
 <new_task>
 <mode>code</mode>


### PR DESCRIPTION
Fixes #4207

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes typo in tool use prompt by changing example tool name from `read_file` to `new_task`.
> 
>   - **Fixes**:
>     - Corrects example tool name from `read_file` to `new_task` in `system.test.ts.snap` and `tool-use.ts`.
>     - Affects multiple instances in `system.test.ts.snap` to ensure consistency in examples.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for f29d4f24383508e57d16ea0602f8b2a4767cd681. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->