### PR TITLE
fix: Fix Auto Approve UI Closing #2579

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,12 @@ out
 out-*
 node_modules
 coverage/
-mock/
 
 .DS_Store
+
+# Webview UI specific ignores
+webview-ui/node_modules
+webview-ui/dist
 
 # IDEs
 .idea

--- a/webview-ui/src/components/chat/AutoApproveMenu.tsx
+++ b/webview-ui/src/components/chat/AutoApproveMenu.tsx
@@ -44,14 +44,14 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 
 	const toggles = useMemo(
 		() => ({
-			alwaysAllowReadOnly: alwaysAllowReadOnly,
-			alwaysAllowWrite: alwaysAllowWrite,
-			alwaysAllowExecute: alwaysAllowExecute,
-			alwaysAllowBrowser: alwaysAllowBrowser,
-			alwaysAllowMcp: alwaysAllowMcp,
-			alwaysAllowModeSwitch: alwaysAllowModeSwitch,
-			alwaysAllowSubtasks: alwaysAllowSubtasks,
-			alwaysApproveResubmit: alwaysApproveResubmit,
+			alwaysAllowReadOnly,
+			alwaysAllowWrite,
+			alwaysAllowExecute,
+			alwaysAllowBrowser,
+			alwaysAllowMcp,
+			alwaysAllowModeSwitch,
+			alwaysAllowSubtasks,
+			alwaysApproveResubmit,
 		}),
 		[
 			alwaysAllowReadOnly,
@@ -65,10 +65,9 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 		],
 	)
 
-	// Use the centralized auto-approve state hook
-	const { hasAnyAutoApprovedAction, updateAutoApprovalState, handleMasterToggle } = useAutoApproveState({
-		toggles,
-		setters: {
+	// Memoize setters object to prevent recreating it on every render
+	const setters = useMemo(
+		() => ({
 			setAlwaysAllowReadOnly,
 			setAlwaysAllowWrite,
 			setAlwaysAllowExecute,
@@ -78,7 +77,24 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 			setAlwaysAllowSubtasks,
 			setAlwaysApproveResubmit,
 			setAutoApprovalEnabled,
-		},
+		}),
+		[
+			setAlwaysAllowReadOnly,
+			setAlwaysAllowWrite,
+			setAlwaysAllowExecute,
+			setAlwaysAllowBrowser,
+			setAlwaysAllowMcp,
+			setAlwaysAllowModeSwitch,
+			setAlwaysAllowSubtasks,
+			setAlwaysApproveResubmit,
+			setAutoApprovalEnabled,
+		],
+	)
+
+	// Use the centralized auto-approve state hook
+	const { hasAnyAutoApprovedAction, updateAutoApprovalState, handleMasterToggle } = useAutoApproveState({
+		toggles,
+		setters,
 	})
 
 	const displayedAutoApproveText = useMemo(() => {

--- a/webview-ui/src/components/chat/AutoApproveMenu.tsx
+++ b/webview-ui/src/components/chat/AutoApproveMenu.tsx
@@ -43,6 +43,7 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 		(key: AutoApproveSetting, value: boolean) => {
 			vscode.postMessage({ type: key, bool: value })
 
+			// Update the specific setting
 			switch (key) {
 				case "alwaysAllowReadOnly":
 					setAlwaysAllowReadOnly(value)
@@ -69,6 +70,29 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 					setAlwaysApproveResubmit(value)
 					break
 			}
+
+			// After updating the specific setting, check if any action is now enabled.
+			// If so, ensure autoApprovalEnabled is true.
+			// This needs to be done after the state updates, so we'll use a temporary check
+			// or re-evaluate the `toggles` object.
+			// For simplicity, we'll assume the `toggles` state will reflect the change
+			// in the next render cycle, and we can force autoApprovalEnabled to true
+			// if any action is being enabled.
+			if (value === true) {
+				setAutoApprovalEnabled(true)
+				vscode.postMessage({ type: "autoApprovalEnabled", bool: true })
+			} else {
+				// If an action is being disabled, check if all are now disabled.
+				// If so, set autoApprovalEnabled to false.
+				// This requires re-evaluating the state of all toggles *after* the current one is set.
+				// A more robust solution would involve passing the updated `toggles` object
+				// or re-calculating `hasAnyAutoApprovedAction` here.
+				// For now, let's rely on the `hasAnyAutoApprovedAction` memoized value
+				// which will update on the next render.
+				// If the user unchecks the last enabled option, autoApprovalEnabled should become false.
+				// This logic is already handled by the main checkbox's disabled state in the collapsed view.
+				// So, we only need to ensure it turns ON when an individual is turned ON.
+			}
 		},
 		[
 			setAlwaysAllowReadOnly,
@@ -79,6 +103,7 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 			setAlwaysAllowModeSwitch,
 			setAlwaysAllowSubtasks,
 			setAlwaysApproveResubmit,
+			setAutoApprovalEnabled, // Added setAutoApprovalEnabled to dependencies
 		],
 	)
 
@@ -107,10 +132,17 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 		],
 	)
 
-	const enabledActionsList = Object.entries(toggles)
-		.filter(([_key, value]) => !!value)
-		.map(([key]) => t(autoApproveSettingsConfig[key as AutoApproveSetting].labelKey))
-		.join(", ")
+	const hasAnyAutoApprovedAction = useMemo(() => Object.values(toggles).some((value) => !!value), [toggles])
+
+	const displayedAutoApproveText = useMemo(() => {
+		if (autoApprovalEnabled && hasAnyAutoApprovedAction) {
+			return Object.entries(toggles)
+				.filter(([_key, value]) => !!value)
+				.map(([key]) => t(autoApproveSettingsConfig[key as AutoApproveSetting].labelKey))
+				.join(", ")
+		}
+		return t("chat:autoApprove.none")
+	}, [autoApprovalEnabled, hasAnyAutoApprovedAction, toggles, t])
 
 	const handleOpenSettings = useCallback(
 		() =>
@@ -140,9 +172,10 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 				onClick={toggleExpanded}>
 				<div onClick={(e) => e.stopPropagation()}>
 					<VSCodeCheckbox
-						checked={autoApprovalEnabled ?? false}
+						checked={autoApprovalEnabled && hasAnyAutoApprovedAction}
+						disabled={!hasAnyAutoApprovedAction}
 						onChange={() => {
-							const newValue = !(autoApprovalEnabled ?? false)
+							const newValue = !(autoApprovalEnabled && hasAnyAutoApprovedAction)
 							setAutoApprovalEnabled(newValue)
 							vscode.postMessage({ type: "autoApprovalEnabled", bool: newValue })
 						}}
@@ -172,7 +205,7 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 							flex: 1,
 							minWidth: 0,
 						}}>
-						{enabledActionsList || t("chat:autoApprove.none")}
+						{displayedAutoApproveText}
 					</span>
 					<span
 						className={`codicon codicon-chevron-${isExpanded ? "down" : "right"}`}
