### PR TITLE
Try to fix win32 esbuild

### DIFF
--- a/packages/build/src/esbuild.ts
+++ b/packages/build/src/esbuild.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs"
 import * as path from "path"
+import { execSync } from "child_process"
 
 import { ViewsContainer, Views, Menus, Configuration, contributesSchema } from "./types.js"
 
@@ -22,7 +23,7 @@ function copyDir(srcDir: string, dstDir: string, count: number): number {
 	return count
 }
 
-function rmDir(dirPath: string, maxRetries: number = 3): void {
+function rmDir(dirPath: string, maxRetries: number = 5): void {
 	for (let attempt = 1; attempt <= maxRetries; attempt++) {
 		try {
 			fs.rmSync(dirPath, { recursive: true, force: true })
@@ -30,15 +31,42 @@ function rmDir(dirPath: string, maxRetries: number = 3): void {
 		} catch (error) {
 			const isLastAttempt = attempt === maxRetries
 
-			const isEnotemptyError =
-				error instanceof Error && "code" in error && (error.code === "ENOTEMPTY" || error.code === "EBUSY")
+			const isRetryableError =
+				error instanceof Error &&
+				"code" in error &&
+				(error.code === "ENOTEMPTY" ||
+					error.code === "EBUSY" ||
+					error.code === "EPERM" ||
+					error.code === "EACCES")
 
-			if (isLastAttempt || !isEnotemptyError) {
-				throw error // Re-throw if it's the last attempt or not a locking error.
+			if (isLastAttempt) {
+				// On the last attempt, try alternative cleanup methods.
+				try {
+					console.warn(`[rmDir] Final attempt using alternative cleanup for ${dirPath}`)
+
+					// Try to clear readonly flags on Windows.
+					if (process.platform === "win32") {
+						try {
+							execSync(`attrib -R "${dirPath}\\*.*" /S /D`, { stdio: "ignore" })
+						} catch {
+							// Ignore attrib errors.
+						}
+					}
+					fs.rmSync(dirPath, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 })
+					return
+				} catch (finalError) {
+					console.error(`[rmDir] Failed to remove ${dirPath} after ${maxRetries} attempts:`, finalError)
+					throw finalError
+				}
 			}
 
-			// Wait with exponential backoff before retrying.
-			const delay = Math.min(100 * Math.pow(2, attempt - 1), 1000) // Cap at 1s.
+			if (!isRetryableError) {
+				throw error // Re-throw if it's not a retryable error.
+			}
+
+			// Wait with exponential backoff before retrying, with longer delays for Windows.
+			const baseDelay = process.platform === "win32" ? 200 : 100
+			const delay = Math.min(baseDelay * Math.pow(2, attempt - 1), 2000) // Cap at 2s
 			console.warn(`[rmDir] Attempt ${attempt} failed for ${dirPath}, retrying in ${delay}ms...`)
 
 			// Synchronous sleep for simplicity in build scripts.
@@ -119,7 +147,9 @@ export function copyWasms(srcDir: string, distDir: string): void {
 	const languageWasmDir = path.join(nodeModulesDir, "tree-sitter-wasms", "out")
 
 	if (!fs.existsSync(languageWasmDir)) {
-		throw new Error(`Directory does not exist: ${languageWasmDir}`)
+		console.warn(`[copyWasms] Warning: Directory does not exist: ${languageWasmDir}`)
+		console.warn(`[copyWasms] Skipping tree-sitter language WASM files copy`)
+		return
 	}
 
 	// Dynamically read all WASM files from the directory instead of using a hardcoded list.

--- a/packages/build/src/esbuild.ts
+++ b/packages/build/src/esbuild.ts
@@ -147,9 +147,7 @@ export function copyWasms(srcDir: string, distDir: string): void {
 	const languageWasmDir = path.join(nodeModulesDir, "tree-sitter-wasms", "out")
 
 	if (!fs.existsSync(languageWasmDir)) {
-		console.warn(`[copyWasms] Warning: Directory does not exist: ${languageWasmDir}`)
-		console.warn(`[copyWasms] Skipping tree-sitter language WASM files copy`)
-		return
+		throw new Error(`Directory does not exist: ${languageWasmDir}`)
 	}
 
 	// Dynamically read all WASM files from the directory instead of using a hardcoded list.

--- a/src/esbuild.mjs
+++ b/src/esbuild.mjs
@@ -81,7 +81,9 @@ async function main() {
 				build.onEnd((result) => {
 					result.errors.forEach(({ text, location }) => {
 						console.error(`✘ [ERROR] ${text}`)
-						console.error(`    ${location.file}:${location.line}:${location.column}:`)
+						if (location && location.file) {
+							console.error(`    ${location.file}:${location.line}:${location.column}:`)
+						}
 					})
 
 					console.log("[esbuild-problem-matcher#onEnd]")


### PR DESCRIPTION
### Description

Trying to fix `win32` build flakes.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix Windows build issues by enhancing `rmDir()` error handling and updating error logging in `esbuild.mjs`.
> 
>   - **Behavior**:
>     - In `esbuild.ts`, `rmDir()` now retries up to 5 times and handles `EPERM` and `EACCES` errors, with Windows-specific logic to clear readonly flags using `execSync`.
>     - In `esbuild.mjs`, error logging in `build.onEnd()` now checks for `location.file` before logging file details.
>   - **Functions**:
>     - `rmDir()` in `esbuild.ts` now includes Windows-specific error handling and retry logic.
>     - `build.onEnd()` in `esbuild.mjs` updated to conditionally log error location details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7b90701d6f8bc353b003f3a610bd18c2c3cd5142. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->