### PR TITLE
Custom Tool descriptions

### DIFF
--- a/.changeset/swift-webs-peel.md
+++ b/.changeset/swift-webs-peel.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": minor
+---
+
+Add ability to Override tools descriptions system prompt. Example usage add your description in .roo/tools/read_file.md it will override default tool description it supports args param replacement with ${args.cwd}

--- a/src/core/prompts/__tests__/tool-overrides.test.ts
+++ b/src/core/prompts/__tests__/tool-overrides.test.ts
@@ -1,0 +1,209 @@
+import { getToolDescriptionsForMode } from "../tools/index"
+import { defaultModeSlug } from "../../../shared/modes"
+import * as fs from "fs/promises"
+import { toPosix } from "./utils"
+
+// Mock the fs/promises module
+jest.mock("fs/promises", () => ({
+	readFile: jest.fn(),
+	mkdir: jest.fn().mockResolvedValue(undefined),
+	access: jest.fn().mockResolvedValue(undefined),
+}))
+
+// Get the mocked fs module
+const mockedFs = fs as jest.Mocked<typeof fs>
+
+describe("Tool Override System", () => {
+	beforeEach(() => {
+		// Reset mocks before each test
+		jest.clearAllMocks()
+
+		// Default behavior: file doesn't exist
+		mockedFs.readFile.mockRejectedValue({ code: "ENOENT" })
+	})
+
+	it("should return default read_file tool description when no override file exists", async () => {
+		const toolDescriptions = await getToolDescriptionsForMode(
+			defaultModeSlug,
+			"test/workspace",
+			false, // supportsComputerUse
+			undefined, // codeIndexManager
+			undefined, // diffStrategy
+			undefined, // browserViewportSize
+			undefined, // mcpHub
+			undefined, // customModes
+			undefined, // experiments
+		)
+
+		// Should contain the default read_file description
+		expect(toolDescriptions).toContain("## read_file")
+		expect(toolDescriptions).toContain("Request to read the contents of one or more files")
+		expect(toolDescriptions).toContain("relative to the current workspace directory test/workspace")
+		expect(toolDescriptions).toContain("<read_file>")
+		expect(toolDescriptions).toContain("Examples:")
+	})
+
+	it("should use custom read_file tool description when override file exists", async () => {
+		// Mock the readFile to return content from an override file
+		const customReadFileDescription = `## read_file
+Description: Custom read file description for testing
+Parameters:
+- path: (required) Custom path description for \${args.cwd}
+- start_line: (optional) Custom start line description
+- end_line: (optional) Custom end line description
+Usage:
+<read_file>
+<path>Custom file path</path>
+</read_file>
+Custom example:
+<read_file>
+<path>custom-example.txt</path>
+</read_file>`
+
+		mockedFs.readFile.mockImplementation((filePath, options) => {
+			if (toPosix(filePath).includes(".roo/tools/read_file.md") && options === "utf-8") {
+				return Promise.resolve(customReadFileDescription)
+			}
+			return Promise.reject({ code: "ENOENT" })
+		})
+
+		const toolDescriptions = await getToolDescriptionsForMode(
+			defaultModeSlug,
+			"test/workspace",
+			false, // supportsComputerUse
+			undefined, // codeIndexManager
+			undefined, // diffStrategy
+			undefined, // browserViewportSize
+			undefined, // mcpHub
+			undefined, // customModes
+			undefined, // experiments
+		)
+
+		// Should contain the custom read_file description
+		expect(toolDescriptions).toContain("Custom read file description for testing")
+		expect(toolDescriptions).toContain("Custom path description for test/workspace")
+		expect(toolDescriptions).toContain("Custom example:")
+		expect(toolDescriptions).toContain("custom-example.txt")
+
+		// Should not contain the default description text
+		expect(toolDescriptions).not.toContain("Request to read the contents of one or more files")
+		expect(toolDescriptions).not.toContain("3. Reading lines 500-1000 of a CSV file:")
+	})
+
+	it("should interpolate args properties in override content", async () => {
+		// Mock the readFile to return content with args interpolation
+		const customReadFileDescription = `## read_file
+Description: Custom read file description with interpolated args
+Parameters:
+- path: (required) File path relative to workspace \${args.cwd}
+- workspace: Current workspace is \${args.cwd}
+Usage:
+<read_file>
+<path>File relative to \${args.cwd}</path>
+</read_file>`
+
+		mockedFs.readFile.mockImplementation((filePath, options) => {
+			if (toPosix(filePath).includes(".roo/tools/read_file.md") && options === "utf-8") {
+				return Promise.resolve(customReadFileDescription)
+			}
+			return Promise.reject({ code: "ENOENT" })
+		})
+
+		const toolDescriptions = await getToolDescriptionsForMode(
+			defaultModeSlug,
+			"test/workspace",
+			false, // supportsComputerUse
+			undefined, // codeIndexManager
+			undefined, // diffStrategy
+			undefined, // browserViewportSize
+			undefined, // mcpHub
+			undefined, // customModes
+			undefined, // experiments
+		)
+
+		// Should contain interpolated values
+		expect(toolDescriptions).toContain("File path relative to workspace test/workspace")
+		expect(toolDescriptions).toContain("Current workspace is test/workspace")
+		expect(toolDescriptions).toContain("File relative to test/workspace")
+
+		// Should not contain the placeholder text
+		expect(toolDescriptions).not.toContain("\${args.cwd}")
+	})
+
+	it("should return multiple tool descriptions including read_file", async () => {
+		const toolDescriptions = await getToolDescriptionsForMode(
+			defaultModeSlug,
+			"test/workspace",
+			false, // supportsComputerUse
+			undefined, // codeIndexManager
+			undefined, // diffStrategy
+			undefined, // browserViewportSize
+			undefined, // mcpHub
+			undefined, // customModes
+			undefined, // experiments
+		)
+
+		// Should contain multiple tools from the default mode
+		expect(toolDescriptions).toContain("# Tools")
+		expect(toolDescriptions).toContain("## read_file")
+		expect(toolDescriptions).toContain("## write_to_file")
+		expect(toolDescriptions).toContain("## list_files")
+		expect(toolDescriptions).toContain("## search_files")
+
+		// Tools should be separated by double newlines
+		const toolSections = toolDescriptions.split("\n\n")
+		expect(toolSections.length).toBeGreaterThan(1)
+	})
+
+	it("should handle empty override file gracefully", async () => {
+		// Mock the readFile to return empty content
+		mockedFs.readFile.mockImplementation((filePath, options) => {
+			if (toPosix(filePath).includes(".roo/tools/read_file.md") && options === "utf-8") {
+				return Promise.resolve("")
+			}
+			return Promise.reject({ code: "ENOENT" })
+		})
+
+		const toolDescriptions = await getToolDescriptionsForMode(
+			defaultModeSlug,
+			"test/workspace",
+			false, // supportsComputerUse
+			undefined, // codeIndexManager
+			undefined, // diffStrategy
+			undefined, // browserViewportSize
+			undefined, // mcpHub
+			undefined, // customModes
+			undefined, // experiments
+		)
+
+		// Should fall back to default description when override file is empty
+		expect(toolDescriptions).toContain("## read_file")
+		expect(toolDescriptions).toContain("Request to read the contents of one or more files")
+	})
+
+	it("should handle whitespace-only override file gracefully", async () => {
+		// Mock the readFile to return whitespace-only content
+		mockedFs.readFile.mockImplementation((filePath, options) => {
+			if (toPosix(filePath).includes(".roo/tools/read_file.md") && options === "utf-8") {
+				return Promise.resolve("   \n  \t  \n   ")
+			}
+			return Promise.reject({ code: "ENOENT" })
+		})
+
+		const toolDescriptions = await getToolDescriptionsForMode(
+			defaultModeSlug,
+			"test/workspace",
+			false, // supportsComputerUse
+			undefined, // codeIndexManager
+			undefined, // diffStrategy
+			undefined, // browserViewportSize
+			undefined, // mcpHub
+			undefined, // customModes
+			undefined, // experiments
+		)
+
+		// Should fall back to default description when override file contains only whitespace
+		expect(toolDescriptions).toContain("## read_file")
+		expect(toolDescriptions).toContain("Request to read the contents of one or more files")
+	})
+})

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -71,7 +71,7 @@ ${markdownFormattingSection()}
 
 ${getSharedToolUseSection()}
 
