### PR TITLE
Revert "chore(deps): update postgres docker tag to v17"

### DIFF
--- a/packages/evals/docker-compose.yml
+++ b/packages/evals/docker-compose.yml
@@ -16,7 +16,7 @@
 services:
     db:
         container_name: evals-db
-        image: postgres:17.5
+        image: postgres:15.4
         # expose:
         #     - 5432
         ports:


### PR DESCRIPTION
Reverts RooCodeInc/Roo-Code#4350

Annoyingly the db files created by Postgres 15 won't work with Postgres 17 - reverting for now.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts Postgres Docker image from 17.5 to 15.4 in `docker-compose.yml` due to db file incompatibility.
> 
>   - **Revert Postgres Version**:
>     - Reverts Postgres Docker image from `17.5` to `15.4` in `docker-compose.yml` for `db` service due to incompatibility with existing db files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c295588b87e655f21aeffeb787c5ddf6fb99bf21. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->