### PR TITLE
Fix #4113: Move relPath & newContent checks in writeToFileTool earlie…

### DIFF
--- a/src/core/tools/__tests__/writeToFileTool.test.ts
+++ b/src/core/tools/__tests__/writeToFileTool.test.ts
@@ -399,4 +399,33 @@ describe("writeToFileTool", () => {
 			expect(mockCline.diffViewProvider.reset).toHaveBeenCalled()
 		})
 	})
+
+	describe("parameter validation", () => {
+		it("errors and resets on missing path parameter", async () => {
+			await executeWriteFileTool({ path: undefined })
+
+			expect(mockCline.consecutiveMistakeCount).toBe(1)
+			expect(mockCline.recordToolError).toHaveBeenCalledWith("write_to_file")
+			expect(mockCline.sayAndCreateMissingParamError).toHaveBeenCalledWith("write_to_file", "path")
+			expect(mockCline.diffViewProvider.reset).toHaveBeenCalled()
+		})
+
+		it("errors and resets on empty path parameter", async () => {
+			await executeWriteFileTool({ path: "" })
+
+			expect(mockCline.consecutiveMistakeCount).toBe(1)
+			expect(mockCline.recordToolError).toHaveBeenCalledWith("write_to_file")
+			expect(mockCline.sayAndCreateMissingParamError).toHaveBeenCalledWith("write_to_file", "path")
+			expect(mockCline.diffViewProvider.reset).toHaveBeenCalled()
+		})
+
+		it("errors and resets on missing content parameter", async () => {
+			await executeWriteFileTool({ content: undefined })
+
+			expect(mockCline.consecutiveMistakeCount).toBe(1)
+			expect(mockCline.recordToolError).toHaveBeenCalledWith("write_to_file")
+			expect(mockCline.sayAndCreateMissingParamError).toHaveBeenCalledWith("write_to_file", "content")
+			expect(mockCline.diffViewProvider.reset).toHaveBeenCalled()
+		})
+	})
 })

--- a/src/core/tools/writeToFileTool.ts
+++ b/src/core/tools/writeToFileTool.ts
@@ -26,9 +26,25 @@ export async function writeToFileTool(
 	let newContent: string | undefined = block.params.content
 	let predictedLineCount: number | undefined = parseInt(block.params.line_count ?? "0")
 
-	if (!relPath || newContent === undefined) {
+	if (block.partial && (!relPath || newContent === undefined)) {
 		// checking for newContent ensure relPath is complete
 		// wait so we can determine if it's a new file or editing an existing file
+		return
+	}
+
+	if (!relPath) {
+		cline.consecutiveMistakeCount++
+		cline.recordToolError("write_to_file")
+		pushToolResult(await cline.sayAndCreateMissingParamError("write_to_file", "path"))
+		await cline.diffViewProvider.reset()
+		return
+	}
+
+	if (newContent === undefined) {
+		cline.consecutiveMistakeCount++
+		cline.recordToolError("write_to_file")
+		pushToolResult(await cline.sayAndCreateMissingParamError("write_to_file", "content"))
+		await cline.diffViewProvider.reset()
 		return
 	}
 
@@ -96,22 +112,6 @@ export async function writeToFileTool(
 
 			return
 		} else {
-			if (!relPath) {
-				cline.consecutiveMistakeCount++
-				cline.recordToolError("write_to_file")
-				pushToolResult(await cline.sayAndCreateMissingParamError("write_to_file", "path"))
-				await cline.diffViewProvider.reset()
-				return
-			}
-
-			if (newContent === undefined) {
-				cline.consecutiveMistakeCount++
-				cline.recordToolError("write_to_file")
-				pushToolResult(await cline.sayAndCreateMissingParamError("write_to_file", "content"))
-				await cline.diffViewProvider.reset()
-				return
-			}
-
 			if (predictedLineCount === undefined) {
 				cline.consecutiveMistakeCount++
 				cline.recordToolError("write_to_file")


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

Closes: #4113

### Description

Fix tool writeToFile with missing or empty path or missing content. 
Checks earlier right after waiting for path & content parameters to be populated, so when block is non-partial, they immediately check instead of later.
This is required as alot of code after requires both to be valid.

Additional unit tests are added to cover these scenarios.

Future work should probably separate partial from non-partial-block logic and modularize the big function for reduced code-complexity.

### Test Procedure

- Run Tests
- Try tool-calling writeToFile with missing or empty path/content parameters (see screenshot)

### Type of Change

- [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [ ] ✨ **New Feature**
- [ ] 💥 **Breaking Change**
- [ ] ♻️ **Refactor**
- [ ] 💅 **Style**
- [ ] 📚 **Documentation**
- [ ] ⚙️ **Build/CI**
- [ ] 🧹 **Chore**

### Pre-Submission Checklist

- [x] **Issue Linked**
- [x] **Scope**
- [x] **Self-Review**
- [x] **Code Quality**
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [x] **Testing**
    - [x] New and/or updated tests have been added to cover my changes.
    - [x] All tests pass locally (`npm test`).
    - [x] The application builds successfully with my changes.
- [x] **Branch Hygiene**
- [x] **Documentation Impact**
- [x] **Changeset**
- [x] **Contribution Guidelines**

### Screenshots / Videos

![image](https://github.com/user-attachments/assets/884f61c5-bf40-4448-a8b6-70e9aa05b4f7)

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

N/A

### Get in Touch

Discord: `ruakij`
