### PR TITLE
fix: remove explicit cache_control for Google models in OpenRouter (#4487)

### DIFF
--- a/packages/types/src/providers/openrouter.ts
+++ b/packages/types/src/providers/openrouter.ts
@@ -39,6 +39,13 @@ export const OPEN_ROUTER_PROMPT_CACHING_MODELS = new Set([
 	"anthropic/claude-3.7-sonnet:thinking",
 	"anthropic/claude-sonnet-4",
 	"anthropic/claude-opus-4",
+	"google/gemini-2.5-flash-preview",
+	"google/gemini-2.5-flash-preview:thinking",
+	"google/gemini-2.5-flash-preview-05-20",
+	"google/gemini-2.5-flash-preview-05-20:thinking",
+	"google/gemini-2.0-flash-001",
+	"google/gemini-flash-1.5",
+	"google/gemini-flash-1.5-8b",
 ])
 
 // https://www.anthropic.com/news/3-5-models-and-computer-use

--- a/packages/types/src/providers/openrouter.ts
+++ b/packages/types/src/providers/openrouter.ts
@@ -39,14 +39,6 @@ export const OPEN_ROUTER_PROMPT_CACHING_MODELS = new Set([
 	"anthropic/claude-3.7-sonnet:thinking",
 	"anthropic/claude-sonnet-4",
 	"anthropic/claude-opus-4",
-	"google/gemini-2.5-pro-preview",
-	"google/gemini-2.5-flash-preview",
-	"google/gemini-2.5-flash-preview:thinking",
-	"google/gemini-2.5-flash-preview-05-20",
-	"google/gemini-2.5-flash-preview-05-20:thinking",
-	"google/gemini-2.0-flash-001",
-	"google/gemini-flash-1.5",
-	"google/gemini-flash-1.5-8b",
 ])
 
 // https://www.anthropic.com/news/3-5-models-and-computer-use

--- a/src/api/providers/fetchers/__tests__/openrouter.spec.ts
+++ b/src/api/providers/fetchers/__tests__/openrouter.spec.ts
@@ -34,8 +34,9 @@ describe("OpenRouter API", () => {
 				expect(openRouterSupportedCaching).toContain(modelId)
 			}
 
-			// Verify we have all supported models except intentionally excluded Google models
-			const expectedCachingModels = openRouterSupportedCaching.filter((id) => !id.startsWith("google/")).sort()
+			// Verify we have all supported models except intentionally excluded ones
+			const excludedModels = new Set(["google/gemini-2.5-pro-preview"]) // Excluded due to lag issue (#4487)
+			const expectedCachingModels = openRouterSupportedCaching.filter((id) => !excludedModels.has(id)).sort()
 
 			expect(ourCachingModels.sort()).toEqual(expectedCachingModels)
 

--- a/src/api/providers/fetchers/__tests__/openrouter.spec.ts
+++ b/src/api/providers/fetchers/__tests__/openrouter.spec.ts
@@ -23,12 +23,37 @@ describe("OpenRouter API", () => {
 
 			const models = await getOpenRouterModels()
 
-			expect(
-				Object.entries(models)
-					.filter(([_, model]) => model.supportsPromptCache)
-					.map(([id, _]) => id)
-					.sort(),
-			).toEqual(Array.from(OPEN_ROUTER_PROMPT_CACHING_MODELS).sort())
+			// Check that our caching models list is a subset of what OpenRouter supports
+			// (we may intentionally exclude some models that support caching)
+			const openRouterSupportedCaching = Object.entries(models)
+				.filter(([_, model]) => model.supportsPromptCache)
+				.map(([id, _]) => id)
+
+			const ourCachingModels = Array.from(OPEN_ROUTER_PROMPT_CACHING_MODELS)
+
+			// Verify all our caching models are actually supported by OpenRouter
+			for (const modelId of ourCachingModels) {
+				expect(openRouterSupportedCaching).toContain(modelId)
+			}
+
+			// Check that we have the expected models (excluding intentionally excluded ones)
+			const excludedCachingModels = new Set([
+				// All Google models intentionally excluded from caching
+				"google/gemini-2.5-pro-preview",
+				"google/gemini-2.0-flash-001",
+				"google/gemini-2.5-flash-preview",
+				"google/gemini-2.5-flash-preview-05-20",
+				"google/gemini-2.5-flash-preview-05-20:thinking",
+				"google/gemini-2.5-flash-preview:thinking",
+				"google/gemini-flash-1.5",
+				"google/gemini-flash-1.5-8b",
+			])
+
+			const expectedCachingModels = openRouterSupportedCaching
+				.filter((id) => !excludedCachingModels.has(id))
+				.sort()
+
+			expect(ourCachingModels.sort()).toEqual(expectedCachingModels)
 
 			expect(
 				Object.entries(models)

--- a/src/api/providers/fetchers/__tests__/openrouter.spec.ts
+++ b/src/api/providers/fetchers/__tests__/openrouter.spec.ts
@@ -35,7 +35,6 @@ describe("OpenRouter API", () => {
 			}
 
 			// Verify we have all supported models except intentionally excluded Google models
-			const excludedModels = openRouterSupportedCaching.filter((id) => id.startsWith("google/"))
 			const expectedCachingModels = openRouterSupportedCaching.filter((id) => !id.startsWith("google/")).sort()
 
 			expect(ourCachingModels.sort()).toEqual(expectedCachingModels)

--- a/src/api/providers/fetchers/__tests__/openrouter.spec.ts
+++ b/src/api/providers/fetchers/__tests__/openrouter.spec.ts
@@ -23,8 +23,6 @@ describe("OpenRouter API", () => {
 
 			const models = await getOpenRouterModels()
 
-			// Check that our caching models list is a subset of what OpenRouter supports
-			// (we may intentionally exclude some models that support caching)
 			const openRouterSupportedCaching = Object.entries(models)
 				.filter(([_, model]) => model.supportsPromptCache)
 				.map(([id, _]) => id)
@@ -36,22 +34,9 @@ describe("OpenRouter API", () => {
 				expect(openRouterSupportedCaching).toContain(modelId)
 			}
 
-			// Check that we have the expected models (excluding intentionally excluded ones)
-			const excludedCachingModels = new Set([
-				// All Google models intentionally excluded from caching
-				"google/gemini-2.5-pro-preview",
-				"google/gemini-2.0-flash-001",
-				"google/gemini-2.5-flash-preview",
-				"google/gemini-2.5-flash-preview-05-20",
-				"google/gemini-2.5-flash-preview-05-20:thinking",
-				"google/gemini-2.5-flash-preview:thinking",
-				"google/gemini-flash-1.5",
-				"google/gemini-flash-1.5-8b",
-			])
-
-			const expectedCachingModels = openRouterSupportedCaching
-				.filter((id) => !excludedCachingModels.has(id))
-				.sort()
+			// Verify we have all supported models except intentionally excluded Google models
+			const excludedModels = openRouterSupportedCaching.filter((id) => id.startsWith("google/"))
+			const expectedCachingModels = openRouterSupportedCaching.filter((id) => !id.startsWith("google/")).sort()
 
 			expect(ourCachingModels.sort()).toEqual(expectedCachingModels)
 


### PR DESCRIPTION
### Related GitHub Issue

Closes: #4487

### Description

This PR fixes the 3+ minute lag issue when using `google/gemini-2.5-pro-preview` through OpenRouter by removing explicit `cache_control` flags for this specific model.

**Key implementation details:**
- Excluded `google/gemini-2.5-pro-preview` from the `OPEN_ROUTER_PROMPT_CACHING_MODELS` set in `packages/types/src/providers/openrouter.ts`
- Added clear comment explaining the exclusion with issue reference
- Updated test logic to handle the intentional exclusion of this specific model
- OpenRouter still provides automatic implicit ephemeral caching for this model, so caching benefits are preserved
- The fix specifically targets the lag caused by explicit `"cache_control": { "type": "ephemeral" }` flags being added to requests

**Reviewers should pay attention to:**
- Only the `google/gemini-2.5-pro-preview` model is affected - all other models continue to work as before
- The surgical approach preserves explicit caching for all other models that work properly

### Test Procedure

**Unit Tests:**
```bash
# Run OpenRouter-specific tests
npx vitest run api/providers/fetchers/__tests__/openrouter.spec.ts

# Run all provider tests
npx vitest run api/providers/__tests__/
```

**Manual Testing:**
1. Use `google/gemini-2.5-pro-preview` model through OpenRouter
2. Verify response time is significantly reduced (from 3+ minutes to normal response time)
3. Verify caching still works (OpenRouter provides automatic implicit caching)
4. Verify other Google models continue to work with explicit cache control
5. Verify non-Google models continue to work with explicit cache control

**Testing Environment:**
- All tests pass locally
- Linting passes
- Type checking passes
- No breaking changes to existing functionality

### Type of Change

- [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [ ] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [x] **Testing**:
    - [x] New and/or updated tests have been added to cover my changes.
    - [x] All tests pass locally (`npm test` - relevant provider tests passing).
    - [x] The application builds successfully with my changes.
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

Not applicable - this is a performance fix with no UI changes.

### Documentation Updates

- [x] No documentation updates are required.
- [ ] Yes, documentation updates are required.

This change is internal to the caching implementation and doesn't affect user-facing behavior beyond improved performance.

### Additional Notes

**Model affected:**
- `google/gemini-2.5-pro-preview` - No longer uses explicit cache_control (prevents 3+ minute lag)

**Models NOT affected (continue to use explicit caching as before):**
- All other Google models (`google/gemini-2.5-flash-preview`, `google/gemini-2.0-flash-001`, etc.)
- All Anthropic models
- All other provider models

**Impact:**
- ✅ Eliminates 3+ minute lag for `google/gemini-2.5-pro-preview`
- ✅ Preserves caching benefits through OpenRouter's automatic system
- ✅ No breaking changes - other models continue to work as before
- ✅ Surgical fix - minimal scope, maximum effectiveness

### Get in Touch

I'm available through GitHub for any questions about this PR.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove explicit cache control for Google models in `openrouter.ts` to fix lag issue, updating tests accordingly.
> 
>   - **Behavior**:
>     - Removed Google models from `OPEN_ROUTER_PROMPT_CACHING_MODELS` in `openrouter.ts` to fix lag issue.
>     - OpenRouter still provides implicit ephemeral caching for these models.
>   - **Tests**:
>     - Updated `openrouter.spec.ts` to exclude Google models from caching tests.
>     - Ensured test logic matches exclusion list for caching models.
>   - **Impact**:
>     - Eliminates 3+ minute lag for Google Gemini models.
>     - No other models affected; non-Google models continue with explicit cache control.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a904d676af8ed1b85aa6de49bf64e6ff644e7a34. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->