### PR TITLE
Disable checkpoint if nested git repos are detected

### DIFF
--- a/src/core/assistant-message/presentAssistantMessage.ts
+++ b/src/core/assistant-message/presentAssistantMessage.ts
@@ -51,7 +51,7 @@ import { codebaseSearchTool } from "../tools/codebaseSearchTool"
 
 export async function presentAssistantMessage(cline: Task) {
 	if (cline.abort) {
-		throw new Error(`[Cline#presentAssistantMessage] task ${cline.taskId}.${cline.instanceId} aborted`)
+		throw new Error(`[Task#presentAssistantMessage] task ${cline.taskId}.${cline.instanceId} aborted`)
 	}
 
 	if (cline.presentAssistantMessageLocked) {

--- a/src/core/checkpoints/index.ts
+++ b/src/core/checkpoints/index.ts
@@ -24,7 +24,7 @@ export function getCheckpointService(cline: Task) {
 	}
 
 	if (cline.checkpointServiceInitializing) {
-		console.log("[Cline#getCheckpointService] checkpoint service is still initializing")
+		console.log("[Task#getCheckpointService] checkpoint service is still initializing")
 		return undefined
 	}
 
@@ -40,13 +40,13 @@ export function getCheckpointService(cline: Task) {
 		}
 	}
 
-	console.log("[Cline#getCheckpointService] initializing checkpoints service")
+	console.log("[Task#getCheckpointService] initializing checkpoints service")
 
 	try {
 		const workspaceDir = getWorkspacePath()
 
 		if (!workspaceDir) {
-			log("[Cline#getCheckpointService] workspace folder not found, disabling checkpoints")
+			log("[Task#getCheckpointService] workspace folder not found, disabling checkpoints")
 			cline.enableCheckpoints = false
 			return undefined
 		}
@@ -54,7 +54,7 @@ export function getCheckpointService(cline: Task) {
 		const globalStorageDir = provider?.context.globalStorageUri.fsPath
 
 		if (!globalStorageDir) {
-			log("[Cline#getCheckpointService] globalStorageDir not found, disabling checkpoints")
+			log("[Task#getCheckpointService] globalStorageDir not found, disabling checkpoints")
 			cline.enableCheckpoints = false
 			return undefined
 		}
@@ -71,7 +71,7 @@ export function getCheckpointService(cline: Task) {
 		cline.checkpointServiceInitializing = true
 
 		service.on("initialize", () => {
-			log("[Cline#getCheckpointService] service initialized")
+			log("[Task#getCheckpointService] service initialized")
 
 			try {
 				const isCheckpointNeeded =
@@ -81,11 +81,11 @@ export function getCheckpointService(cline: Task) {
 				cline.checkpointServiceInitializing = false
 
 				if (isCheckpointNeeded) {
-					log("[Cline#getCheckpointService] no checkpoints found, saving initial checkpoint")
+					log("[Task#getCheckpointService] no checkpoints found, saving initial checkpoint")
 					checkpointSave(cline)
 				}
 			} catch (err) {
-				log("[Cline#getCheckpointService] caught error in on('initialize'), disabling checkpoints")
+				log("[Task#getCheckpointService] caught error in on('initialize'), disabling checkpoints")
 				cline.enableCheckpoints = false
 			}
 		})
@@ -99,30 +99,26 @@ export function getCheckpointService(cline: Task) {
 						isNonInteractive: true,
 					})
 					.catch((err) => {
-						log("[Cline#getCheckpointService] caught unexpected error in say('checkpoint_saved')")
+						log("[Task#getCheckpointService] caught unexpected error in say('checkpoint_saved')")
 						console.error(err)
 					})
 			} catch (err) {
-				log("[Cline#getCheckpointService] caught unexpected error in on('checkpoint'), disabling checkpoints")
+				log("[Task#getCheckpointService] caught unexpected error in on('checkpoint'), disabling checkpoints")
 				console.error(err)
 				cline.enableCheckpoints = false
 			}
 		})
 
-		log("[Cline#getCheckpointService] initializing shadow git")
+		log("[Task#getCheckpointService] initializing shadow git")
 
 		service.initShadowGit().catch((err) => {
-			log(
-				`[Cline#getCheckpointService] caught unexpected error in initShadowGit, disabling checkpoints (${err.message})`,
-			)
-
-			console.error(err)
+			log(`[Task#getCheckpointService] initShadowGit -> ${err.message}`)
 			cline.enableCheckpoints = false
 		})
 
 		return service
 	} catch (err) {
-		log("[Cline#getCheckpointService] caught unexpected error, disabling checkpoints")
+		log(`[Task#getCheckpointService] ${err.message}`)
 		cline.enableCheckpoints = false
 		return undefined
 	}
