### PR TITLE
♻️ Refactor: Avoid type system duplication

### DIFF
--- a/packages/types/src/global-settings.ts
+++ b/packages/types/src/global-settings.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 
-import { type Keys, keysOf } from "./type-fu.js"
+import { type Keys } from "./type-fu.js"
 import {
 	type ProviderSettings,
 	PROVIDER_SETTINGS_KEYS,
@@ -106,89 +106,7 @@ export const globalSettingsSchema = z.object({
 
 export type GlobalSettings = z.infer<typeof globalSettingsSchema>
 
-export const GLOBAL_SETTINGS_KEYS = keysOf<GlobalSettings>()([
-	"currentApiConfigName",
-	"listApiConfigMeta",
-	"pinnedApiConfigs",
-
-	"lastShownAnnouncementId",
-	"customInstructions",
-	"taskHistory",
-
-	"condensingApiConfigId",
-	"customCondensingPrompt",
-
-	"autoApprovalEnabled",
-	"alwaysAllowReadOnly",
-	"alwaysAllowReadOnlyOutsideWorkspace",
-	"alwaysAllowWrite",
-	"alwaysAllowWriteOutsideWorkspace",
-	"writeDelayMs",
-	"alwaysAllowBrowser",
-	"alwaysApproveResubmit",
-	"requestDelaySeconds",
-	"alwaysAllowMcp",
-	"alwaysAllowModeSwitch",
-	"alwaysAllowSubtasks",
-	"alwaysAllowExecute",
-	"allowedCommands",
-	"allowedMaxRequests",
-	"autoCondenseContext",
-	"autoCondenseContextPercent",
-	"maxConcurrentFileReads",
-
-	"browserToolEnabled",
-	"browserViewportSize",
-	"screenshotQuality",
-	"remoteBrowserEnabled",
-	"remoteBrowserHost",
-
-	"enableCheckpoints",
-
-	"ttsEnabled",
-	"ttsSpeed",
-	"soundEnabled",
-	"soundVolume",
-
-	"maxOpenTabsContext",
-	"maxWorkspaceFiles",
-	"showRooIgnoredFiles",
-	"maxReadFileLine",
-
-	"terminalOutputLineLimit",
-	"terminalShellIntegrationTimeout",
-	"terminalShellIntegrationDisabled",
-	"terminalCommandDelay",
-	"terminalPowershellCounter",
-	"terminalZshClearEolMark",
-	"terminalZshOhMy",
-	"terminalZshP10k",
-	"terminalZdotdir",
-	"terminalCompressProgressBar",
-
-	"rateLimitSeconds",
-	"diffEnabled",
-	"fuzzyMatchThreshold",
-	"experiments",
-
-	"codebaseIndexModels",
-	"codebaseIndexConfig",
-
-	"language",
-
-	"telemetrySetting",
-	"mcpEnabled",
-	"enableMcpServerCreation",
-
-	"mode",
-	"modeApiConfigs",
-	"customModes",
-	"customModePrompts",
-	"customSupportPrompts",
-	"enhancementApiConfigId",
-	"cachedChromeHostUrl",
-	"historyPreviewCollapsed",
-])
+export const GLOBAL_SETTINGS_KEYS = globalSettingsSchema.keyof().options
 
 /**
  * RooCodeSettings
@@ -201,32 +119,7 @@ export type RooCodeSettings = GlobalSettings & ProviderSettings
 /**
  * SecretState
  */
-
-export type SecretState = Pick<
-	ProviderSettings,
-	| "apiKey"
-	| "glamaApiKey"
-	| "openRouterApiKey"
-	| "awsAccessKey"
-	| "awsSecretKey"
-	| "awsSessionToken"
-	| "openAiApiKey"
-	| "geminiApiKey"
-	| "openAiNativeApiKey"
-	| "deepSeekApiKey"
-	| "mistralApiKey"
-	| "unboundApiKey"
-	| "requestyApiKey"
-	| "xaiApiKey"
-	| "groqApiKey"
-	| "chutesApiKey"
-	| "litellmApiKey"
-	| "codeIndexOpenAiKey"
-	| "codeIndexQdrantApiKey"
-	| "codebaseIndexOpenAiCompatibleApiKey"
->
-
-export const SECRET_STATE_KEYS = keysOf<SecretState>()([
+export const SECRET_STATE_KEYS = [
 	"apiKey",
 	"glamaApiKey",
 	"openRouterApiKey",
@@ -247,7 +140,8 @@ export const SECRET_STATE_KEYS = keysOf<SecretState>()([
 	"codeIndexOpenAiKey",
 	"codeIndexQdrantApiKey",
 	"codebaseIndexOpenAiCompatibleApiKey",
-])
+] as const satisfies readonly (keyof ProviderSettings)[]
+export type SecretState = Pick<ProviderSettings, (typeof SECRET_STATE_KEYS)[number]>
 
 export const isSecretStateKey = (key: string): key is Keys<SecretState> =>
 	SECRET_STATE_KEYS.includes(key as Keys<SecretState>)

--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -1,6 +1,5 @@
 import { z } from "zod"
 
-import { keysOf } from "./type-fu.js"
 import { reasoningEffortsSchema, modelInfoSchema } from "./model.js"
 import { codebaseIndexProviderSchema } from "./codebase-index.js"
 
@@ -259,110 +258,7 @@ export const providerSettingsSchema = z.object({
 })
 
 export type ProviderSettings = z.infer<typeof providerSettingsSchema>
-
-export const PROVIDER_SETTINGS_KEYS = keysOf<ProviderSettings>()([
-	"apiProvider",
-	// Anthropic
-	"apiModelId",
-	"apiKey",
-	"anthropicBaseUrl",
-	"anthropicUseAuthToken",
-	// Glama
-	"glamaModelId",
-	"glamaApiKey",
-	// OpenRouter
-	"openRouterApiKey",
-	"openRouterModelId",
-	"openRouterBaseUrl",
-	"openRouterSpecificProvider",
-	"openRouterUseMiddleOutTransform",
-	// Amazon Bedrock
-	"awsAccessKey",
-	"awsSecretKey",
-	"awsSessionToken",
-	"awsRegion",
-	"awsUseCrossRegionInference",
-	"awsUsePromptCache",
-	"awsProfile",
-	"awsUseProfile",
-	"awsCustomArn",
-	"awsModelContextWindow",
-	"awsBedrockEndpointEnabled",
-	"awsBedrockEndpoint",
-	// Google Vertex
-	"vertexKeyFile",
-	"vertexJsonCredentials",
-	"vertexProjectId",
-	"vertexRegion",
-	// OpenAI
-	"openAiBaseUrl",
-	"openAiApiKey",
-	"openAiLegacyFormat",
-	"openAiR1FormatEnabled",
-	"openAiModelId",
-	"openAiCustomModelInfo",
-	"openAiUseAzure",
-	"azureApiVersion",
-	"openAiStreamingEnabled",
-	"openAiHostHeader", // Keep temporarily for backward compatibility during migration.
-	"openAiHeaders",
-	// Ollama
-	"ollamaModelId",
-	"ollamaBaseUrl",
-	// VS Code LM
-	"vsCodeLmModelSelector",
-	"lmStudioModelId",
-	"lmStudioBaseUrl",
-	"lmStudioDraftModelId",
-	"lmStudioSpeculativeDecodingEnabled",
-	// Gemini
-	"geminiApiKey",
-	"googleGeminiBaseUrl",
-	// OpenAI Native
-	"openAiNativeApiKey",
-	"openAiNativeBaseUrl",
-	// Mistral
-	"mistralApiKey",
-	"mistralCodestralUrl",
-	// DeepSeek
-	"deepSeekBaseUrl",
-	"deepSeekApiKey",
-	// Unbound
-	"unboundApiKey",
-	"unboundModelId",
-	// Requesty
-	"requestyApiKey",
-	"requestyModelId",
-	// Code Index
-	"codeIndexOpenAiKey",
-	"codeIndexQdrantApiKey",
-	"codebaseIndexOpenAiCompatibleBaseUrl",
-	"codebaseIndexOpenAiCompatibleApiKey",
-	"codebaseIndexOpenAiCompatibleModelDimension",
-	// Reasoning
-	"enableReasoningEffort",
-	"reasoningEffort",
-	"modelMaxTokens",
-	"modelMaxThinkingTokens",
-	// Generic
-	"includeMaxTokens",
-	"diffEnabled",
-	"fuzzyMatchThreshold",
-	"modelTemperature",
-	"rateLimitSeconds",
-	// Fake AI
-	"fakeAi",
-	// X.AI (Grok)
-	"xaiApiKey",
-	// Groq
-	"groqApiKey",
-	// Chutes AI
-	"chutesApiKey",
-	// LiteLLM
-	"litellmBaseUrl",
-	"litellmApiKey",
-	"litellmModelId",
-])
+export const PROVIDER_SETTINGS_KEYS = providerSettingsSchema.keyof().options
 
 export const MODEL_ID_KEYS: Partial<keyof ProviderSettings>[] = [
 	"apiModelId",

--- a/packages/types/src/type-fu.ts
+++ b/packages/types/src/type-fu.ts
@@ -9,13 +9,3 @@ export type Values<T> = T[keyof T]
 export type Equals<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false
 
 export type AssertEqual<T extends true> = T
-
-/**
- * Creates a type-safe keys array that enforces ALL keys from type T are present.
- * Returns a compile-time error if any keys are missing or extra keys are provided.
- */
-export function keysOf<T>() {
-	return <const U extends readonly (keyof T)[]>(
-		keys: keyof T extends U[number] ? (U[number] extends keyof T ? U : never) : never,
-	): U => keys
-}


### PR DESCRIPTION
### Description

Reduce duplication between compile-time types and run-time types. The aim is to reduce the amount of busywork when changing in particular settings state, without loss of compile-time type safety.  This originates from https://github.com/Kilo-Org/kilocode/pull/710 (where I work), but I hope it'll be useful for you too?

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [ ] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).

I think an example speaks more clearly than type-system mumbo jumbo, so I decided to propose this with this example.  If that's really unwanted - no hard feelings for closing the PR.

- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**:
    - ? My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [x] **Testing**:
    - n/a New and/or updated tests have been added to cover my changes.
    - [x] All tests pass locally (`npm test`).
    - [x] The application builds successfully with my changes.
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- n/a  **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- n/a **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos


---

main: 
<img width="1066" alt="image" src="https://github.com/user-attachments/assets/d256ab8c-d349-44cf-b84d-274f8b31aa91" />

this branch:
![image](https://github.com/user-attachments/assets/2e3f85d1-6812-48bc-90bf-6c32dc6b48a6)

---

main:
![image](https://github.com/user-attachments/assets/e35d82fa-9de5-4e09-a2a6-924ae07aefe5)


this branch:
![image](https://github.com/user-attachments/assets/f3b5bc19-7e64-499f-8c3c-63aec792c5a0)

---

One impact to be aware of is that the ordering of the string arrays now follows those of the `zod` types, and is thus no longer manual. I don't believe that's relevant, but perhaps I'm missing some subtlety.



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor to reduce type duplication by using `zod` schema key extraction in `global-settings.ts` and `provider-settings.ts`.
> 
>   - **Refactor**:
>     - Remove `keysOf` function from `type-fu.ts`.
>     - Replace manual key arrays with `zod` schema key extraction in `global-settings.ts` and `provider-settings.ts`.
>   - **Behavior**:
>     - `GLOBAL_SETTINGS_KEYS` and `PROVIDER_SETTINGS_KEYS` now use `zod` schema key extraction.
>     - `SECRET_STATE_KEYS` is now a constant array with type assertion.
>   - **Misc**:
>     - Ordering of string arrays now follows `zod` types, not manual.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ba44e6384e67b7db4626b92e8638c7d6c506b6d8. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->