### PR TITLE
Improve eval docker ports

### DIFF
--- a/packages/evals/docker-compose.yml
+++ b/packages/evals/docker-compose.yml
@@ -17,8 +17,8 @@ services:
     db:
         container_name: evals-db
         image: postgres:15.4
-        ports:
-            - 5432:5432
+        expose:
+            - 5432
         volumes:
             - ./.docker/postgres:/var/lib/postgresql/data
             - ./.docker/scripts/postgres:/docker-entrypoint-initdb.d
@@ -38,8 +38,8 @@ services:
     redis:
         container_name: evals-redis
         image: redis:7-alpine
-        ports:
-            - "6379:6379"
+        expose:
+            - 6379
         volumes:
             - ./.docker/redis:/data
         command: redis-server --appendonly yes
@@ -52,7 +52,7 @@ services:
             context: ../../
             dockerfile: packages/evals/Dockerfile.web
         ports:
-            - "3000:3000"
+            - "${EVALS_WEB_PORT:-3000}:3000"
         environment:
             - HOST_EXECUTION_METHOD=docker
         volumes:


### PR DESCRIPTION
- Just expose postgres and redis
- Allow a different port using `EVALS_WEB_PORT` (the default is still 3000)

Example (accessing the web ui through http://localhost:3001):
`EVALS_WEB_PORT=3001 docker compose --profile server --profile runner up`

@cte it's always a little annoying using environment variables with docker compose, but this might accomplish most of what you were looking for in #4421
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves port handling in `docker-compose.yml` by using `expose` for `db` and `redis`, and allowing `web` port configuration via `EVALS_WEB_PORT`.
> 
>   - **Docker Compose Changes**:
>     - `db` and `redis` services now use `expose` instead of `ports` to limit external access.
>     - `web` service port is configurable via `EVALS_WEB_PORT` environment variable, defaulting to 3000.
>   - **Usage**:
>     - Example command to run with a different web port: `EVALS_WEB_PORT=3001 docker compose --profile server --profile runner up`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 10e36e029e49efea92a92b84d1cef30286a2f544. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->