### PR TITLE
Switch back to GH runners for CI

### DIFF
--- a/.github/workflows/code-qa.yml
+++ b/.github/workflows/code-qa.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
     check-translations:
-        runs-on: blacksmith-4vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -20,7 +20,7 @@ jobs:
               run: node scripts/find-missing-translations.js
 
     knip:
-        runs-on: blacksmith-4vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
               run: pnpm knip
 
     compile:
-        runs-on: blacksmith-4vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
         strategy:
             matrix:
                 include:
-                    - os: blacksmith-4vcpu-ubuntu-2404
+                    - os: ubuntu-latest
                       name: ubuntu-latest
                     - os: windows-latest
                       name: windows-latest
@@ -75,7 +75,7 @@ jobs:
                   fi
 
     integration-test:
-        runs-on: blacksmith-4vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         needs: [check-openrouter-api-key]
         if: needs.check-openrouter-api-key.outputs.exists == 'true'
         steps:


### PR DESCRIPTION
### Description

GH runners are free for open-source, so let's use them and reserve the Blacksmith monthly free allocation for evals.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switches CI runner from Blacksmith to GitHub's default runner in `code-qa.yml`.
> 
>   - **CI Runner Change**:
>     - Switches `runs-on` from `blacksmith-4vcpu-ubuntu-2404` to `ubuntu-latest` in `code-qa.yml` for jobs: `check-translations`, `knip`, `compile`, `unit-test`, and `integration-test`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ff7b8365e7f83aea9b31d8aca47192b729d29a3e. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->