@@ -199,7 +232,11 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 						/>
 					</div>
 
-					<AutoApproveToggle {...toggles} onToggle={onAutoApproveToggle} />
+					<AutoApproveToggle
+						{...toggles}
+						onToggle={onAutoApproveToggle}
+						isOverallApprovalEnabled={autoApprovalEnabled}
+					/>
 
 					{/* Auto-approve API request count limit input row inspired by Cline */}
 					<div

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react"
-import { useDeepCompareEffect, useEvent, useMount } from "react-use"
+import { useEvent, useMount } from "react-use"
 import debounce from "debounce"
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso"
 import removeMd from "remove-markdown"
@@ -215,7 +215,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 		vscode.postMessage({ type: "playTts", text })
 	}
 
-	useDeepCompareEffect(() => {
+	useEffect(() => {
 		// if last message is an ask, show user ask UI
 		// if user finished a task, then start a new task with a new conversation history since in this moment that the extension is waiting for user response, the user could close the extension and the conversation history would be lost.
 		// basically as long as a task is active, the conversation history will be persisted
@@ -390,7 +390,8 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 					break
 			}
 		}
-	}, [lastMessage, secondLastMessage])
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- isAutoApproved is defined later in the file
+	}, [lastMessage, secondLastMessage, t, playSound])
 
 	useEffect(() => {
 		if (messages.length === 0) {

--- a/webview-ui/src/components/chat/__tests__/AutoApproveMenu.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/AutoApproveMenu.spec.tsx
@@ -1,0 +1,322 @@
+import React from "react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import AutoApproveMenu from "../AutoApproveMenu"
+import { useExtensionState } from "@src/context/ExtensionStateContext"
+import { vscode } from "@src/utils/vscode"
+
+// Mock dependencies
+jest.mock("@src/context/ExtensionStateContext")
+jest.mock("@src/utils/vscode", () => ({
+	vscode: {
+		postMessage: jest.fn(),
+	},
+}))
+
+jest.mock("@src/i18n/TranslationContext", () => ({
+	useAppTranslation: () => ({
+		t: jest.fn((key: string) => {
+			const translations: Record<string, string> = {
+				"chat:autoApprove.title": "Auto Approve",
+				"chat:autoApprove.none": "None",
+				"chat:autoApprove.description": "Auto-approve certain actions",
+				"settings:autoApprove.readOnly.label": "Read-only",
+				"settings:autoApprove.write.label": "Write files",
+				"settings:autoApprove.execute.label": "Execute",
+				"settings:autoApprove.browser.label": "Browser",
+				"settings:autoApprove.mcp.label": "MCP",
+				"settings:autoApprove.modeSwitch.label": "Mode Switch",
+				"settings:autoApprove.subtasks.label": "Subtasks",
+				"settings:autoApprove.retry.label": "Retry",
+				"settings:autoApprove.apiRequestLimit.title": "API Request Limit",
+				"settings:autoApprove.apiRequestLimit.unlimited": "Unlimited",
+				"settings:autoApprove.apiRequestLimit.description": "Maximum number of API requests",
+			}
+			return translations[key] || key
+		}),
+	}),
+}))
+
+jest.mock("react-i18next", () => ({
+	Trans: ({ i18nKey, children }: { i18nKey?: string; children?: React.ReactNode }) => {
+		const translations: Record<string, string> = {
+			"chat:autoApprove.description": "Auto-approve certain actions",
+		}
+		return <div>{translations[i18nKey as string] || children}</div>
+	},
+}))
+
+// Mock useExtensionState
+const mockUseExtensionState = jest.mocked(useExtensionState)
+
+describe("AutoApproveMenu", () => {
+	const defaultState = {
+		autoApprovalEnabled: false,
+		alwaysAllowReadOnly: false,
+		alwaysAllowWrite: false,
+		alwaysAllowExecute: false,
+		alwaysAllowBrowser: false,
+		alwaysAllowMcp: false,
+		alwaysAllowModeSwitch: false,
+		alwaysAllowSubtasks: false,
+		alwaysApproveResubmit: false,
+		allowedMaxRequests: undefined,
+	}
+
+	const mockSetters = {
+		setAutoApprovalEnabled: jest.fn(),
+		setAlwaysAllowReadOnly: jest.fn(),
+		setAlwaysAllowWrite: jest.fn(),
+		setAlwaysAllowExecute: jest.fn(),
+		setAlwaysAllowBrowser: jest.fn(),
+		setAlwaysAllowMcp: jest.fn(),
+		setAlwaysAllowModeSwitch: jest.fn(),
+		setAlwaysAllowSubtasks: jest.fn(),
+		setAlwaysApproveResubmit: jest.fn(),
+		setAllowedMaxRequests: jest.fn(),
+	}
+
+	beforeEach(() => {
+		jest.clearAllMocks()
+		mockUseExtensionState.mockReturnValue({
+			...defaultState,
+			...mockSetters,
+		} as any)
+	})
+
+	describe("Initial state", () => {
+		it("should show 'None' when no auto-approve settings are enabled", () => {
+			render(<AutoApproveMenu />)
+			expect(screen.getByText("None")).toBeInTheDocument()
+		})
+
+		it("should have unchecked main checkbox when no settings are enabled", () => {
+			render(<AutoApproveMenu />)
+			const mainCheckbox = screen.getByRole("checkbox")
+			expect(mainCheckbox).not.toBeChecked()
+		})
+	})
+
+	describe("Individual toggle enables main checkbox", () => {
+		it("should enable main checkbox when first individual toggle is enabled", async () => {
+			const { rerender } = render(<AutoApproveMenu />)
+
+			// Initially unchecked
+			expect(screen.getByRole("checkbox")).not.toBeChecked()
+
+			// Simulate enabling read-only toggle
+			mockUseExtensionState.mockReturnValue({
+				...defaultState,
+				alwaysAllowReadOnly: true,
+				...mockSetters,
+			} as any)
+
+			rerender(<AutoApproveMenu />)
+
+			// Main checkbox should now be checked
+			expect(screen.getByRole("checkbox")).toBeChecked()
+			expect(screen.getByText("Read-only")).toBeInTheDocument()
+		})
+
+		it("should show enabled actions in display text", () => {
+			mockUseExtensionState.mockReturnValue({
+				...defaultState,
+				alwaysAllowReadOnly: true,
+				alwaysAllowWrite: true,
+				...mockSetters,
+			} as any)
+
+			render(<AutoApproveMenu />)
+
+			expect(screen.getByText("Read-only, Write files")).toBeInTheDocument()
+		})
+	})
+
+	describe("Main checkbox toggle behavior", () => {
+		it("should enable all toggles when main checkbox is clicked (none enabled)", async () => {
+			render(<AutoApproveMenu />)
+
+			const mainCheckbox = screen.getByRole("checkbox")
+			fireEvent.click(mainCheckbox)
+
+			// Should call setters for all individual toggles with true
+			await waitFor(() => {
+				expect(mockSetters.setAlwaysAllowReadOnly).toHaveBeenCalledWith(true)
+				expect(mockSetters.setAlwaysAllowWrite).toHaveBeenCalledWith(true)
+				expect(mockSetters.setAlwaysAllowExecute).toHaveBeenCalledWith(true)
+				expect(mockSetters.setAlwaysAllowBrowser).toHaveBeenCalledWith(true)
+				expect(mockSetters.setAlwaysAllowMcp).toHaveBeenCalledWith(true)
+				expect(mockSetters.setAlwaysAllowModeSwitch).toHaveBeenCalledWith(true)
+				expect(mockSetters.setAlwaysAllowSubtasks).toHaveBeenCalledWith(true)
+				expect(mockSetters.setAlwaysApproveResubmit).toHaveBeenCalledWith(true)
+			})
+
+			// Should send vscode messages for all toggles
+			expect(vscode.postMessage).toHaveBeenCalledWith({ type: "alwaysAllowReadOnly", bool: true })
+			expect(vscode.postMessage).toHaveBeenCalledWith({ type: "alwaysAllowWrite", bool: true })
+			expect(vscode.postMessage).toHaveBeenCalledWith({ type: "autoApprovalEnabled", bool: true })
+		})
+
+		it("should disable all toggles when main checkbox is clicked (some enabled)", async () => {
+			mockUseExtensionState.mockReturnValue({
+				...defaultState,
+				alwaysAllowReadOnly: true,
+				alwaysAllowWrite: true,
+				...mockSetters,
+			} as any)
+
+			render(<AutoApproveMenu />)
+
+			const mainCheckbox = screen.getByRole("checkbox")
+			fireEvent.click(mainCheckbox)
+
+			// Should call setters for all individual toggles with false
+			await waitFor(() => {
+				expect(mockSetters.setAlwaysAllowReadOnly).toHaveBeenCalledWith(false)
+				expect(mockSetters.setAlwaysAllowWrite).toHaveBeenCalledWith(false)
+				expect(mockSetters.setAlwaysAllowExecute).toHaveBeenCalledWith(false)
+				expect(mockSetters.setAlwaysAllowBrowser).toHaveBeenCalledWith(false)
+				expect(mockSetters.setAlwaysAllowMcp).toHaveBeenCalledWith(false)
+				expect(mockSetters.setAlwaysAllowModeSwitch).toHaveBeenCalledWith(false)
+				expect(mockSetters.setAlwaysAllowSubtasks).toHaveBeenCalledWith(false)
+				expect(mockSetters.setAlwaysApproveResubmit).toHaveBeenCalledWith(false)
+			})
+
+			// Should send vscode messages for all toggles with false
+			expect(vscode.postMessage).toHaveBeenCalledWith({ type: "alwaysAllowReadOnly", bool: false })
+			expect(vscode.postMessage).toHaveBeenCalledWith({ type: "autoApprovalEnabled", bool: false })
+		})
+	})
+
+	describe("Bidirectional state synchronization", () => {
+		it("should disable main auto-approval when last individual toggle is disabled", async () => {
+			// Start with only one toggle enabled
+			mockUseExtensionState.mockReturnValue({
+				...defaultState,
+				alwaysAllowReadOnly: true,
+				...mockSetters,
+			} as any)
+
+			const { rerender } = render(<AutoApproveMenu />)
+
+			// Expand to show individual toggles
+			fireEvent.click(screen.getByText("Auto Approve"))
+
+			// Simulate disabling the last toggle
+			mockUseExtensionState.mockReturnValue({
+				...defaultState,
+				alwaysAllowReadOnly: false,
+				...mockSetters,
+			} as any)
+
+			rerender(<AutoApproveMenu />)
+
+			// Main checkbox should now be unchecked
+			expect(screen.getByRole("checkbox")).not.toBeChecked()
+			expect(screen.getByText("None")).toBeInTheDocument()
+		})
+
+		it("should enable main auto-approval when any individual toggle is enabled", async () => {
+			const { rerender } = render(<AutoApproveMenu />)
+
+			// Initially no toggles enabled
+			expect(screen.getByRole("checkbox")).not.toBeChecked()
+
+			// Simulate enabling one toggle
+			mockUseExtensionState.mockReturnValue({
+				...defaultState,
+				alwaysAllowExecute: true,
+				...mockSetters,
+			} as any)
+
+			rerender(<AutoApproveMenu />)
+
+			// Main checkbox should now be checked
+			expect(screen.getByRole("checkbox")).toBeChecked()
+			expect(screen.getByText("Execute")).toBeInTheDocument()
+		})
+	})
+
+	describe("Expandable behavior", () => {
+		it("should expand and show individual toggles when clicked", () => {
+			render(<AutoApproveMenu />)
+
+			// Initially collapsed - description should not be visible
+			expect(screen.queryByText(/Auto-approve certain actions/)).not.toBeInTheDocument()
+
+			// Click to expand
+			fireEvent.click(screen.getByText("Auto Approve"))
+
+			// Should show description (indicating expanded state)
+			expect(screen.getByText(/Auto-approve certain actions/)).toBeInTheDocument()
+		})
+
+		it("should show correct chevron direction when expanded/collapsed", () => {
+			render(<AutoApproveMenu />)
+
+			// Initially should show right chevron
+			expect(document.querySelector(".codicon-chevron-right")).toBeInTheDocument()
+
+			// Click to expand
+			fireEvent.click(screen.getByText("Auto Approve"))
+
+			// Should show down chevron
+			expect(document.querySelector(".codicon-chevron-down")).toBeInTheDocument()
+		})
+	})
+
+	describe("API request limit", () => {
+		it("should show unlimited placeholder when no limit is set", () => {
+			render(<AutoApproveMenu />)
+
+			// Expand to show settings
+			fireEvent.click(screen.getByText("Auto Approve"))
+
+			const input = screen.getByPlaceholderText("Unlimited")
+			expect(input).toHaveValue("")
+		})
+
+		it("should handle numeric input for API request limit", async () => {
+			render(<AutoApproveMenu />)
+
+			// Expand to show settings
+			fireEvent.click(screen.getByText("Auto Approve"))
+
+			const input = screen.getByPlaceholderText("Unlimited")
+			fireEvent.input(input, { target: { value: "10" } })
+
+			await waitFor(() => {
+				expect(mockSetters.setAllowedMaxRequests).toHaveBeenCalledWith(10)
+				expect(vscode.postMessage).toHaveBeenCalledWith({ type: "allowedMaxRequests", value: 10 })
+			})
+		})
+
+		it("should filter out non-numeric characters", async () => {
+			render(<AutoApproveMenu />)
+
+			// Expand to show settings
+			fireEvent.click(screen.getByText("Auto Approve"))
+
+			const input = screen.getByPlaceholderText("Unlimited") as HTMLInputElement
+
+			// Mock the input value behavior
+			let inputValue = "abc123def"
+			Object.defineProperty(input, "value", {
+				get() {
+					return inputValue
+				},
+				set(val) {
+					inputValue = val.replace(/[^0-9]/g, "")
+				},
+			})
+
+			// Simulate the input event with the filtered behavior
+			fireEvent.input(input, { target: { value: "abc123def" } })
+
+			await waitFor(() => {
+				expect(mockSetters.setAllowedMaxRequests).toHaveBeenCalledWith(123)
+				expect(vscode.postMessage).toHaveBeenCalledWith({ type: "allowedMaxRequests", value: 123 })
+			})
+		})
+	})
+})

--- a/webview-ui/src/components/settings/AutoApproveSettings.tsx
+++ b/webview-ui/src/components/settings/AutoApproveSettings.tsx
@@ -10,6 +10,7 @@ import { SetCachedStateField } from "./types"
 import { SectionHeader } from "./SectionHeader"
 import { Section } from "./Section"
 import { AutoApproveToggle } from "./AutoApproveToggle"
+import { useAutoApproveState } from "@/hooks/useAutoApproveState"
 
 type AutoApproveSettingsProps = HTMLAttributes<HTMLDivElement> & {
 	alwaysAllowReadOnly?: boolean
@@ -62,6 +63,24 @@ export const AutoApproveSettings = ({
 	const { t } = useAppTranslation()
 	const [commandInput, setCommandInput] = useState("")
 
+	// Prepare toggles object for the hook
+	const toggles = {
+		alwaysAllowReadOnly,
+		alwaysAllowWrite,
+		alwaysAllowBrowser,
+		alwaysApproveResubmit,
+		alwaysAllowMcp,
+		alwaysAllowModeSwitch,
+		alwaysAllowSubtasks,
+		alwaysAllowExecute,
+	}
+
+	// Use the centralized auto-approve state hook
+	const { hasAnyAutoApprovedAction, updateAutoApprovalState, handleMasterToggle } = useAutoApproveState({
+		toggles,
+		setCachedStateField,
+	})
+
 	const handleAddCommand = () => {
 		const currentCommands = allowedCommands ?? []
 
@@ -83,16 +102,27 @@ export const AutoApproveSettings = ({
 			</SectionHeader>
 
 			<Section>
+				{/* Master Auto-Approval Checkbox */}
+				<div className="flex flex-col gap-4 mb-6">
+					<div className="flex items-center gap-3">
+						<VSCodeCheckbox
+							checked={hasAnyAutoApprovedAction}
+							onChange={() => handleMasterToggle()}
+							data-testid="master-auto-approve-checkbox">
+							<span className="font-medium text-base">
+								{t("settings:autoApprove.masterToggle.label")}
+							</span>
+						</VSCodeCheckbox>
+					</div>
+					<div className="text-vscode-descriptionForeground text-sm pl-6">
+						{t("settings:autoApprove.masterToggle.description")}
+					</div>
+				</div>
+
 				<AutoApproveToggle
-					alwaysAllowReadOnly={alwaysAllowReadOnly}
-					alwaysAllowWrite={alwaysAllowWrite}
-					alwaysAllowBrowser={alwaysAllowBrowser}
-					alwaysApproveResubmit={alwaysApproveResubmit}
-					alwaysAllowMcp={alwaysAllowMcp}
-					alwaysAllowModeSwitch={alwaysAllowModeSwitch}
-					alwaysAllowSubtasks={alwaysAllowSubtasks}
-					alwaysAllowExecute={alwaysAllowExecute}
-					onToggle={(key, value) => setCachedStateField(key, value)}
+					{...toggles}
+					onToggle={updateAutoApprovalState}
+					isOverallApprovalEnabled={hasAnyAutoApprovedAction}
 				/>
 
 				{/* ADDITIONAL SETTINGS */}

--- a/webview-ui/src/components/settings/AutoApproveSettings.tsx
+++ b/webview-ui/src/components/settings/AutoApproveSettings.tsx
@@ -76,7 +76,7 @@ export const AutoApproveSettings = ({
 	}
 
 	// Use the centralized auto-approve state hook
-	const { hasAnyAutoApprovedAction, updateAutoApprovalState, handleMasterToggle } = useAutoApproveState({
+	const { updateAutoApprovalState } = useAutoApproveState({
 		toggles,
 		setCachedStateField,
 	})
@@ -102,28 +102,7 @@ export const AutoApproveSettings = ({
 			</SectionHeader>
 
 			<Section>
-				{/* Master Auto-Approval Checkbox */}
-				<div className="flex flex-col gap-4 mb-6">
-					<div className="flex items-center gap-3">
-						<VSCodeCheckbox
-							checked={hasAnyAutoApprovedAction}
-							onChange={() => handleMasterToggle()}
-							data-testid="master-auto-approve-checkbox">
-							<span className="font-medium text-base">
-								{t("settings:autoApprove.masterToggle.label")}
-							</span>
-						</VSCodeCheckbox>
-					</div>
-					<div className="text-vscode-descriptionForeground text-sm pl-6">
-						{t("settings:autoApprove.masterToggle.description")}
-					</div>
-				</div>
-
-				<AutoApproveToggle
-					{...toggles}
-					onToggle={updateAutoApprovalState}
-					isOverallApprovalEnabled={hasAnyAutoApprovedAction}
-				/>
+				<AutoApproveToggle {...toggles} onToggle={updateAutoApprovalState} />
 
 				{/* ADDITIONAL SETTINGS */}
 

--- a/webview-ui/src/components/settings/AutoApproveToggle.tsx
+++ b/webview-ui/src/components/settings/AutoApproveToggle.tsx
@@ -87,9 +87,10 @@ export const autoApproveSettingsConfig: Record<AutoApproveSetting, AutoApproveCo
 
 type AutoApproveToggleProps = AutoApproveToggles & {
 	onToggle: (key: AutoApproveSetting, value: boolean) => void
+	isOverallApprovalEnabled?: boolean // New prop
 }
 
-export const AutoApproveToggle = ({ onToggle, ...props }: AutoApproveToggleProps) => {
+export const AutoApproveToggle = ({ onToggle, isOverallApprovalEnabled, ...props }: AutoApproveToggleProps) => {
 	const { t } = useAppTranslation()
 
 	return (
@@ -99,22 +100,28 @@ export const AutoApproveToggle = ({ onToggle, ...props }: AutoApproveToggleProps
 				"[@media(min-width:600px)]:gap-4",
 				"[@media(min-width:800px)]:max-w-[800px]",
 			)}>
-			{Object.values(autoApproveSettingsConfig).map(({ key, descriptionKey, labelKey, icon, testId }) => (
-				<Button
-					key={key}
-					variant={props[key] ? "default" : "outline"}
-					onClick={() => onToggle(key, !props[key])}
-					title={t(descriptionKey || "")}
-					aria-label={t(labelKey)}
-					aria-pressed={!!props[key]}
-					data-testid={testId}
-					className={cn(" aspect-square h-[80px]", !props[key] && "opacity-50")}>
-					<span className={cn("flex flex-col items-center gap-1")}>
-						<span className={`codicon codicon-${icon}`} />
-						<span className="text-sm text-center">{t(labelKey)}</span>
-					</span>
-				</Button>
-			))}
+			{Object.values(autoApproveSettingsConfig).map(({ key, descriptionKey, labelKey, icon, testId }) => {
+				const isButtonActive = props[key] // This reflects the actual state of the individual toggle
+				const isButtonVisuallyEnabled = isOverallApprovalEnabled === false ? false : isButtonActive
+
+				return (
+					<Button
+						key={key}
+						variant={isButtonActive ? "default" : "outline"} // Variant always reflects its own state
+						onClick={() => onToggle(key, !props[key])}
+						title={t(descriptionKey || "")}
+						aria-label={t(labelKey)}
+						aria-pressed={!!isButtonActive}
+						data-testid={testId}
+						className={cn(" aspect-square h-[80px]", !isButtonVisuallyEnabled && "opacity-50")} // Opacity based on overall state
+					>
+						<span className={cn("flex flex-col items-center gap-1")}>
+							<span className={`codicon codicon-${icon}`} />
+							<span className="text-sm text-center">{t(labelKey)}</span>
+						</span>
+					</Button>
+				)
+			})}
 		</div>
 	)
 }

--- a/webview-ui/src/components/settings/__tests__/AutoApproveSettings.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/AutoApproveSettings.spec.tsx
@@ -1,0 +1,308 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { AutoApproveSettings } from "../AutoApproveSettings"
+
+// Mock UI components
+jest.mock("@/components/ui", () => ({
+	Button: ({ children, onClick, ...props }: any) => (
+		<button onClick={onClick} {...props}>
+			{children}
+		</button>
+	),
+	Input: ({ onChange, onKeyDown, ...props }: any) => <input onChange={onChange} onKeyDown={onKeyDown} {...props} />,
+	Slider: ({ value, onValueChange, ...props }: any) => (
+		<input
+			type="range"
+			value={value?.[0] || 0}
+			onChange={(e) => onValueChange?.([parseInt(e.target.value)])}
+			{...props}
+		/>
+	),
+}))
+
+// Mock dependencies
+jest.mock("@/utils/vscode", () => ({
+	vscode: {
+		postMessage: jest.fn(),
+	},
+}))
+
+jest.mock("@/i18n/TranslationContext", () => ({
+	useAppTranslation: () => ({
+		t: jest.fn((key: string) => {
+			const translations: Record<string, string> = {
+				"settings:sections.autoApprove": "Auto Approve",
+				"settings:autoApprove.description": "Auto-approve certain actions",
+				"settings:autoApprove.masterToggle.label": "Enable Auto-Approval",
+				"settings:autoApprove.masterToggle.description": "Enable or disable all auto-approval settings at once",
+				"settings:autoApprove.readOnly.label": "Read-only",
+				"settings:autoApprove.write.label": "Write files",
+				"settings:autoApprove.execute.label": "Execute",
+				"settings:autoApprove.browser.label": "Browser",
+				"settings:autoApprove.mcp.label": "MCP",
+				"settings:autoApprove.modeSwitch.label": "Mode Switch",
+				"settings:autoApprove.subtasks.label": "Subtasks",
+				"settings:autoApprove.retry.label": "Retry",
+				"settings:autoApprove.readOnly.outsideWorkspace.label": "Allow outside workspace",
+				"settings:autoApprove.readOnly.outsideWorkspace.description":
+					"Allow read-only operations outside the workspace",
+				"settings:autoApprove.write.outsideWorkspace.label": "Allow outside workspace",
+				"settings:autoApprove.write.outsideWorkspace.description":
+					"Allow write operations outside the workspace",
+				"settings:autoApprove.write.delayLabel": "Delay before writing files",
+				"settings:autoApprove.retry.delayLabel": "Delay before retrying requests",
+				"settings:autoApprove.execute.allowedCommands": "Allowed Commands",
+				"settings:autoApprove.execute.allowedCommandsDescription": "Commands that can be auto-approved",
+				"settings:autoApprove.execute.commandPlaceholder": "Enter command",
+				"settings:autoApprove.execute.addButton": "Add",
+			}
+			return translations[key] || key
+		}),
+	}),
+}))
+
+describe("AutoApproveSettings", () => {
+	const defaultProps = {
+		alwaysAllowReadOnly: false,
+		alwaysAllowReadOnlyOutsideWorkspace: false,
+		alwaysAllowWrite: false,
+		alwaysAllowWriteOutsideWorkspace: false,
+		writeDelayMs: 1000,
+		alwaysAllowBrowser: false,
+		alwaysApproveResubmit: false,
+		requestDelaySeconds: 30,
+		alwaysAllowMcp: false,
+		alwaysAllowModeSwitch: false,
+		alwaysAllowSubtasks: false,
+		alwaysAllowExecute: false,
+		allowedCommands: [],
+		setCachedStateField: jest.fn(),
+	}
+
+	beforeEach(() => {
+		jest.clearAllMocks()
+	})
+
+	describe("Master Auto-Approval Checkbox", () => {
+		it("should render master checkbox when no settings are enabled", () => {
+			render(<AutoApproveSettings {...defaultProps} />)
+
+			const masterCheckbox = screen.getByTestId("master-auto-approve-checkbox")
+			expect(masterCheckbox).toBeInTheDocument()
+			expect(masterCheckbox).not.toBeChecked()
+		})
+
+		it("should render master checkbox as checked when any setting is enabled", () => {
+			render(<AutoApproveSettings {...defaultProps} alwaysAllowReadOnly={true} />)
+
+			const masterCheckbox = screen.getByTestId("master-auto-approve-checkbox")
+			expect(masterCheckbox).toBeChecked()
+		})
+
+		it("should render master checkbox as checked when multiple settings are enabled", () => {
+			render(
+				<AutoApproveSettings
+					{...defaultProps}
+					alwaysAllowReadOnly={true}
+					alwaysAllowWrite={true}
+					alwaysAllowBrowser={true}
+				/>,
+			)
+
+			const masterCheckbox = screen.getByTestId("master-auto-approve-checkbox")
+			expect(masterCheckbox).toBeChecked()
+		})
+	})
+
+	describe("Individual toggles with master state", () => {
+		it("should show individual toggles with full opacity when master is enabled", () => {
+			render(<AutoApproveSettings {...defaultProps} alwaysAllowReadOnly={true} />)
+
+			const readOnlyToggle = screen.getByTestId("always-allow-readonly-toggle")
+			expect(readOnlyToggle).toBeInTheDocument()
+			expect(readOnlyToggle).not.toHaveClass("opacity-50")
+		})
+
+		it("should show individual toggles with reduced opacity when master is disabled", () => {
+			render(<AutoApproveSettings {...defaultProps} />)
+
+			const readOnlyToggle = screen.getByTestId("always-allow-readonly-toggle")
+			expect(readOnlyToggle).toBeInTheDocument()
+			expect(readOnlyToggle).toHaveClass("opacity-50")
+		})
+	})
+
+	describe("Additional settings visibility", () => {
+		it("should show read-only additional settings when read-only is enabled", () => {
+			render(<AutoApproveSettings {...defaultProps} alwaysAllowReadOnly={true} />)
+
+			expect(screen.getByTestId("always-allow-readonly-outside-workspace-checkbox")).toBeInTheDocument()
+		})
+
+		it("should show write additional settings when write is enabled", () => {
+			render(<AutoApproveSettings {...defaultProps} alwaysAllowWrite={true} />)
+
+			expect(screen.getByTestId("always-allow-write-outside-workspace-checkbox")).toBeInTheDocument()
+			expect(screen.getByTestId("write-delay-slider")).toBeInTheDocument()
+		})
+
+		it("should show retry additional settings when retry is enabled", () => {
+			render(<AutoApproveSettings {...defaultProps} alwaysApproveResubmit={true} />)
+
+			expect(screen.getByTestId("request-delay-slider")).toBeInTheDocument()
+		})
+
+		it("should show execute additional settings when execute is enabled", () => {
+			render(<AutoApproveSettings {...defaultProps} alwaysAllowExecute={true} />)
+
+			expect(screen.getByTestId("allowed-commands-heading")).toBeInTheDocument()
+			expect(screen.getByTestId("command-input")).toBeInTheDocument()
+			expect(screen.getByTestId("add-command-button")).toBeInTheDocument()
+		})
+	})
+
+	describe("Command management", () => {
+		it("should add a new command when add button is clicked", () => {
+			const setCachedStateField = jest.fn()
+			render(
+				<AutoApproveSettings
+					{...defaultProps}
+					alwaysAllowExecute={true}
+					setCachedStateField={setCachedStateField}
+				/>,
+			)
+
+			const commandInput = screen.getByTestId("command-input")
+			const addButton = screen.getByTestId("add-command-button")
+
+			fireEvent.change(commandInput, { target: { value: "npm test" } })
+			fireEvent.click(addButton)
+
+			expect(setCachedStateField).toHaveBeenCalledWith("allowedCommands", ["npm test"])
+		})
+
+		it("should add a new command when Enter key is pressed", () => {
+			const setCachedStateField = jest.fn()
+			render(
+				<AutoApproveSettings
+					{...defaultProps}
+					alwaysAllowExecute={true}
+					setCachedStateField={setCachedStateField}
+				/>,
+			)
+
+			const commandInput = screen.getByTestId("command-input")
+
+			fireEvent.change(commandInput, { target: { value: "npm build" } })
+			fireEvent.keyDown(commandInput, { key: "Enter" })
+
+			expect(setCachedStateField).toHaveBeenCalledWith("allowedCommands", ["npm build"])
+		})
+
+		it("should not add duplicate commands", () => {
+			const setCachedStateField = jest.fn()
+			render(
+				<AutoApproveSettings
+					{...defaultProps}
+					alwaysAllowExecute={true}
+					allowedCommands={["npm test"]}
+					setCachedStateField={setCachedStateField}
+				/>,
+			)
+
+			const commandInput = screen.getByTestId("command-input")
+			const addButton = screen.getByTestId("add-command-button")
+
+			fireEvent.change(commandInput, { target: { value: "npm test" } })
+			fireEvent.click(addButton)
+
+			expect(setCachedStateField).not.toHaveBeenCalled()
+		})
+
+		it("should remove commands when remove button is clicked", () => {
+			const setCachedStateField = jest.fn()
+			render(
+				<AutoApproveSettings
+					{...defaultProps}
+					alwaysAllowExecute={true}
+					allowedCommands={["npm test", "npm build"]}
+					setCachedStateField={setCachedStateField}
+				/>,
+			)
+
+			const removeButton = screen.getByTestId("remove-command-0")
+			fireEvent.click(removeButton)
+
+			expect(setCachedStateField).toHaveBeenCalledWith("allowedCommands", ["npm build"])
+		})
+	})
+
+	describe("Slider interactions", () => {
+		it("should update write delay when slider changes", () => {
+			const setCachedStateField = jest.fn()
+			render(
+				<AutoApproveSettings
+					{...defaultProps}
+					alwaysAllowWrite={true}
+					setCachedStateField={setCachedStateField}
+				/>,
+			)
+
+			const slider = screen.getByTestId("write-delay-slider")
+			fireEvent.change(slider, { target: { value: "2000" } })
+
+			expect(setCachedStateField).toHaveBeenCalledWith("writeDelayMs", 2000)
+		})
+
+		it("should update request delay when slider changes", () => {
+			const setCachedStateField = jest.fn()
+			render(
+				<AutoApproveSettings
+					{...defaultProps}
+					alwaysApproveResubmit={true}
+					setCachedStateField={setCachedStateField}
+				/>,
+			)
+
+			const slider = screen.getByTestId("request-delay-slider")
+			fireEvent.change(slider, { target: { value: "60" } })
+
+			expect(setCachedStateField).toHaveBeenCalledWith("requestDelaySeconds", 60)
+		})
+	})
+
+	describe("Checkbox interactions", () => {
+		it("should update outside workspace setting for read-only", () => {
+			const setCachedStateField = jest.fn()
+			render(
+				<AutoApproveSettings
+					{...defaultProps}
+					alwaysAllowReadOnly={true}
+					setCachedStateField={setCachedStateField}
+				/>,
+			)
+
+			const checkbox = screen.getByTestId("always-allow-readonly-outside-workspace-checkbox")
+			fireEvent.click(checkbox)
+
+			expect(setCachedStateField).toHaveBeenCalledWith("alwaysAllowReadOnlyOutsideWorkspace", true)
+		})
+
+		it("should update outside workspace setting for write", () => {
+			const setCachedStateField = jest.fn()
+			render(
+				<AutoApproveSettings
+					{...defaultProps}
+					alwaysAllowWrite={true}
+					setCachedStateField={setCachedStateField}
+				/>,
+			)
+
+			const checkbox = screen.getByTestId("always-allow-write-outside-workspace-checkbox")
+			fireEvent.click(checkbox)
+
+			expect(setCachedStateField).toHaveBeenCalledWith("alwaysAllowWriteOutsideWorkspace", true)
+		})
+	})
+})

--- a/webview-ui/src/components/settings/__tests__/AutoApproveSettings.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/AutoApproveSettings.spec.tsx
@@ -34,8 +34,6 @@ jest.mock("@/i18n/TranslationContext", () => ({
 			const translations: Record<string, string> = {
 				"settings:sections.autoApprove": "Auto Approve",
 				"settings:autoApprove.description": "Auto-approve certain actions",
-				"settings:autoApprove.masterToggle.label": "Enable Auto-Approval",
-				"settings:autoApprove.masterToggle.description": "Enable or disable all auto-approval settings at once",
 				"settings:autoApprove.readOnly.label": "Read-only",
 				"settings:autoApprove.write.label": "Write files",
 				"settings:autoApprove.execute.label": "Execute",
@@ -82,55 +80,6 @@ describe("AutoApproveSettings", () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks()
-	})
-
-	describe("Master Auto-Approval Checkbox", () => {
-		it("should render master checkbox when no settings are enabled", () => {
-			render(<AutoApproveSettings {...defaultProps} />)
-
-			const masterCheckbox = screen.getByTestId("master-auto-approve-checkbox")
-			expect(masterCheckbox).toBeInTheDocument()
-			expect(masterCheckbox).not.toBeChecked()
-		})
-
-		it("should render master checkbox as checked when any setting is enabled", () => {
-			render(<AutoApproveSettings {...defaultProps} alwaysAllowReadOnly={true} />)
-
-			const masterCheckbox = screen.getByTestId("master-auto-approve-checkbox")
-			expect(masterCheckbox).toBeChecked()
-		})
-
-		it("should render master checkbox as checked when multiple settings are enabled", () => {
-			render(
-				<AutoApproveSettings
-					{...defaultProps}
-					alwaysAllowReadOnly={true}
-					alwaysAllowWrite={true}
-					alwaysAllowBrowser={true}
-				/>,
-			)
-
-			const masterCheckbox = screen.getByTestId("master-auto-approve-checkbox")
-			expect(masterCheckbox).toBeChecked()
-		})
-	})
-
-	describe("Individual toggles with master state", () => {
-		it("should show individual toggles with full opacity when master is enabled", () => {
-			render(<AutoApproveSettings {...defaultProps} alwaysAllowReadOnly={true} />)
-
-			const readOnlyToggle = screen.getByTestId("always-allow-readonly-toggle")
-			expect(readOnlyToggle).toBeInTheDocument()
-			expect(readOnlyToggle).not.toHaveClass("opacity-50")
-		})
-
-		it("should show individual toggles with reduced opacity when master is disabled", () => {
-			render(<AutoApproveSettings {...defaultProps} />)
-
-			const readOnlyToggle = screen.getByTestId("always-allow-readonly-toggle")
-			expect(readOnlyToggle).toBeInTheDocument()
-			expect(readOnlyToggle).toHaveClass("opacity-50")
-		})
 	})
 
 	describe("Additional settings visibility", () => {

--- a/webview-ui/src/hooks/useAutoApproveState.ts
+++ b/webview-ui/src/hooks/useAutoApproveState.ts
@@ -1,0 +1,152 @@
+import { useCallback, useMemo } from "react"
+import { vscode } from "@/utils/vscode"
+import { AutoApproveSetting, autoApproveSettingsConfig } from "@/components/settings/AutoApproveToggle"
+
+type AutoApproveToggles = {
+	alwaysAllowReadOnly?: boolean
+	alwaysAllowWrite?: boolean
+	alwaysAllowBrowser?: boolean
+	alwaysApproveResubmit?: boolean
+	alwaysAllowMcp?: boolean
+	alwaysAllowModeSwitch?: boolean
+	alwaysAllowSubtasks?: boolean
+	alwaysAllowExecute?: boolean
+}
+
+type AutoApproveStateSetters = {
+	setAlwaysAllowReadOnly?: (value: boolean) => void
+	setAlwaysAllowWrite?: (value: boolean) => void
+	setAlwaysAllowBrowser?: (value: boolean) => void
+	setAlwaysApproveResubmit?: (value: boolean) => void
+	setAlwaysAllowMcp?: (value: boolean) => void
+	setAlwaysAllowModeSwitch?: (value: boolean) => void
+	setAlwaysAllowSubtasks?: (value: boolean) => void
+	setAlwaysAllowExecute?: (value: boolean) => void
+	setAutoApprovalEnabled?: (value: boolean) => void
+}
+
+type SetCachedStateFieldFunction = (key: any, value: any) => void
+
+interface UseAutoApproveStateProps {
+	toggles: AutoApproveToggles
+	setters?: AutoApproveStateSetters
+	setCachedStateField?: SetCachedStateFieldFunction
+}
+
+export const useAutoApproveState = ({ toggles, setters, setCachedStateField }: UseAutoApproveStateProps) => {
+	// Calculate if any auto-approve action is enabled
+	const hasAnyAutoApprovedAction = useMemo(() => Object.values(toggles).some((value) => !!value), [toggles])
+
+	// Update individual auto-approval setting
+	const updateAutoApprovalState = useCallback(
+		(key: AutoApproveSetting, value: boolean) => {
+			// Calculate updated toggles state
+			const updatedToggles = { ...toggles, [key]: value }
+			const hasAnyEnabled = Object.values(updatedToggles).some((v) => !!v)
+
+			// Send vscode message for individual setting
+			vscode.postMessage({ type: key, bool: value })
+
+			// Update main auto-approval setting based on new state if setter available
+			if (setters?.setAutoApprovalEnabled) {
+				const shouldEnableAutoApproval = hasAnyEnabled
+				setters.setAutoApprovalEnabled(shouldEnableAutoApproval)
+				vscode.postMessage({ type: "autoApprovalEnabled", bool: shouldEnableAutoApproval })
+			}
+
+			// Update the specific setting state using appropriate setter
+			if (setters) {
+				switch (key) {
+					case "alwaysAllowReadOnly":
+						setters.setAlwaysAllowReadOnly?.(value)
+						break
+					case "alwaysAllowWrite":
+						setters.setAlwaysAllowWrite?.(value)
+						break
+					case "alwaysAllowExecute":
+						setters.setAlwaysAllowExecute?.(value)
+						break
+					case "alwaysAllowBrowser":
+						setters.setAlwaysAllowBrowser?.(value)
+						break
+					case "alwaysAllowMcp":
+						setters.setAlwaysAllowMcp?.(value)
+						break
+					case "alwaysAllowModeSwitch":
+						setters.setAlwaysAllowModeSwitch?.(value)
+						break
+					case "alwaysAllowSubtasks":
+						setters.setAlwaysAllowSubtasks?.(value)
+						break
+					case "alwaysApproveResubmit":
+						setters.setAlwaysApproveResubmit?.(value)
+						break
+				}
+			} else if (setCachedStateField) {
+				// Fallback to setCachedStateField for settings page
+				setCachedStateField(key, value)
+			}
+		},
+		[toggles, setters, setCachedStateField],
+	)
+
+	// Handler for master checkbox toggle - toggles ALL individual settings
+	const handleMasterToggle = useCallback(
+		(enabled?: boolean) => {
+			const newValue = enabled !== undefined ? enabled : !hasAnyAutoApprovedAction
+
+			// Set all individual toggles to the new value
+			Object.keys(autoApproveSettingsConfig).forEach((key) => {
+				const settingKey = key as AutoApproveSetting
+				// Send vscode message for individual setting
+				vscode.postMessage({ type: settingKey, bool: newValue })
+
+				// Update individual setting state using appropriate setter
+				if (setters) {
+					switch (settingKey) {
+						case "alwaysAllowReadOnly":
+							setters.setAlwaysAllowReadOnly?.(newValue)
+							break
+						case "alwaysAllowWrite":
+							setters.setAlwaysAllowWrite?.(newValue)
+							break
+						case "alwaysAllowExecute":
+							setters.setAlwaysAllowExecute?.(newValue)
+							break
+						case "alwaysAllowBrowser":
+							setters.setAlwaysAllowBrowser?.(newValue)
+							break
+						case "alwaysAllowMcp":
+							setters.setAlwaysAllowMcp?.(newValue)
+							break
+						case "alwaysAllowModeSwitch":
+							setters.setAlwaysAllowModeSwitch?.(newValue)
+							break
+						case "alwaysAllowSubtasks":
+							setters.setAlwaysAllowSubtasks?.(newValue)
+							break
+						case "alwaysApproveResubmit":
+							setters.setAlwaysApproveResubmit?.(newValue)
+							break
+					}
+				} else if (setCachedStateField) {
+					// Fallback to setCachedStateField for settings page
+					setCachedStateField(settingKey, newValue)
+				}
+			})
+
+			// Update main auto-approval setting once at the end
+			if (setters?.setAutoApprovalEnabled) {
+				setters.setAutoApprovalEnabled(newValue)
+				vscode.postMessage({ type: "autoApprovalEnabled", bool: newValue })
+			}
+		},
+		[hasAnyAutoApprovedAction, setters, setCachedStateField],
+	)
+
+	return {
+		hasAnyAutoApprovedAction,
+		updateAutoApprovalState,
+		handleMasterToggle,
+	}
+}

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -68,6 +68,10 @@
 	},
 	"autoApprove": {
 		"description": "Allow Roo to automatically perform operations without requiring approval. Enable these settings only if you fully trust the AI and understand the associated security risks.",
+		"masterToggle": {
+			"label": "Enable Auto-Approval",
+			"description": "Enable or disable all auto-approval settings at once. When disabled, all individual auto-approval toggles are visually disabled but their saved states are preserved."
+		},
 		"readOnly": {
 			"label": "Read",
 			"description": "When enabled, Roo will automatically view directory contents and read files without requiring you to click the Approve button.",

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -68,10 +68,6 @@
 	},
 	"autoApprove": {
 		"description": "Allow Roo to automatically perform operations without requiring approval. Enable these settings only if you fully trust the AI and understand the associated security risks.",
-		"masterToggle": {
-			"label": "Enable Auto-Approval",
-			"description": "Enable or disable all auto-approval settings at once. When disabled, all individual auto-approval toggles are visually disabled but their saved states are preserved."
-		},
 		"readOnly": {
 			"label": "Read",
 			"description": "When enabled, Roo will automatically view directory contents and read files without requiring you to click the Approve button.",

--- a/webview-ui/src/setupTests.tsx
+++ b/webview-ui/src/setupTests.tsx
@@ -31,6 +31,14 @@ Object.defineProperty(window, "matchMedia", {
 	})),
 })
 
+// Mock ResizeObserver
+global.ResizeObserver = class ResizeObserver {
+	constructor(_cb: ResizeObserverCallback) {}
+	observe() {}
+	disconnect() {}
+	unobserve() {}
+}
+
 // Mock lucide-react icons globally using Proxy for dynamic icon handling
 jest.mock("lucide-react", () => {
 	return new Proxy(


### PR DESCRIPTION
### Related GitHub Issue

Closes: #2579

### Description

This pull request re-implements the changes from the original PR #4371.

This PR addresses issue #2579, which pointed out confusing UI behavior in the auto-approve feature. The changes ensure that the UI state is always clear and unambiguous to the user.

The primary changes are:

*   **`webview-ui/src/components/chat/AutoApproveMenu.tsx`**:
    *   The main "Auto-Approve" checkbox is now disabled when no individual actions are approved.
    *   Enabling an individual action now automatically enables the main auto-approve setting.
*   **`webview-ui/src/components/settings/AutoApproveToggle.tsx`**:
    *   The toggle buttons now correctly reflect their individual state while also visually indicating whether the overall auto-approve setting is enabled.
*   **`.gitignore`**:
    *   Added `webview-ui/node_modules` and `webview-ui/dist` to the ignore list.

These changes ensure that the user's preference is respected, improving the overall user experience.

### Test Procedure

1.  Go to the chat view.
2.  Open the Auto-approve menu.
3.  Verify the main checkbox is disabled when no options are selected.
4.  Select an option (e.g., "Read-Only").
5.  Verify the main checkbox becomes checked.
6.  Uncheck all options.
7.  Verify the main checkbox becomes unchecked and disabled.
8.  Collapse the menu with an option selected.
9.  Verify the checkbox is checked and the selected option is displayed.
10. Uncheck the checkbox in the collapsed state.
11. Verify the text changes to "None".

### Type of Change

-   [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
-   [ ] ✨ **New Feature**: Non-breaking change that adds functionality.
-   [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
-   [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
-   [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
-   [ ] 📚 **Documentation**: Updates to documentation files.
-   [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
-   [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

-   [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
-   [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
-   [x] **Self-Review**: I have performed a thorough self-review of my code.
-   [x] **Code Quality**:
    -   [x] My code adheres to the project's style guidelines.
    -   [x] There are no new linting errors or warnings (`npm run lint`).
    -   [x] All debug code (e.g., `console.log`) has been removed.
-   [x] **Testing**:
    -   [ ] New and/or updated tests have been added to cover my changes.
    -   [x] All tests pass locally (`npm test`).
    -   [x] The application builds successfully with my changes.
-   [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
-   [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
-   [x] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
-   [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos
![image](https://github.com/user-attachments/assets/967c904b-3a95-4bdd-bf4e-5e830a7eb4f4)
![image](https://github.com/user-attachments/assets/80a24985-b5f8-4065-8e8a-ba50fc7f6f18)
![image](https://github.com/user-attachments/assets/0e83ed22-994d-4e6f-be63-d17d4913fae4)
![image](https://github.com/user-attachments/assets/661cc871-9379-48e8-b537-8547f8501860)
![image](https://github.com/user-attachments/assets/82c6cd70-2029-4eda-bb48-9580ae31d64e)

### Documentation Updates

-   [x] No documentation updates are required.

### Additional Notes

This PR is a recreation of #4371 after the original branch was accidentally deleted.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes UI behavior in `AutoApproveMenu.tsx` and `AutoApproveToggle.tsx` to ensure clear auto-approve state indication and updates `.gitignore`.
> 
>   - **Behavior**:
>     - In `AutoApproveMenu.tsx`, the main "Auto-Approve" checkbox is disabled when no actions are approved and is automatically enabled when any action is selected.
>     - In `AutoApproveToggle.tsx`, toggle buttons reflect their individual state and indicate if the overall auto-approve setting is enabled.
>   - **Misc**:
>     - Added `webview-ui/node_modules` and `webview-ui/dist` to `.gitignore`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 629aee0362d112bf179b1b86d52719fe470427c3. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->