### PR TITLE
Evals fixes

### DIFF
--- a/packages/evals/src/cli/runTask.ts
+++ b/packages/evals/src/cli/runTask.ts
@@ -294,8 +294,8 @@ export const runTask = async ({ run, task, publish, logger }: RunTaskOptions) =>
 		data: {
 			configuration: {
 				...EVALS_SETTINGS,
-				...run.settings,
 				openRouterApiKey: process.env.OPENROUTER_API_KEY,
+				...run.settings, // Allow the provided settings to override `openRouterApiKey`.
 			},
 			text: prompt,
 			newTab: true,

--- a/packages/types/src/experiment.ts
+++ b/packages/types/src/experiment.ts
@@ -6,7 +6,13 @@ import type { Keys, Equals, AssertEqual } from "./type-fu.js"
  * ExperimentId
  */
 
-export const experimentIds = ["powerSteering", "concurrentFileReads", "disableCompletionCommand", "marketplace", "multiFileApplyDiff"] as const
+export const experimentIds = [
+	"powerSteering",
+	"concurrentFileReads",
+	"disableCompletionCommand",
+	"marketplace",
+	"multiFileApplyDiff",
+] as const
 
 export const experimentIdsSchema = z.enum(experimentIds)
 
@@ -17,11 +23,11 @@ export type ExperimentId = z.infer<typeof experimentIdsSchema>
  */
 
 export const experimentsSchema = z.object({
-	powerSteering: z.boolean(),
-	marketplace: z.boolean(),
-	concurrentFileReads: z.boolean(),
-	disableCompletionCommand: z.boolean(),
-	multiFileApplyDiff: z.boolean(),
+	powerSteering: z.boolean().optional(),
+	concurrentFileReads: z.boolean().optional(),
+	disableCompletionCommand: z.boolean().optional(),
+	marketplace: z.boolean().optional(),
+	multiFileApplyDiff: z.boolean().optional(),
 })
 
 export type Experiments = z.infer<typeof experimentsSchema>

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -5,7 +5,7 @@ import type {
 	HistoryItem,
 	ModeConfig,
 	TelemetrySetting,
-	ExperimentId,
+	Experiments,
 	ClineMessage,
 	OrganizationAllowList,
 	CloudUserInfo,
@@ -208,7 +208,7 @@ export type ExtensionState = Pick<
 	showRooIgnoredFiles: boolean // Whether to show .rooignore'd files in listings
 	maxReadFileLine: number // Maximum number of lines to read from a file before truncating
 
-	experiments: Record<ExperimentId, boolean> // Map of experiment IDs to their enabled state
+	experiments: Experiments // Map of experiment IDs to their enabled state
 
 	mcpEnabled: boolean
 	enableMcpServerCreation: boolean

--- a/src/shared/experiments.ts
+++ b/src/shared/experiments.ts
@@ -1,4 +1,4 @@
-import type { AssertEqual, Equals, Keys, Values, ExperimentId } from "@roo-code/types"
+import type { AssertEqual, Equals, Keys, Values, ExperimentId, Experiments } from "@roo-code/types"
 
 export const EXPERIMENT_IDS = {
 	MARKETPLACE: "marketplace",
@@ -33,6 +33,5 @@ export const experimentDefault = Object.fromEntries(
 
 export const experiments = {
 	get: (id: ExperimentKey): ExperimentConfig | undefined => experimentConfigsMap[id],
-	isEnabled: (experimentsConfig: Record<ExperimentId, boolean>, id: ExperimentId) =>
-		experimentsConfig[id] ?? experimentDefault[id],
+	isEnabled: (experimentsConfig: Experiments, id: ExperimentId) => experimentsConfig[id] ?? experimentDefault[id],
 } as const

--- a/webview-ui/src/components/settings/ExperimentalSettings.tsx
+++ b/webview-ui/src/components/settings/ExperimentalSettings.tsx
@@ -1,7 +1,7 @@
 import { HTMLAttributes } from "react"
 import { FlaskConical } from "lucide-react"
 
-import type { ExperimentId, CodebaseIndexConfig, CodebaseIndexModels, ProviderSettings } from "@roo-code/types"
+import type { Experiments, CodebaseIndexConfig, CodebaseIndexModels, ProviderSettings } from "@roo-code/types"
 
 import { EXPERIMENT_IDS, experimentConfigsMap } from "@roo/experiments"
 
@@ -17,7 +17,7 @@ import { CodeIndexSettings } from "./CodeIndexSettings"
 import { ConcurrentFileReadsExperiment } from "./ConcurrentFileReadsExperiment"
 
 type ExperimentalSettingsProps = HTMLAttributes<HTMLDivElement> & {
-	experiments: Record<ExperimentId, boolean>
+	experiments: Experiments
 	setExperimentEnabled: SetExperimentEnabled
 	maxConcurrentFileReads?: number
 	setCachedStateField: SetCachedStateField<"codebaseIndexConfig" | "maxConcurrentFileReads">


### PR DESCRIPTION
### Description

- Allow `openRouterApiKey` to be overridden by the uploaded Roo Code settings file.
- Make experiment keys optional (older builds won't populate new settings, e.g. `marketplace` and `multiFileApplyDiff`)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Allow `openRouterApiKey` override and make experiment keys optional, updating types and UI components accordingly.
> 
>   - **Behavior**:
>     - Allow `openRouterApiKey` to be overridden by `run.settings` in `runTask()` in `runTask.ts`.
>     - Make experiment keys optional in `experimentsSchema` in `experiment.ts`.
>   - **Types**:
>     - Change `experiments` type from `Record<ExperimentId, boolean>` to `Experiments` in `ExtensionMessage.ts` and `experiments.ts`.
>   - **UI**:
>     - Update `ExperimentalSettings` component in `ExperimentalSettings.tsx` to use `Experiments` type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 99fdc61f61203608b92391d0c0b49c79d8e5d1d3. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->