### PR TITLE
Add PostHog server configuration to MCP setup

### DIFF
--- a/.roo/mcp.json
+++ b/.roo/mcp.json
@@ -1,16 +1,29 @@
 {
-  "mcpServers": {
-    "github": {
-      "command": "docker",
-      "args": [
-        "run",
-        "-i",
-        "--rm",
-        "-e",
-        "GITHUB_PERSONAL_ACCESS_TOKEN=${env:GITHUB_PERSONAL_ACCESS_TOKEN}",
-        "ghcr.io/github/github-mcp-server"
-      ],
-      "alwaysAllow": []
-    }
-  }
+	"mcpServers": {
+		"github": {
+			"command": "docker",
+			"args": [
+				"run",
+				"-i",
+				"--rm",
+				"-e",
+				"GITHUB_PERSONAL_ACCESS_TOKEN=${env:GITHUB_PERSONAL_ACCESS_TOKEN}",
+				"ghcr.io/github/github-mcp-server"
+			],
+			"alwaysAllow": []
+		},
+		"posthog": {
+			"command": "npx",
+			"args": [
+				"-y",
+				"mcp-remote@latest",
+				"https://mcp.posthog.com/sse",
+				"--header",
+				"Authorization:${POSTHOG_AUTH_HEADER}"
+			],
+			"env": {
+				"POSTHOG_AUTH_HEADER": "Bearer ${env:POSTHOG_PERSONAL_ACCESS_TOKEN}"
+			}
+		}
+	}
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add PostHog server configuration to `.roo/mcp.json` using `npx` and environment variables.
> 
>   - **Configuration**:
>     - Adds `posthog` server configuration to `.roo/mcp.json`.
>     - Uses `npx` to run `mcp-remote@latest` with URL `https://mcp.posthog.com/sse`.
>     - Sets `Authorization` header using `POSTHOG_AUTH_HEADER`.
>     - Defines `POSTHOG_AUTH_HEADER` as `Bearer ${env:POSTHOG_PERSONAL_ACCESS_TOKEN}`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4b493d7b8b4f3ca9b2ca2e7926dfc2211f7dfa44. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->