### PR TITLE
Fix undefined on multi-file apply_diff output

### DIFF
--- a/src/core/assistant-message/presentAssistantMessage.ts
+++ b/src/core/assistant-message/presentAssistantMessage.ts
@@ -161,7 +161,24 @@ export async function presentAssistantMessage(cline: Task) {
 					case "write_to_file":
 						return `[${block.name} for '${block.params.path}']`
 					case "apply_diff":
-						return `[${block.name} for '${block.params.path}']`
+						// Handle both legacy format and new multi-file format
+						if (block.params.path) {
+							return `[${block.name} for '${block.params.path}']`
+						} else if (block.params.args) {
+							// Try to extract first file path from args for display
+							const match = block.params.args.match(/<file>.*?<path>([^<]+)<\/path>/s)
+							if (match) {
+								const firstPath = match[1]
+								// Check if there are multiple files
+								const fileCount = (block.params.args.match(/<file>/g) || []).length
+								if (fileCount > 1) {
+									return `[${block.name} for '${firstPath}' and ${fileCount - 1} more file${fileCount > 2 ? "s" : ""}]`
+								} else {
+									return `[${block.name} for '${firstPath}']`
+								}
+							}
+						}
+						return `[${block.name}]`
 					case "search_files":
 						return `[${block.name} for '${block.params.regex}'${
 							block.params.file_pattern ? ` in '${block.params.file_pattern}'` : ""


### PR DESCRIPTION
With this PR the output should look like this:

```markdown
Input: { 
  args: `<file>
    <path>src/components/Button.tsx</path>
    <diff>...</diff>
  </file>
  <file>
    <path>src/components/Input.tsx</path>
    <diff>...</diff>
  </file>`
}
Output: [apply_diff for 'src/components/Button.tsx' and 1 more file]
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `apply_diff` output in `presentAssistantMessage.ts` to correctly display multi-file diffs.
> 
>   - **Behavior**:
>     - Updates `apply_diff` case in `presentAssistantMessage()` to handle multi-file diffs.
>     - Extracts first file path from `args` and counts total files, adjusting output message accordingly.
>     - Handles both legacy single-file and new multi-file formats.
>   - **Misc**:
>     - Adds logic to return a default message if no path or args are provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e7fee62a71fb338534307f41cfc9a0e9ad7f0f17. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->