### PR TITLE
fix: auto patch for file-watcher_93

### DIFF
--- a/src/services/code-index/manager.ts
+++ b/src/services/code-index/manager.ts
@@ -216,7 +216,11 @@ export class CodeIndexManager {
 	 */
 	public dispose(): void {
 		if (this._orchestrator) {
-			this.stopWatcher()
+			this.stopWatcher() // This calls _orchestrator.stopWatcher()
+			// Ensure orchestrator is fully cleaned up if it has a dispose method
+			if (typeof (this._orchestrator as any).dispose === "function") {
+				;(this._orchestrator as any).dispose()
+			}
 		}
 		this._stateManager.dispose()
 	}

--- a/src/services/code-index/orchestrator.ts
+++ b/src/services/code-index/orchestrator.ts
@@ -219,4 +219,13 @@ export class CodeIndexOrchestrator {
 	public get state(): IndexingState {
 		return this.stateManager.state
 	}
+
+	/**
+	 * Disposes of resources held by the orchestrator.
+	 */
+	public dispose(): void {
+		this.stopWatcher()
+		// Dispose other resources if any (e.g., if scanner or vectorStore had disposables not managed elsewhere)
+		// For now, stopWatcher handles the primary disposable (fileWatcher).
+	}
 }


### PR DESCRIPTION
# PR for FileWatcher Leak (file-watcher_93)

This PR addresses the potential `FileSystemWatcher` leak identified in `leak-report/guaranteed/file-watcher_93.md`.

## Description

The `FileWatcher` creates a `FileSystemWatcher` that might not be disposed if the `CodeIndexManager`'s disposal chain is interrupted. While `CodeIndexManager` is added to `context.subscriptions` (which should ensure its `dispose` method is called on extension deactivation), this patch aims to add robustness to the disposal process within the `CodeIndexOrchestrator` as a defensive measure.

The proposed fix involves ensuring `CodeIndexOrchestrator` has an explicit `dispose` method that reliably calls `stopWatcher()` (which in turn disposes the `FileWatcher`).

## Related Bug Report

https://github.com/RooCodeInc/Roo-Code/issues/4230

## Changes

- Added/Updated `dispose()` method in `src/services/code-index/orchestrator.ts` to ensure `stopWatcher()` is called.
- Ensured `CodeIndexManager.dispose()` calls the orchestrator's dispose method if available (this might be redundant but adds safety).
- [ ] Add/update unit tests if applicable to verify disposal chain.

## How to Test

1.  Verify that `CodeIndexManager.dispose()` is called upon extension deactivation.
2.  Trace the disposal calls: `CodeIndexManager.dispose()` -> `CodeIndexOrchestrator.stopWatcher()` (or `dispose()`) -> `FileWatcher.dispose()`.
3.  Simulate scenarios where extension deactivation might have errors to see if the watcher is still disposed of (this might be hard to test directly).