### PR TITLE
fix(RooTips): Clear setTimeout in useEffect cleanup to prevent state updates on unmounted components

### DIFF
--- a/webview-ui/src/components/welcome/RooTips.tsx
+++ b/webview-ui/src/components/welcome/RooTips.tsx
@@ -32,15 +32,21 @@ const RooTips = ({ cycle = false }: RooTipsProps) => {
 	useEffect(() => {
 		if (!cycle) return
 
+		let timeoutId: NodeJS.Timeout | undefined = undefined
 		const intervalId = setInterval(() => {
 			setIsFading(true) // Start fade out
-			setTimeout(() => {
+			timeoutId = setTimeout(() => {
 				setCurrentTipIndex((prevIndex) => (prevIndex + 1) % tips.length)
 				setIsFading(false) // Start fade in
 			}, 1000) // Fade duration
 		}, 11000) // 10s display + 1s fade
 
-		return () => clearInterval(intervalId) // Cleanup on unmount
+		return () => {
+			clearInterval(intervalId)
+			if (timeoutId) {
+				clearTimeout(timeoutId)
+			}
+		}
 	}, [cycle])
 
 	const currentTip = tips[currentTipIndex]


### PR DESCRIPTION
# PR for RooTips setTimeout Leak (RooTips_37)

This PR addresses the uncleaned `setTimeout` in the `RooTips` component, as identified in `leak-report/guaranteed/RooTips_37.md`.

## Description

The `useEffect` hook in `RooTips.tsx` correctly clears its `setInterval` but fails to clear a `setTimeout` that is scheduled within the interval's callback. If the component unmounts or the `cycle` prop changes while this `setTimeout` is pending, it can lead to attempts to update state on an unmounted component.

This patch implements the suggested fix from the leak report: storing the `timeoutId` from `setTimeout` and clearing it in the `useEffect` cleanup function.

## Related Bug Report

https://github.com/RooCodeInc/Roo-Code/issues/4234

## Changes

- Modified `webview-ui/src/components/welcome/RooTips.tsx`:
  - Declared `timeoutId` within the `useEffect` scope.
  - Assigned the ID returned by `setTimeout` to `timeoutId`.
  - Added `clearTimeout(timeoutId)` to the `useEffect` cleanup function.

## How to Test

1.  Render the `RooTips` component with `cycle={true}`.
2.  Allow the tip to cycle at least once so the `setTimeout` is scheduled.
3.  Unmount the `RooTips` component (or change the `cycle` prop) before the 1-second fade duration (controlled by the `setTimeout`) completes.
4.  Verify that no React warnings about state updates on unmounted components appear in the console.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes uncleaned `setTimeout` in `RooTips.tsx` to prevent state updates on unmounted components.
> 
>   - **Behavior**:
>     - Fixes uncleaned `setTimeout` in `RooTips.tsx` by storing `timeoutId` and clearing it in `useEffect` cleanup.
>     - Prevents state updates on unmounted components when `cycle` prop changes or component unmounts.
>   - **Testing**:
>     - Render `RooTips` with `cycle={true}` and unmount before `setTimeout` completes to ensure no React warnings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 8cb42dd244525d01a3441d47142a29752b790080. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

Closes: #4234