### PR TITLE
Add proper error handling for API conversation history issues

### DIFF
--- a/src/core/task-persistence/apiMessages.ts
+++ b/src/core/task-persistence/apiMessages.ts
@@ -21,17 +21,34 @@ export async function readApiMessages({
 	const filePath = path.join(taskDir, GlobalFileNames.apiConversationHistory)
 
 	if (await fileExistsAtPath(filePath)) {
-		return JSON.parse(await fs.readFile(filePath, "utf8"))
+		const fileContent = await fs.readFile(filePath, "utf8")
+		const parsedData = JSON.parse(fileContent)
+		if (Array.isArray(parsedData) && parsedData.length === 0) {
+			console.error(
+				`[Roo-Debug] readApiMessages: Found API conversation history file, but it's empty. TaskId: ${taskId}, Path: ${filePath}`,
+			)
+		}
+		return parsedData
 	} else {
 		const oldPath = path.join(taskDir, "claude_messages.json")
 
 		if (await fileExistsAtPath(oldPath)) {
-			const data = JSON.parse(await fs.readFile(oldPath, "utf8"))
+			const fileContent = await fs.readFile(oldPath, "utf8")
+			const parsedData = JSON.parse(fileContent)
+			if (Array.isArray(parsedData) && parsedData.length === 0) {
+				console.error(
+					`[Roo-Debug] readApiMessages: Found OLD API conversation history file (claude_messages.json), but it's empty. TaskId: ${taskId}, Path: ${oldPath}`,
+				)
+			}
 			await fs.unlink(oldPath)
-			return data
+			return parsedData
 		}
 	}
 
+	// If we reach here, neither the new nor the old history file was found.
+	console.error(
+		`[Roo-Debug] readApiMessages: API conversation history file not found for taskId: ${taskId}. Expected at: ${filePath}`,
+	)
 	return []
 }
 


### PR DESCRIPTION
## Context

This PR adds detailed debug logging to the `readApiMessages` function to help diagnose "Unexpected: No existing API conversation history" errors.

## Implementation

Added logging for three scenarios:
1. When the API conversation history file exists but contains an empty array
2. When the old history file exists but contains an empty array
3. When neither history file is found (already implemented)

## How to Test

When encountering the "Unexpected: No existing API conversation history" error, check the Developer Tools console (Help > Toggle Developer Tools > Console tab) for debug messages with the format:
`[Roo-Debug] readApiMessages: ...`

These logs will show the taskId and file path, helping to diagnose the issue.

## Screenshots

N/A - Console logging only

## Get in Touch

Discord: KJ7LNW

 does not completely fix #4311 but it may provide debug output that may help us fix it from other users.



<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds detailed debug logging to `readApiMessages` in `apiMessages.ts` for diagnosing issues with API conversation history files.
> 
>   - **Debug Logging**:
>     - Adds detailed debug logging to `readApiMessages` in `apiMessages.ts` for diagnosing missing or empty API conversation history files.
>     - Logs when the history file exists but is empty, and when the old history file exists but is empty.
>     - Logs when neither the new nor old history file is found.
>   - **Error Handling**:
>     - Catches JSON parsing errors and logs them with taskId and file path details.
>     - Ensures old history file is not deleted if parsing fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 9d19c687f1e92cec0270cba06a1a0b5be5d4ab88. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->