### PR TITLE
Fix OpenRouter cost calculation with BYOK

### DIFF
--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -48,7 +48,12 @@ interface CompletionUsage {
 	}
 	total_tokens?: number
 	cost?: number
+	is_byok?: boolean
 }
+
+// with bring your own key, OpenRouter charges 5% of what it normally would: https://openrouter.ai/docs/use-cases/byok
+// so we multiply the cost reported by OpenRouter to get an estimate of what the request actually cost
+const BYOK_COST_MULTIPLIER = 20
 
 export class OpenRouterHandler extends BaseProvider implements SingleCompletionHandler {
 	protected options: ApiHandlerOptions
@@ -164,7 +169,7 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 				// and how to best support it.
 				// cacheReadTokens: lastUsage.prompt_tokens_details?.cached_tokens,
 				reasoningTokens: lastUsage.completion_tokens_details?.reasoning_tokens,
-				totalCost: lastUsage.cost || 0,
+				totalCost: (lastUsage.is_byok ? BYOK_COST_MULTIPLIER : 1) * (lastUsage.cost || 0),
 			}
 		}
 	}


### PR DESCRIPTION
Hello, Kilo maintainer here upstreaming a fix (https://github.com/Kilo-Org/kilocode/pull/671)

Currently, when you use OpenRouter with your own key for the underlying service, the costs shown by Roo Code are way off what it actually costs.

With bring your own key, OpenRouter charges 5% of what it normally would (see https://openrouter.ai/docs/use-cases/byok) so we have to multiply the reported cost by 20 to get an estimate of what it actually costs.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes cost calculation in `OpenRouterHandler` for BYOK by multiplying reported cost by 20.
> 
>   - **Behavior**:
>     - Fix cost calculation in `OpenRouterHandler` for BYOK (Bring Your Own Key) by multiplying reported cost by 20.
>     - Adds `is_byok` field to `CompletionUsage` interface in `openrouter.ts` to identify BYOK usage.
>   - **Constants**:
>     - Introduces `BYOK_COST_MULTIPLIER` constant set to 20 in `openrouter.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1bd1d879d671094783c287aa53602124f422366d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->