### PR TITLE
fix(modes): prevent missing role definition when selecting default mode

### DIFF
--- a/src/shared/modes.ts
+++ b/src/shared/modes.ts
@@ -171,17 +171,14 @@ export function findModeBySlug(slug: string, modes: readonly ModeConfig[] | unde
  * If neither is found, the default mode is used.
  */
 export function getModeSelection(mode: string, promptComponent?: PromptComponent, customModes?: ModeConfig[]) {
-	const customMode = findModeBySlug(mode, customModes)
-	const builtInMode = findModeBySlug(mode, modes)
-
-	const modeToUse = customMode || promptComponent || builtInMode
-
-	const roleDefinition = modeToUse?.roleDefinition || ""
-	const baseInstructions = modeToUse?.customInstructions || ""
+	const modeToUse =
+		findModeBySlug(mode, customModes) ||
+		(promptComponent?.roleDefinition ? promptComponent : undefined) ||
+		findModeBySlug(mode, modes)
 
 	return {
-		roleDefinition,
-		baseInstructions,
+		roleDefinition: modeToUse?.roleDefinition || "",
+		baseInstructions: modeToUse?.customInstructions || "",
 	}
 }
 


### PR DESCRIPTION
### Related GitHub Issue

Closes: #4285

### Description

- Previously, `getModeSelection` could pick `promptComponent` as the active mode even if it lacked a `roleDefinition`.
- This resulted in an empty `roleDefinition` being returned, overriding potentially valid role definitions from built-in modes.
- The logic now only considers `promptComponent` if it provides a `roleDefinition`, ensuring that a proper role definition is always selected if available from custom, prompt, or built-in modes.

### Test Procedure

Same as the Issue: #4285 

### Type of Change

<!-- Mark all applicable boxes with an 'x'. -->

- [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [ ] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [x] **Testing**:
    - [x] New and/or updated tests have been added to cover my changes.
    - [x] All tests pass locally (`npm test`).
    - [x] The application builds successfully with my changes.
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

_BEFORE FIX_
![Screenshot 2025-06-03 at 6 34 44 PM](https://github.com/user-attachments/assets/f8d36e2d-9f23-4cc9-8431-31d1c0065a6c)

_AFTER_FIX_
![Screenshot 2025-06-03 at 6 35 11 PM](https://github.com/user-attachments/assets/fe2b4bc2-9aec-4be6-9a6d-44c871b58f8d)

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [x] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `getModeSelection` in `modes.ts` to ensure `promptComponent` is only considered if it has a `roleDefinition`, preventing empty role definitions from overriding valid ones.
> 
>   - **Behavior**:
>     - Fixes `getModeSelection` in `modes.ts` to only consider `promptComponent` if it has a `roleDefinition`.
>     - Prevents empty `roleDefinition` from overriding valid ones from custom or built-in modes.
>   - **Misc**:
>     - Closes issue #4285.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 89ffd9bcce14efcce9aabc958126b2d5ffb1d10c. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->