### PR TITLE
Rate limit when starting a subtask

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
 		"dist": true // set this to false to include "dist" folder in search results
 	},
 	// Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-	"typescript.tsc.autoDetect": "off"
+	"typescript.tsc.autoDetect": "off",
+	"vitest.disableWorkspaceWarning": true
 }

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -144,6 +144,14 @@ export class Task extends EventEmitter<ClineEvents> {
 	private lastApiRequestTime?: number
 	private consecutiveAutoApprovedRequestsCount: number = 0
 
+	/**
+	 * Reset the global API request timestamp. This should only be used for testing.
+	 * @internal
+	 */
+	static resetGlobalApiRequestTime(): void {
+		Task.lastGlobalApiRequestTime = undefined
+	}
+
 	toolRepetitionDetector: ToolRepetitionDetector
 	rooIgnoreController?: RooIgnoreController
 	rooProtectedController?: RooProtectedController

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -141,7 +141,6 @@ export class Task extends EventEmitter<ClineEvents> {
 	readonly apiConfiguration: ProviderSettings
 	api: ApiHandler
 	private static lastGlobalApiRequestTime?: number
-	private lastApiRequestTime?: number
 	private consecutiveAutoApprovedRequestsCount: number = 0
 
 	/**
@@ -1685,11 +1684,9 @@ export class Task extends EventEmitter<ClineEvents> {
 			}
 		}
 
-		// Update last request time before making the request (both instance-level
-		// and global) so that subsequent requests — even from new subtasks — will
-		// honour the provider's rate-limit.
-		this.lastApiRequestTime = Date.now()
-		Task.lastGlobalApiRequestTime = this.lastApiRequestTime
+		// Update last request time before making the request so that subsequent
+		// requests — even from new subtasks — will honour the provider's rate-limit.
+		Task.lastGlobalApiRequestTime = Date.now()
 
 		const systemPrompt = await this.getSystemPrompt()
 		const { contextTokens } = this.getTokenUsage()

--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -30,34 +30,43 @@ vi.mock("execa", () => ({
 	execa: vi.fn(),
 }))
 
-vi.mock("fs/promises", () => ({
-	mkdir: vi.fn().mockResolvedValue(undefined),
-	writeFile: vi.fn().mockResolvedValue(undefined),
-	readFile: vi.fn().mockImplementation((filePath) => {
-		if (filePath.includes("ui_messages.json")) {
-			return Promise.resolve(JSON.stringify(mockMessages))
-		}
-		if (filePath.includes("api_conversation_history.json")) {
-			return Promise.resolve(
-				JSON.stringify([
-					{
-						role: "user",
-						content: [{ type: "text", text: "historical task" }],
-						ts: Date.now(),
-					},
-					{
-						role: "assistant",
-						content: [{ type: "text", text: "I'll help you with that task." }],
-						ts: Date.now(),
-					},
-				]),
-			)
-		}
-		return Promise.resolve("[]")
-	}),
-	unlink: vi.fn().mockResolvedValue(undefined),
-	rmdir: vi.fn().mockResolvedValue(undefined),
-}))
+vi.mock("fs/promises", async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, any>
+	const mockFunctions = {
+		mkdir: vi.fn().mockResolvedValue(undefined),
+		writeFile: vi.fn().mockResolvedValue(undefined),
+		readFile: vi.fn().mockImplementation((filePath) => {
+			if (filePath.includes("ui_messages.json")) {
+				return Promise.resolve(JSON.stringify(mockMessages))
+			}
+			if (filePath.includes("api_conversation_history.json")) {
+				return Promise.resolve(
+					JSON.stringify([
+						{
+							role: "user",
+							content: [{ type: "text", text: "historical task" }],
+							ts: Date.now(),
+						},
+						{
+							role: "assistant",
+							content: [{ type: "text", text: "I'll help you with that task." }],
+							ts: Date.now(),
+						},
+					]),
+				)
+			}
+			return Promise.resolve("[]")
+		}),
+		unlink: vi.fn().mockResolvedValue(undefined),
+		rmdir: vi.fn().mockResolvedValue(undefined),
+	}
+
+	return {
+		...actual,
+		...mockFunctions,
+		default: mockFunctions,
+	}
+})
 
 vi.mock("p-wait-for", () => ({
 	default: vi.fn().mockImplementation(async () => Promise.resolve()),

--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -18,6 +18,14 @@ import { MultiSearchReplaceDiffStrategy } from "../../diff/strategies/multi-sear
 import { MultiFileSearchReplaceDiffStrategy } from "../../diff/strategies/multi-file-search-replace"
 import { EXPERIMENT_IDS } from "../../../shared/experiments"
 
+// Mock delay before any imports that might use it
+vi.mock("delay", () => ({
+	__esModule: true,
+	default: vi.fn().mockResolvedValue(undefined),
+}))
+
+import delay from "delay"
+
 vi.mock("execa", () => ({
 	execa: vi.fn(),
 }))
@@ -866,6 +874,353 @@ describe("Cline", () => {
 					await cline.abortTask(true)
 					await task.catch(() => {})
 				})
+			})
+		})
+
+		describe("Subtask Rate Limiting", () => {
+			let mockProvider: any
+			let mockApiConfig: any
+			let mockDelay: ReturnType<typeof vi.fn>
+
+			beforeEach(() => {
+				vi.clearAllMocks()
+				// Reset the global timestamp before each test
+				Task.resetGlobalApiRequestTime()
+
+				mockApiConfig = {
+					apiProvider: "anthropic",
+					apiKey: "test-key",
+					rateLimitSeconds: 5,
+				}
+
+				mockProvider = {
+					context: {
+						globalStorageUri: { fsPath: "/test/storage" },
+					},
+					getState: vi.fn().mockResolvedValue({
+						apiConfiguration: mockApiConfig,
+					}),
+					say: vi.fn(),
+					postStateToWebview: vi.fn().mockResolvedValue(undefined),
+					postMessageToWebview: vi.fn().mockResolvedValue(undefined),
+					updateTaskHistory: vi.fn().mockResolvedValue(undefined),
+				}
+
+				// Get the mocked delay function
+				mockDelay = delay as ReturnType<typeof vi.fn>
+				mockDelay.mockClear()
+			})
+
+			afterEach(() => {
+				// Clean up the global state after each test
+				Task.resetGlobalApiRequestTime()
+			})
+
+			it("should enforce rate limiting across parent and subtask", async () => {
+				// Add a spy to track getState calls
+				const getStateSpy = vi.spyOn(mockProvider, "getState")
+
+				// Create parent task
+				const parent = new Task({
+					provider: mockProvider,
+					apiConfiguration: mockApiConfig,
+					task: "parent task",
+					startTask: false,
+				})
+
+				// Mock the API stream response
+				const mockStream = {
+					async *[Symbol.asyncIterator]() {
+						yield { type: "text", text: "parent response" }
+					},
+					async next() {
+						return { done: true, value: { type: "text", text: "parent response" } }
+					},
+					async return() {
+						return { done: true, value: undefined }
+					},
+					async throw(e: any) {
+						throw e
+					},
+					[Symbol.asyncDispose]: async () => {},
+				} as AsyncGenerator<ApiStreamChunk>
+
+				vi.spyOn(parent.api, "createMessage").mockReturnValue(mockStream)
+
+				// Make an API request with the parent task
+				const parentIterator = parent.attemptApiRequest(0)
+				await parentIterator.next()
+
+				// Verify no delay was applied for the first request
+				expect(mockDelay).not.toHaveBeenCalled()
+
+				// Create a subtask immediately after
+				const child = new Task({
+					provider: mockProvider,
+					apiConfiguration: mockApiConfig,
+					task: "child task",
+					parentTask: parent,
+					rootTask: parent,
+					startTask: false,
+				})
+
+				// Mock the child's API stream
+				const childMockStream = {
+					async *[Symbol.asyncIterator]() {
+						yield { type: "text", text: "child response" }
+					},
+					async next() {
+						return { done: true, value: { type: "text", text: "child response" } }
+					},
+					async return() {
+						return { done: true, value: undefined }
+					},
+					async throw(e: any) {
+						throw e
+					},
+					[Symbol.asyncDispose]: async () => {},
+				} as AsyncGenerator<ApiStreamChunk>
+
+				vi.spyOn(child.api, "createMessage").mockReturnValue(childMockStream)
+
+				// Make an API request with the child task
+				const childIterator = child.attemptApiRequest(0)
+				await childIterator.next()
+
+				// Verify rate limiting was applied
+				expect(mockDelay).toHaveBeenCalledTimes(mockApiConfig.rateLimitSeconds)
+				expect(mockDelay).toHaveBeenCalledWith(1000)
+			}, 10000) // Increase timeout to 10 seconds
+
+			it("should not apply rate limiting if enough time has passed", async () => {
+				// Create parent task
+				const parent = new Task({
+					provider: mockProvider,
+					apiConfiguration: mockApiConfig,
+					task: "parent task",
+					startTask: false,
+				})
+
+				// Mock the API stream response
+				const mockStream = {
+					async *[Symbol.asyncIterator]() {
+						yield { type: "text", text: "response" }
+					},
+					async next() {
+						return { done: true, value: { type: "text", text: "response" } }
+					},
+					async return() {
+						return { done: true, value: undefined }
+					},
+					async throw(e: any) {
+						throw e
+					},
+					[Symbol.asyncDispose]: async () => {},
+				} as AsyncGenerator<ApiStreamChunk>
+
+				vi.spyOn(parent.api, "createMessage").mockReturnValue(mockStream)
+
+				// Make an API request with the parent task
+				const parentIterator = parent.attemptApiRequest(0)
+				await parentIterator.next()
+
+				// Simulate time passing (more than rate limit)
+				const originalDateNow = Date.now
+				const mockTime = Date.now() + (mockApiConfig.rateLimitSeconds + 1) * 1000
+				Date.now = vi.fn(() => mockTime)
+
+				// Create a subtask after time has passed
+				const child = new Task({
+					provider: mockProvider,
+					apiConfiguration: mockApiConfig,
+					task: "child task",
+					parentTask: parent,
+					rootTask: parent,
+					startTask: false,
+				})
+
+				vi.spyOn(child.api, "createMessage").mockReturnValue(mockStream)
+
+				// Make an API request with the child task
+				const childIterator = child.attemptApiRequest(0)
+				await childIterator.next()
+
+				// Verify no rate limiting was applied
+				expect(mockDelay).not.toHaveBeenCalled()
+
+				// Restore Date.now
+				Date.now = originalDateNow
+			})
+
+			it("should share rate limiting across multiple subtasks", async () => {
+				// Create parent task
+				const parent = new Task({
+					provider: mockProvider,
+					apiConfiguration: mockApiConfig,
+					task: "parent task",
+					startTask: false,
+				})
+
+				// Mock the API stream response
+				const mockStream = {
+					async *[Symbol.asyncIterator]() {
+						yield { type: "text", text: "response" }
+					},
+					async next() {
+						return { done: true, value: { type: "text", text: "response" } }
+					},
+					async return() {
+						return { done: true, value: undefined }
+					},
+					async throw(e: any) {
+						throw e
+					},
+					[Symbol.asyncDispose]: async () => {},
+				} as AsyncGenerator<ApiStreamChunk>
+
+				vi.spyOn(parent.api, "createMessage").mockReturnValue(mockStream)
+
+				// Make an API request with the parent task
+				const parentIterator = parent.attemptApiRequest(0)
+				await parentIterator.next()
+
+				// Create first subtask
+				const child1 = new Task({
+					provider: mockProvider,
+					apiConfiguration: mockApiConfig,
+					task: "child task 1",
+					parentTask: parent,
+					rootTask: parent,
+					startTask: false,
+				})
+
+				vi.spyOn(child1.api, "createMessage").mockReturnValue(mockStream)
+
+				// Make an API request with the first child task
+				const child1Iterator = child1.attemptApiRequest(0)
+				await child1Iterator.next()
+
+				// Verify rate limiting was applied
+				const firstDelayCount = mockDelay.mock.calls.length
+				expect(firstDelayCount).toBe(mockApiConfig.rateLimitSeconds)
+
+				// Clear the mock to count new delays
+				mockDelay.mockClear()
+
+				// Create second subtask immediately after
+				const child2 = new Task({
+					provider: mockProvider,
+					apiConfiguration: mockApiConfig,
+					task: "child task 2",
+					parentTask: parent,
+					rootTask: parent,
+					startTask: false,
+				})
+
+				vi.spyOn(child2.api, "createMessage").mockReturnValue(mockStream)
+
+				// Make an API request with the second child task
+				const child2Iterator = child2.attemptApiRequest(0)
+				await child2Iterator.next()
+
+				// Verify rate limiting was applied again
+				expect(mockDelay).toHaveBeenCalledTimes(mockApiConfig.rateLimitSeconds)
+			}, 15000) // Increase timeout to 15 seconds
+
+			it("should handle rate limiting with zero rate limit", async () => {
+				// Update config to have zero rate limit
+				mockApiConfig.rateLimitSeconds = 0
+				mockProvider.getState.mockResolvedValue({
+					apiConfiguration: mockApiConfig,
+				})
+
+				// Create parent task
+				const parent = new Task({
+					provider: mockProvider,
+					apiConfiguration: mockApiConfig,
+					task: "parent task",
+					startTask: false,
+				})
+
+				// Mock the API stream response
+				const mockStream = {
+					async *[Symbol.asyncIterator]() {
+						yield { type: "text", text: "response" }
+					},
+					async next() {
+						return { done: true, value: { type: "text", text: "response" } }
+					},
+					async return() {
+						return { done: true, value: undefined }
+					},
+					async throw(e: any) {
+						throw e
+					},
+					[Symbol.asyncDispose]: async () => {},
+				} as AsyncGenerator<ApiStreamChunk>
+
+				vi.spyOn(parent.api, "createMessage").mockReturnValue(mockStream)
+
+				// Make an API request with the parent task
+				const parentIterator = parent.attemptApiRequest(0)
+				await parentIterator.next()
+
+				// Create a subtask
+				const child = new Task({
+					provider: mockProvider,
+					apiConfiguration: mockApiConfig,
+					task: "child task",
+					parentTask: parent,
+					rootTask: parent,
+					startTask: false,
+				})
+
+				vi.spyOn(child.api, "createMessage").mockReturnValue(mockStream)
+
+				// Make an API request with the child task
+				const childIterator = child.attemptApiRequest(0)
+				await childIterator.next()
+
+				// Verify no delay was applied
+				expect(mockDelay).not.toHaveBeenCalled()
+			})
+
+			it("should update global timestamp even when no rate limiting is needed", async () => {
+				// Create task
+				const task = new Task({
+					provider: mockProvider,
+					apiConfiguration: mockApiConfig,
+					task: "test task",
+					startTask: false,
+				})
+
+				// Mock the API stream response
+				const mockStream = {
+					async *[Symbol.asyncIterator]() {
+						yield { type: "text", text: "response" }
+					},
+					async next() {
+						return { done: true, value: { type: "text", text: "response" } }
+					},
+					async return() {
+						return { done: true, value: undefined }
+					},
+					async throw(e: any) {
+						throw e
+					},
+					[Symbol.asyncDispose]: async () => {},
+				} as AsyncGenerator<ApiStreamChunk>
+
+				vi.spyOn(task.api, "createMessage").mockReturnValue(mockStream)
+
+				// Make an API request
+				const iterator = task.attemptApiRequest(0)
+				await iterator.next()
+
+				// Access the private static property via reflection for testing
+				const globalTimestamp = (Task as any).lastGlobalApiRequestTime
+				expect(globalTimestamp).toBeDefined()
+				expect(globalTimestamp).toBeGreaterThan(0)
 			})
 		})
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1559,7 +1559,7 @@ export class ClineProvider
 			mcpEnabled: stateValues.mcpEnabled ?? true,
 			enableMcpServerCreation: stateValues.enableMcpServerCreation ?? true,
 			alwaysApproveResubmit: stateValues.alwaysApproveResubmit ?? false,
-			requestDelaySeconds: Math.max(5, stateValues.requestDelaySeconds ?? 10),
+			requestDelaySeconds: stateValues.requestDelaySeconds ?? 10,
 			currentApiConfigName: stateValues.currentApiConfigName ?? "default",
 			listApiConfigMeta: stateValues.listApiConfigMeta ?? [],
 			pinnedApiConfigs: stateValues.pinnedApiConfigs ?? {},

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1559,7 +1559,7 @@ export class ClineProvider
 			mcpEnabled: stateValues.mcpEnabled ?? true,
 			enableMcpServerCreation: stateValues.enableMcpServerCreation ?? true,
 			alwaysApproveResubmit: stateValues.alwaysApproveResubmit ?? false,
-			requestDelaySeconds: stateValues.requestDelaySeconds ?? 10,
+			requestDelaySeconds: Math.max(5, stateValues.requestDelaySeconds ?? 10),
 			currentApiConfigName: stateValues.currentApiConfigName ?? "default",
 			listApiConfigMeta: stateValues.listApiConfigMeta ?? [],
 			pinnedApiConfigs: stateValues.pinnedApiConfigs ?? {},


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #3089 

### Description

<!--
Briefly summarize the changes in this PR and how they address the linked issue.
The issue should cover the "what" and "why"; this section should focus on:
- The "how": key implementation details, design choices, or trade-offs made.
- Anything specific reviewers should pay attention to in this PR.
-->

### Test Procedure

<!--
Detail the steps to test your changes. This helps reviewers verify your work.
- How did you test this specific implementation? (e.g., unit tests, manual testing steps)
- How can reviewers reproduce your tests or verify the fix/feature?
- Include relevant testing environment details if applicable.
-->

### Type of Change

<!-- Mark all applicable boxes with an 'x'. -->

- [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [ ] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [x] **Testing**:
    - [x] New and/or updated tests have been added to cover my changes.
    - [x] All tests pass locally (`npm test`).
    - [x] The application builds successfully with my changes.
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [ ] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [ ] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->

### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Implement global rate-limiting for API requests across tasks and subtasks using a shared timestamp in `Task.ts`.
> 
>   - **Rate Limiting**:
>     - Introduced `lastGlobalApiRequestTime` in `Task` class to enforce rate-limiting across tasks and subtasks.
>     - Modified `attemptApiRequest()` in `Task.ts` to use `lastGlobalApiRequestTime` for calculating rate limit delays.
>   - **Code Adjustments**:
>     - Changed `requestDelaySeconds` default value in `ClineProvider.ts` from 5 to 10.
>     - Added `lastApiRequestTime` to `ClineProvider` class.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c9d5fd9437f176d61d5535fb33745fbe479a734d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->