### PR TITLE
fix: Address memory leaks in ChatView component (ChatView_1113, ChatView_1236)

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -159,6 +159,13 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 		clineAskRef.current = clineAsk
 	}, [clineAsk])
 
+	useEffect(() => {
+		isMountedRef.current = true
+		return () => {
+			isMountedRef.current = false
+		}
+	}, [])
+
 	const isProfileDisabled = useMemo(
 		() => !!apiConfiguration && !ProfileValidator.isProfileAllowed(apiConfiguration, organizationAllowList),
 		[apiConfiguration, organizationAllowList],

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -60,6 +60,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 	{ isHidden, showAnnouncement, hideAnnouncement },
 	ref,
 ) => {
+	const isMountedRef = useRef(true)
 	const [audioBaseUri] = useState(() => {
 		const w = window as any
 		return w.AUDIO_BASE_URI || ""
@@ -1109,10 +1110,14 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 	)
 
 	useEffect(() => {
+		let timerId: NodeJS.Timeout | undefined
 		if (!disableAutoScrollRef.current) {
-			setTimeout(() => scrollToBottomSmooth(), 50)
-			// Don't cleanup since if visibleMessages.length changes it cancels.
-			// return () => clearTimeout(timer)
+			timerId = setTimeout(() => scrollToBottomSmooth(), 50)
+		}
+		return () => {
+			if (timerId) {
+				clearTimeout(timerId)
+			}
 		}
 	}, [groupedMessages.length, scrollToBottomSmooth])
 
@@ -1234,6 +1239,9 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 				// Add delay for write operations.
 				if (lastMessage.ask === "tool" && isWriteToolAction(lastMessage)) {
 					await new Promise((resolve) => setTimeout(resolve, writeDelayMs))
+					if (!isMountedRef.current) {
+						return
+					}
 				}
 
 				vscode.postMessage({ type: "askResponse", askResponse: "yesButtonClicked" })
@@ -1241,9 +1249,11 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 				// This is copied from `handlePrimaryButtonClick`, which we used
 				// to call from `autoApprove`. I'm not sure how many of these
 				// things are actually needed.
-				setSendingDisabled(true)
-				setClineAsk(undefined)
-				setEnableButtons(false)
+				if (isMountedRef.current) {
+					setSendingDisabled(true)
+					setClineAsk(undefined)
+					setEnableButtons(false)
+				}
 			}
 		}
 		autoApprove()


### PR DESCRIPTION
## PR Type

- [x] Bugfix

## Description

This PR addresses multiple potential memory leaks in the `ChatView` component (`webview-ui/src/components/chat/ChatView.tsx`) related to unmanaged asynchronous operations and `setTimeout` calls.

**1. Auto-Scroll Timeout Leak (ChatView_1113):**

- A `useEffect` hook (original line 1111) that schedules a `setTimeout` for `scrollToBottomSmooth()` did not clear the timeout.
- **Fix:** The timeout ID is now captured and cleared in the `useEffect`'s cleanup function.

**2. Auto-Approve Async Delay Leak (ChatView_1236):**

- The `autoApprove` function (called by `useEffect` at original line 939) uses an `await new Promise(setTimeout)` for `writeDelayMs`. Subsequent state updates could occur on an unmounted component.
- **Fix:** A `isMountedRef` is added to `ChatViewComponent` and checked before state updates within `autoApprove` after the delay. State updates are now grouped under a single `isMountedRef.current` check.

These changes ensure that asynchronous operations and timeouts are properly managed, preventing state updates on unmounted components and resolving potential memory leaks.

## Related Issue

https://github.com/RooCodeInc/Roo-Code/issues/4247

## Changes

- Modified `webview-ui/src/components/chat/ChatView.tsx`:
  - Added cleanup for the auto-scroll `setTimeout`.
  - Added `isMountedRef` and checks before state updates in the `autoApprove` function.

## Testing

**For Auto-Scroll Leak (ChatView_1113):**

1. Ensure `disableAutoScrollRef.current` is false.
2. Trigger rapid changes in `groupedMessages.length` or quickly unmount `ChatView` (e.g., close the webview).
3. Observe the console for "Can't perform a React state update on an unmounted component" warnings related to `scrollToBottomSmooth`. With the fix, this should not occur.

**For Auto-Approve Leak (ChatView_1236):**

1. Configure an operation that triggers `autoApprove` with a `writeDelayMs > 0` (e.g., an auto-approved file write operation).
2. Trigger the operation.
3. Quickly unmount the `ChatView` component before `writeDelayMs` elapses.
4. Observe the console for warnings related to `setSendingDisabled`, `setClineAsk`, or `setEnableButtons` on an unmounted component. With the fix, these should not occur.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes memory leaks in `ChatView.tsx` by managing asynchronous operations and timeouts, ensuring no state updates on unmounted components.
> 
>   - **Behavior**:
>     - Fixes memory leaks in `ChatView.tsx` by managing asynchronous operations and `setTimeout` calls.
>     - Auto-scroll `setTimeout` now cleared in `useEffect` cleanup.
>     - `autoApprove` function checks `isMountedRef` before state updates after delay.
>   - **State Management**:
>     - Adds `isMountedRef` to track component mount status.
>     - Groups state updates under `isMountedRef.current` check in `autoApprove`.
>   - **Testing**:
>     - Auto-scroll: Ensure no warnings on unmounted component during rapid `groupedMessages` changes.
>     - Auto-approve: Ensure no warnings on unmounted component when `writeDelayMs` elapses.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 480bf871eddf9af9e46f344b5128f3ca9290d4a5. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->