### PR TITLE
Prevent MCP 'installed' label from being squeezed #4630

### DIFF
--- a/webview-ui/src/components/marketplace/components/MarketplaceItemCard.tsx
+++ b/webview-ui/src/components/marketplace/components/MarketplaceItemCard.tsx
@@ -114,10 +114,10 @@ export const MarketplaceItemCard: React.FC<MarketplaceItemCardProps> = ({ item, 
 
 				{/* Installation status badges and tags in the same row */}
 				{(isInstalled || (item.tags && item.tags.length > 0)) && (
-					<div className="relative flex gap-1 my-2 overflow-x-auto scrollbar-hide">
+					<div className="relative flex flex-wrap gap-1 my-2">
 						{/* Installation status badge on the left */}
 						{isInstalled && (
-							<span className="text-xs px-2 py-0.5 rounded-sm h-5 flex items-center bg-green-600/20 text-green-400 border border-green-600/30">
+							<span className="text-xs px-2 py-0.5 rounded-sm h-5 flex items-center bg-green-600/20 text-green-400 border border-green-600/30 shrink-0">
 								{t("marketplace:items.card.installed")}
 							</span>
 						)}


### PR DESCRIPTION
Closes #4630

- Add `shrink-0` class to installed badge to prevent flexbox squeezing
- Change container from `overflow-x-auto` to `flex-wrap` to allow labels to wrap instead of overflow
- Fixes issue where Korean text '설치됨' was being squeezed to only show '치'


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevent 'installed' label squeezing in `MarketplaceItemCard` by adding `shrink-0` class and allowing label wrapping.
> 
>   - **UI Fixes**:
>     - Add `shrink-0` class to the 'installed' badge in `MarketplaceItemCard` to prevent flexbox squeezing.
>     - Change container from `overflow-x-auto` to `flex-wrap` in `MarketplaceItemCard` to allow labels to wrap instead of overflow.
>   - **Localization**:
>     - Fix issue where Korean text '설치됨' was being squeezed to only show '치'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1a377e2cf69b301ae00a017ccbbf5927f8641eca. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->