-${getToolDescriptionsForMode(
+${await getToolDescriptionsForMode(
 	mode,
 	cwd,
 	supportsComputerUse,


### PR DESCRIPTION
Add ability to Override tools descriptions system prompt. Example usage - add your description in .roo/tools/read_file.md it will override default tool description it supports args param replacement with "

<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: [#4010](https://github.com/RooCodeInc/Roo-Code/issues/4010)

### Description

Adds file based check in .roo/tools/
now it will look for {toolname.md} and if found replace current description with new one from file.
This allows users customize tool usage for specific models.
Some Models like GPT 4.1 and Sonnet 4 are great and require little guidance with tool usage so descriptions can be reduced drastically to achieve same effect.

### Test Procedure

1. Create toolname.md file in .roo/tools/

For ex. new file: 
 .roo/tools/read_file.md:
```
## read_file

Custom description

Description: Read file contents. Use for analyzing code, text files, or configs. Output includes line numbers. Extracts text from PDFs and DOCX. Not for other binary files.
Parameters: path (required) (relative to the current workspace directory ${args.cwd}), start_line (optional), end_line (optional)
```

2. navigate to roo =>Prompt
3. Click Preview System prompt
![image](https://github.com/user-attachments/assets/98f11b83-69ee-4f11-b4b9-e506745b4053)


### Type of Change

<!-- Mark all applicable boxes with an 'x'. -->

- [ ] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [x] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [x] **Testing**:
    - [x] New and/or updated tests have been added to cover my changes.
    - [x] All tests pass locally (`npm test`).
    - [x] The application builds successfully with my changes.
- [ ] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [ ] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [ ] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [ ] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

![image](https://github.com/user-attachments/assets/98f11b83-69ee-4f11-b4b9-e506745b4053)

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [x] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->
Needs new section for advanced users how to customize tool descriptions. Check Test Procedure similar steps how to change descriptions. This also needs needs Warning note that improper custom description will affect or even break ability to call tools.

### Additional Notes

 .roo/tools/read_file.md it will override default tool description
 this supports original args param replacement with data from args for any property

### Get in Touch

Roo discord: Basas