@@ -141,7 +137,7 @@ async function getInitializedCheckpointService(
 	try {
 		await pWaitFor(
 			() => {
-				console.log("[Cline#getCheckpointService] waiting for service to initialize")
+				console.log("[Task#getCheckpointService] waiting for service to initialize")
 				return service.isInitialized
 			},
 			{ interval, timeout },
@@ -171,7 +167,7 @@ export async function checkpointSave(cline: Task, force = false) {
 
 	// Start the checkpoint process in the background.
 	return service.saveCheckpoint(`Task: ${cline.taskId}, Time: ${Date.now()}`, { allowEmpty: force }).catch((err) => {
-		console.error("[Cline#checkpointSave] caught unexpected error, disabling checkpoints", err)
+		console.error("[Task#checkpointSave] caught unexpected error, disabling checkpoints", err)
 		cline.enableCheckpoints = false
 	})
 }

--- a/src/core/environment/getEnvironmentDetails.ts
+++ b/src/core/environment/getEnvironmentDetails.ts
@@ -153,7 +153,7 @@ export async function getEnvironmentDetails(cline: Task, includeFileDetails: boo
 		}
 	}
 
-	// console.log(`[Cline#getEnvironmentDetails] terminalDetails: ${terminalDetails}`)
+	// console.log(`[Task#getEnvironmentDetails] terminalDetails: ${terminalDetails}`)
 
 	// Add recently modified files section.
 	const recentlyModifiedFiles = cline.fileContextTracker.getAndClearRecentlyModifiedFiles()

--- a/src/services/checkpoints/__tests__/excludes.test.ts
+++ b/src/services/checkpoints/__tests__/excludes.test.ts
@@ -6,7 +6,6 @@ import { join } from "path"
 import { fileExistsAtPath } from "../../../utils/fs"
 
 import { getExcludePatterns } from "../excludes"
-import { GIT_DISABLED_SUFFIX } from "../constants"
 
 jest.mock("fs/promises")
 
@@ -54,7 +53,6 @@ readme.md text
 
 			// Verify all normal patterns also exist
 			expect(excludePatterns).toContain(".git/")
-			expect(excludePatterns).toContain(`.git${GIT_DISABLED_SUFFIX}/`)
 		})
 
 		it("should handle .gitattributes with no LFS patterns", async () => {
@@ -89,7 +87,6 @@ readme.md text
 
 			// Verify default patterns are included
 			expect(excludePatterns).toContain(".git/")
-			expect(excludePatterns).toContain(`.git${GIT_DISABLED_SUFFIX}/`)
 		})
 
 		it("should handle missing .gitattributes file", async () => {
@@ -107,7 +104,6 @@ readme.md text
 
 			// Verify standard patterns are included
 			expect(excludePatterns).toContain(".git/")
-			expect(excludePatterns).toContain(`.git${GIT_DISABLED_SUFFIX}/`)
 
 			// Verify we have standard patterns but no LFS patterns
 			// Check for a few known patterns from different categories
@@ -139,7 +135,6 @@ readme.md text
 
 			// Verify standard patterns are included
 			expect(excludePatterns).toContain(".git/")
-			expect(excludePatterns).toContain(`.git${GIT_DISABLED_SUFFIX}/`)
 
 			// Verify we have standard patterns but no LFS patterns
 			// Check for a few known patterns from different categories

--- a/src/services/checkpoints/constants.ts
+++ b/src/services/checkpoints/constants.ts
@@ -1,1 +1,0 @@
-export const GIT_DISABLED_SUFFIX = "_disabled"

--- a/src/services/checkpoints/excludes.ts
+++ b/src/services/checkpoints/excludes.ts
@@ -3,8 +3,6 @@ import { join } from "path"
 
 import { fileExistsAtPath } from "../../utils/fs"
 
-import { GIT_DISABLED_SUFFIX } from "./constants"
-
 const getBuildArtifactPatterns = () => [
 	".gradle/",
 	".idea/",
@@ -200,7 +198,6 @@ const getLfsPatterns = async (workspacePath: string) => {
 
 export const getExcludePatterns = async (workspacePath: string) => [
 	".git/",
-	`.git${GIT_DISABLED_SUFFIX}/`,
 	...getBuildArtifactPatterns(),
 	...getMediaFilePatterns(),
 	...getCacheFilePatterns(),


### PR DESCRIPTION
### Description

The logic to rename .git has always been a bit dodgy; this seems like a safer approach until we re-visit checkpoints.

I tested multi-root workspaces as well and found that VSCode will set the cwd to be the path of the first root in the workspace, so if we want to handle that case then some additional logic will be required (which is probably worth doing since the checkpoints will only apply to the first root in the workspace which will be confusing for people).

Open question: Should we display something in the UI if checkpoints are disabled due to one of the conditions that makes the checkpoint initialization throw?

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disable checkpoints in `ShadowCheckpointService` if nested git repositories are detected, and update related tests and logging.
> 
>   - **Behavior**:
>     - Disable checkpoints if nested git repositories are detected in `ShadowCheckpointService`.
>     - Remove logic to rename nested `.git` directories.
>   - **Logging**:
>     - Update log messages from `[Cline#...]` to `[Task#...]` in `presentAssistantMessage.ts`, `index.ts`, and `getEnvironmentDetails.ts`.
>   - **Tests**:
>     - Update `ShadowCheckpointService.test.ts` to test for detection of nested git repositories instead of renaming logic.
>     - Remove tests related to renaming `.git` directories in `excludes.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4093faa528fcc869c3570f280176b253ca5eb173. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->