### PR TITLE
Run evals on port 8080

### DIFF
--- a/apps/web-evals/package.json
+++ b/apps/web-evals/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"lint": "next lint",
 		"check-types": "tsc -b",
-		"dev": "scripts/check-services.sh && next dev",
+		"dev": "scripts/check-services.sh && next dev --port 8080",
 		"format": "prettier --write src",
 		"build": "next build",
 		"start": "next start"

--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -29,13 +29,13 @@ Start the evals service:
 docker compose -f packages/evals/docker-compose.yml --profile server --profile runner up --build --scale runner=0
 ```
 
-The initial build process can take a minute or two. Upon success you should see ouput indicating that a web service is running on [localhost:3000](http://localhost:3000/):
+The initial build process can take a minute or two. Upon success you should see ouput indicating that a web service is running on [localhost:8080](http://localhost:8080/):
 <img width="1182" alt="Screenshot 2025-06-05 at 12 05 38 PM" src="https://github.com/user-attachments/assets/34f25a59-1362-458c-aafa-25e13cdb2a7a" />
 
 Additionally, you'll find in Docker Desktop that database and redis services are running:
 <img width="1283" alt="Screenshot 2025-06-05 at 12 07 09 PM" src="https://github.com/user-attachments/assets/ad75d791-9cc7-41e3-8168-df7b21b49da2" />
 
-Navigate to [localhost:3000](http://localhost:3000/) in your browser and click the 🚀 button.
+Navigate to [localhost:8080](http://localhost:8080/) in your browser and click the 🚀 button.
 
 By default a evals run will run all programming exercises in [Roo Code Evals](https://github.com/RooCodeInc/Roo-Code-Evals) repository with the Claude Sonnet 4 model and default settings. For basic configuration you can specify the LLM to use and any subset of the exercises you'd like. For advanced configuration you can import a Roo Code settings file which will allow you to run the evals with Roo Code configured any way you'd like (this includes custom modes, a footgun prompt, etc).
 
@@ -67,7 +67,6 @@ The memory and CPU limits can be set from the "Resources" section of the Docker 
 To stop an evals run early you can simply stop the "controller" container using Docker Desktop. This will prevent any new task containers from being spawned. You can optionally stop any existing task containers immediately or let them finish their current tasks at which point they will exit.
 
 <img width="1302" alt="Screenshot 2025-06-06 at 9 00 41 AM" src="https://github.com/user-attachments/assets/a9d4725b-730c-441a-ba24-ac99f9599ced" />
-
 
 ## Advanced Usage / Debugging
 

--- a/packages/evals/docker-compose.yml
+++ b/packages/evals/docker-compose.yml
@@ -52,7 +52,7 @@ services:
             context: ../../
             dockerfile: packages/evals/Dockerfile.web
         ports:
-            - "3000:3000"
+            - "8080:3000"
         environment:
             - HOST_EXECUTION_METHOD=docker
         volumes:

--- a/packages/evals/scripts/setup.sh
+++ b/packages/evals/scripts/setup.sh
@@ -377,7 +377,7 @@ fi
 
 echo -e "\n🚀 You're ready to rock and roll! \n"
 
-if ! nc -z localhost 3000; then
+if ! nc -z localhost 8080; then
   read -p "🌐 Would you like to start the evals web app? (Y/n): " start_evals
 
   if [[ "$start_evals" =~ ^[Yy]|^$ ]]; then
@@ -386,5 +386,5 @@ if ! nc -z localhost 3000; then
     echo "💡 You can start it anytime with 'pnpm --filter @roo-code/web-evals dev'."
   fi
 else
-  echo "👟 The evals web app is running at http://localhost:3000"
+  echo "👟 The evals web app is running at http://localhost:8080"
 fi


### PR DESCRIPTION
### Description

Some people have conflicts on port 3000.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Change evals web app port from 3000 to 8080 to avoid conflicts, updating scripts, documentation, and Docker configurations accordingly.
> 
>   - **Behavior**:
>     - Change evals web app port from 3000 to 8080 in `package.json`, `docker-compose.yml`, and `setup.sh`.
>     - Update `README.md` to reflect new port 8080 for web service access.
>   - **Scripts**:
>     - Modify `dev` script in `package.json` to use `--port 8080`.
>     - Update port check in `setup.sh` to 8080.
>   - **Docker**:
>     - Change port mapping in `docker-compose.yml` from `3000:3000` to `8080:3000`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 618af52b17102ee3140698347cc01d00154f03dd. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->