### PR TITLE
Fixes #4601: Exclude Terraform and Terragrunt cache directories from checkpoints

### DIFF
--- a/src/services/checkpoints/__tests__/excludes.spec.ts
+++ b/src/services/checkpoints/__tests__/excludes.spec.ts
@@ -113,6 +113,8 @@ readme.md text
 			// Verify we have standard patterns but no LFS patterns
 			// Check for a few known patterns from different categories
 			expect(excludePatterns).toContain("node_modules/") // buildArtifact
+			expect(excludePatterns).toContain(".terraform/") // terraform cache
+			expect(excludePatterns).toContain(".terragrunt-cache/") // terragrunt cache
 			expect(excludePatterns).toContain("*.jpg") // media
 			expect(excludePatterns).toContain("*.tmp") // cache
 			expect(excludePatterns).toContain("*.env*") // config
@@ -144,6 +146,8 @@ readme.md text
 			// Verify we have standard patterns but no LFS patterns
 			// Check for a few known patterns from different categories
 			expect(excludePatterns).toContain("node_modules/") // buildArtifact
+			expect(excludePatterns).toContain(".terraform/") // terraform cache
+			expect(excludePatterns).toContain(".terragrunt-cache/") // terragrunt cache
 			expect(excludePatterns).toContain("*.jpg") // media
 			expect(excludePatterns).toContain("*.tmp") // cache
 			expect(excludePatterns).toContain("*.env*") // config

--- a/src/services/checkpoints/excludes.ts
+++ b/src/services/checkpoints/excludes.ts
@@ -11,6 +11,8 @@ const getBuildArtifactPatterns = () => [
 	".next/",
 	".nuxt/",
 	".sass-cache/",
+	".terraform/",
+	".terragrunt-cache/",
 	".vs/",
 	".vscode/",
 	"Pods/",


### PR DESCRIPTION
## Summary

Closes #4601

This PR fixes issue #4601 by adding  and  directories to the checkpoint exclusion patterns, preventing these large cache directories from being included in snapshots and reducing disk space usage.

## Changes Made

- Added  and  to the  function in 
- Updated tests in  to verify the new exclusion patterns are included

## Problem Solved

When working on Terraform/Terragrunt IaC projects, Roo Code's checkpoint system was including large cache directories in snapshots, consuming excessive disk space. Early in a project, these paths may not be included in .gitignore, so they were saved in every checkpoint, sometimes consuming 10x more disk space than needed.

## Solution

The checkpoint system will now automatically exclude these directories from all checkpoints, just like other build artifacts (node_modules/, .gradle/, etc.). The checkpoint system writes these patterns to .git/info/exclude in the shadow repository, ensuring Git ignores them regardless of .gitignore.

## Testing

- All existing tests pass
- Added test coverage for the new exclusion patterns
- Verified that  and  are now included in the exclude patterns

## Acceptance Criteria Met

✅ Given I'm working on an initialized Terraform|Terragrunt project with downloaded providers and without .terraform|.terragrunt-cache in .gitignore  
✅ When I run work on a task and Roo Code creates checkpoints  
✅ Then the .terraform|.terragrunt-cache directory is automatically excluded from checkpoints  
✅ And checkpoint size remains small, comparable to projects without Terraform caches  
✅ But my actual Terraform/Terragrunt configuration files (.tf, .hcl, etc.) are still included

Fixes #4601
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `.terraform/` and `.terragrunt-cache/` to checkpoint exclusion patterns in `excludes.ts` to reduce disk space usage.
> 
>   - **Behavior**:
>     - Adds `.terraform/` and `.terragrunt-cache/` to exclusion patterns in `getBuildArtifactPatterns()` in `excludes.ts`.
>     - Updates `getExcludePatterns()` in `excludes.ts` to include new patterns.
>   - **Testing**:
>     - Updates tests in `excludes.spec.ts` to verify `.terraform/` and `.terragrunt-cache/` are excluded.
>     - Ensures tests cover scenarios with and without `.gitattributes` file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 27ae143ff229550dac210524f21f60eb9ff3671d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->