### PR TITLE
Cloud: add auth logs to the output channel

### DIFF
--- a/packages/cloud/src/CloudService.ts
+++ b/packages/cloud/src/CloudService.ts
@@ -18,10 +18,12 @@ export class CloudService {
 	private settingsService: SettingsService | null = null
 	private telemetryClient: TelemetryClient | null = null
 	private isInitialized = false
+	private log: (...args: unknown[]) => void
 
 	private constructor(context: vscode.ExtensionContext, callbacks: CloudServiceCallbacks) {
 		this.context = context
 		this.callbacks = callbacks
+		this.log = callbacks.log || console.log
 		this.authListener = () => {
 			this.callbacks.stateChanged?.()
 		}
@@ -33,7 +35,7 @@ export class CloudService {
 		}
 
 		try {
-			this.authService = await AuthService.createInstance(this.context)
+			this.authService = await AuthService.createInstance(this.context, this.log)
 
 			this.authService.on("inactive-session", this.authListener)
 			this.authService.on("active-session", this.authListener)
@@ -49,12 +51,12 @@ export class CloudService {
 			try {
 				TelemetryService.instance.register(this.telemetryClient)
 			} catch (error) {
-				console.warn("[CloudService] Failed to register TelemetryClient:", error)
+				this.log("[CloudService] Failed to register TelemetryClient:", error)
 			}
 
 			this.isInitialized = true
 		} catch (error) {
-			console.error("[CloudService] Failed to initialize:", error)
+			this.log("[CloudService] Failed to initialize:", error)
 			throw new Error(`Failed to initialize CloudService: ${error}`)
 		}
 	}

--- a/packages/cloud/src/__tests__/CloudService.test.ts
+++ b/packages/cloud/src/__tests__/CloudService.test.ts
@@ -135,7 +135,7 @@ describe("CloudService", () => {
 			const cloudService = await CloudService.createInstance(mockContext, callbacks)
 
 			expect(cloudService).toBeInstanceOf(CloudService)
-			expect(AuthService.createInstance).toHaveBeenCalledWith(mockContext)
+			expect(AuthService.createInstance).toHaveBeenCalledWith(mockContext, expect.any(Function))
 			expect(SettingsService.createInstance).toHaveBeenCalledWith(mockContext, expect.any(Function))
 		})
 

--- a/packages/cloud/src/types.ts
+++ b/packages/cloud/src/types.ts
@@ -1,3 +1,4 @@
 export interface CloudServiceCallbacks {
 	stateChanged?: () => void
+	log?: (...args: unknown[]) => void
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import { CloudService } from "@roo-code/cloud"
 import { TelemetryService, PostHogTelemetryClient } from "@roo-code/telemetry"
 
 import "./utils/path" // Necessary to have access to String.prototype.toPosix.
+import { createOutputChannelLogger, createDualLogger } from "./utils/outputChannelLogger"
 
 import { Package } from "./shared/package"
 import { formatLanguage } from "./shared/language"
@@ -68,9 +69,13 @@ export async function activate(context: vscode.ExtensionContext) {
 		console.warn("Failed to register PostHogTelemetryClient:", error)
 	}
 
+	// Create logger for cloud services
+	const cloudLogger = createDualLogger(createOutputChannelLogger(outputChannel))
+
 	// Initialize Roo Code Cloud service.
 	await CloudService.createInstance(context, {
 		stateChanged: () => ClineProvider.getVisibleInstance()?.postStateToWebview(),
+		log: cloudLogger,
 	})
 
 	// Initialize i18n for internationalization support

--- a/src/utils/__tests__/outputChannelLogger.test.ts
+++ b/src/utils/__tests__/outputChannelLogger.test.ts
@@ -1,0 +1,86 @@
+import * as vscode from "vscode"
+import { createOutputChannelLogger, createDualLogger } from "../outputChannelLogger"
+
+// Mock VSCode output channel
+const mockOutputChannel = {
+	appendLine: jest.fn(),
+} as unknown as vscode.OutputChannel
+
+describe("outputChannelLogger", () => {
+	beforeEach(() => {
+		jest.clearAllMocks()
+		// Clear console.log mock if it exists
+		if (jest.isMockFunction(console.log)) {
+			;(console.log as jest.Mock).mockClear()
+		}
+	})
+
+	describe("createOutputChannelLogger", () => {
+		it("should log strings to output channel", () => {
+			const logger = createOutputChannelLogger(mockOutputChannel)
+			logger("test message")
+
+			expect(mockOutputChannel.appendLine).toHaveBeenCalledWith("test message")
+		})
+
+		it("should log null values", () => {
+			const logger = createOutputChannelLogger(mockOutputChannel)
+			logger(null)
+
+			expect(mockOutputChannel.appendLine).toHaveBeenCalledWith("null")
+		})
+
+		it("should log undefined values", () => {
+			const logger = createOutputChannelLogger(mockOutputChannel)
+			logger(undefined)
+
+			expect(mockOutputChannel.appendLine).toHaveBeenCalledWith("undefined")
+		})
+
+		it("should log Error objects with stack trace", () => {
+			const logger = createOutputChannelLogger(mockOutputChannel)
+			const error = new Error("test error")
+			logger(error)
+
+			expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(expect.stringContaining("Error: test error"))
+		})
+
+		it("should log objects as JSON", () => {
+			const logger = createOutputChannelLogger(mockOutputChannel)
+			const obj = { key: "value", number: 42 }
+			logger(obj)
+
+			expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(JSON.stringify(obj, expect.any(Function), 2))
+		})
+
+		it("should handle multiple arguments", () => {
+			const logger = createOutputChannelLogger(mockOutputChannel)
+			logger("message", 42, { key: "value" })
+
+			expect(mockOutputChannel.appendLine).toHaveBeenCalledTimes(3)
+			expect(mockOutputChannel.appendLine).toHaveBeenNthCalledWith(1, "message")
+			expect(mockOutputChannel.appendLine).toHaveBeenNthCalledWith(2, "42")
+			expect(mockOutputChannel.appendLine).toHaveBeenNthCalledWith(
+				3,
+				JSON.stringify({ key: "value" }, expect.any(Function), 2),
+			)
+		})
+	})
+
+	describe("createDualLogger", () => {
+		it("should log to both output channel and console", () => {
+			const consoleSpy = jest.spyOn(console, "log").mockImplementation()
+			const outputChannelLogger = createOutputChannelLogger(mockOutputChannel)
+			const dualLogger = createDualLogger(outputChannelLogger)
+
+			dualLogger("test message", 42)
+
+			expect(mockOutputChannel.appendLine).toHaveBeenCalledTimes(2)
+			expect(mockOutputChannel.appendLine).toHaveBeenNthCalledWith(1, "test message")
+			expect(mockOutputChannel.appendLine).toHaveBeenNthCalledWith(2, "42")
+			expect(consoleSpy).toHaveBeenCalledWith("test message", 42)
+
+			consoleSpy.mockRestore()
+		})
+	})
+})

--- a/src/utils/outputChannelLogger.ts
+++ b/src/utils/outputChannelLogger.ts
@@ -1,0 +1,51 @@
+import * as vscode from "vscode"
+
+export type LogFunction = (...args: unknown[]) => void
+
+/**
+ * Creates a logging function that writes to a VSCode output channel
+ * Based on the outputChannelLog implementation from src/extension/api.ts
+ */
+export function createOutputChannelLogger(outputChannel: vscode.OutputChannel): LogFunction {
+	return (...args: unknown[]) => {
+		for (const arg of args) {
+			if (arg === null) {
+				outputChannel.appendLine("null")
+			} else if (arg === undefined) {
+				outputChannel.appendLine("undefined")
+			} else if (typeof arg === "string") {
+				outputChannel.appendLine(arg)
+			} else if (arg instanceof Error) {
+				outputChannel.appendLine(`Error: ${arg.message}\n${arg.stack || ""}`)
+			} else {
+				try {
+					outputChannel.appendLine(
+						JSON.stringify(
+							arg,
+							(key, value) => {
+								if (typeof value === "bigint") return `BigInt(${value})`
+								if (typeof value === "function") return `Function: ${value.name || "anonymous"}`
+								if (typeof value === "symbol") return value.toString()
+								return value
+							},
+							2,
+						),
+					)
+				} catch (error) {
+					outputChannel.appendLine(`[Non-serializable object: ${Object.prototype.toString.call(arg)}]`)
+				}
+			}
+		}
+	}
+}
+
+/**
+ * Creates a logging function that logs to both the output channel and console
+ * Following the pattern from src/extension/api.ts
+ */
+export function createDualLogger(outputChannelLog: LogFunction): LogFunction {
+	return (...args: unknown[]) => {
+		outputChannelLog(...args)
+		console.log(...args)
+	}
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add logging to Cloud service using `createOutputChannelLogger` and `createDualLogger` to log to both console and VSCode output channel.
> 
>   - **Logging**:
>     - Add `log` function to `AuthService` and `CloudService` for logging, defaulting to `console.log`.
>     - Use `createOutputChannelLogger` and `createDualLogger` in `outputChannelLogger.ts` to log to both console and VSCode output channel.
>   - **Initialization**:
>     - Pass `log` function to `AuthService.createInstance()` and `CloudService.createInstance()` in `extension.ts`.
>   - **Testing**:
>     - Add tests for `createOutputChannelLogger` and `createDualLogger` in `outputChannelLogger.test.ts`.
>     - Update `CloudService.test.ts` to check `AuthService.createInstance` is called with a logging function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 8000cc97067f27210c8210fefa99c316fb053b3c. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->