### PR TITLE
Fixes #4647: .rooignore not working for .next folders in nested projects

### DIFF
--- a/src/services/glob/list-files.ts
+++ b/src/services/glob/list-files.ts
@@ -26,7 +26,12 @@ const DIRS_TO_IGNORE = [
 	"deps",
 	"pkg",
 	"Pods",
-	".*",
+	".git",
+	".svn",
+	".hg",
+	".bzr",
+	".vscode",
+	".idea",
 ]
 
 /**
@@ -156,14 +161,9 @@ function buildNonRecursiveArgs(): string[] {
 
 	// Apply directory exclusions for non-recursive searches
 	for (const dir of DIRS_TO_IGNORE) {
-		if (dir === ".*") {
-			// For hidden files/dirs in non-recursive mode
-			args.push("-g", "!.*")
-		} else {
-			// Direct children only
-			args.push("-g", `!${dir}`)
-			args.push("-g", `!${dir}/**`)
-		}
+		// Direct children only
+		args.push("-g", `!${dir}`)
+		args.push("-g", `!${dir}/**`)
 	}
 
 	return args
@@ -237,11 +237,6 @@ async function listFilteredDirectories(
  * Determine if a directory should be included in results based on filters
  */
 function shouldIncludeDirectory(dirName: string, recursive: boolean, gitignorePatterns: string[]): boolean {
-	// Skip hidden directories if configured to ignore them
-	if (dirName.startsWith(".") && DIRS_TO_IGNORE.includes(".*")) {
-		return false
-	}
-
 	// Check against explicit ignore patterns
 	if (isDirectoryExplicitlyIgnored(dirName)) {
 		return false


### PR DESCRIPTION
Fixes issue where .rooignore patterns were not working for .next folders in nested Next.js projects.

The problem was that listFiles was using a blanket '.*' pattern to exclude all hidden directories at the ripgrep level, before RooIgnoreController could process them.

Changes:
- Replace generic '.*' pattern with specific hidden directory patterns (.git, .svn, .hg, .bzr, .vscode, .idea)
- Remove special handling for '.*' pattern in directory filtering
- Add test case for the reported scenario

This allows users to specify patterns like 'example-nextjs/.next/' in .rooignore and have them work correctly.