### PR TITLE
Fix "The thinking budget (52428) is invalid" Gemini 2.5 Pro Preview e…

### DIFF
--- a/.changeset/slick-knives-invent.md
+++ b/.changeset/slick-knives-invent.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix Gemini 2.5 Pro Preview thinking budget bug


### PR DESCRIPTION
### Description

Fixes #4399

I think this has caused issues before; if you check the "Thinking Budget" box and don't change the defaults then we don't end up persisting the custom `maxTokens` and `maxThinkingTokens` in your settings. We probably should fix this on the webview side, but we still need to handle the case where these values are `undefined` in the settings and default to the values that we display in the webview (in this case `DEFAULT_HYBRID_REASONING_MODEL_MAX_TOKENS` and `DEFAULT_HYBRID_REASONING_MODEL_THINKING_TOKENS`).
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes Gemini 2.5 Pro Preview thinking budget bug by defaulting to specified token values when settings are undefined and updates tests accordingly.
> 
>   - **Behavior**:
>     - Fixes thinking budget bug in Gemini 2.5 Pro Preview by defaulting to `DEFAULT_HYBRID_REASONING_MODEL_MAX_TOKENS` and `DEFAULT_HYBRID_REASONING_MODEL_THINKING_TOKENS` when settings are `undefined` in `model-params.ts`.
>     - Ensures reasoning budget does not exceed 80% of `maxTokens` and is at least 1024 tokens.
>   - **Tests**:
>     - Updates `model-params.spec.ts` to test new default behavior and clamping logic for reasoning budget and thinking tokens.
>     - Renames `model-params.test.ts` to `model-params.spec.ts` for consistency with testing framework.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e50c7ab1141698691f87ca6682394344f7251daf. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->