### PR TITLE
Fix git clone in evals setup script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
 		"clean": "turbo clean --log-order grouped --output-logs new-only && rimraf dist out bin .vite-port .turbo",
 		"changeset:version": "cp CHANGELOG.md src/CHANGELOG.md && changeset version && cp -vf src/CHANGELOG.md .",
 		"knip": "knip --include files",
-		"update-contributors": "node scripts/update-contributors.js"
+		"update-contributors": "node scripts/update-contributors.js",
+		"evals": "docker compose -f packages/evals/docker-compose.yml --profile server --profile runner up --build --scale runner=0"
 	},
 	"devDependencies": {
 		"@changesets/cli": "^2.27.10",

--- a/packages/evals/scripts/setup.sh
+++ b/packages/evals/scripts/setup.sh
@@ -336,7 +336,7 @@ echo "✅ Done"
 
 if [[ ! -d "../../../evals" ]]; then
   echo -n "🔗 Cloning evals repository... "
-  git clone https://github.com/RooCodeInc/Roo-Code-Evals.git evals ../../../evals || exit 1
+  git clone https://github.com/RooCodeInc/Roo-Code-Evals.git ../../../evals || exit 1
   echo "✅ Done"
 else
   echo -n "🔄 Updating evals repository... "


### PR DESCRIPTION
### Description

Fix `git clone` command in evals setup script.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `git clone` command in `setup.sh` and add `evals` script in `package.json` for Docker management.
> 
>   - **Scripts**:
>     - Fix `git clone` command in `setup.sh` to clone into `../../../evals` instead of `evals ../../../evals`.
>     - Add `evals` script in `package.json` to manage Docker services for evals with `docker compose`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a9acf28eb5c3a061f4408038b3d20be0955a86ce. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->