### PR TITLE
Fix multi-file diff error handling and UI feedback

### DIFF
--- a/src/core/diff/strategies/multi-file-search-replace.ts
+++ b/src/core/diff/strategies/multi-file-search-replace.ts
@@ -410,7 +410,13 @@ Each file requires its own path, start_line, and diff elements.
 					resultContent = singleResult.content
 					successCount++
 				} else {
-					allFailParts.push(singleResult)
+					// If singleResult has failParts, push those directly to avoid nesting
+					if (singleResult.failParts && singleResult.failParts.length > 0) {
+						allFailParts.push(...singleResult.failParts)
+					} else {
+						// Otherwise push the single result itself
+						allFailParts.push(singleResult)
+					}
 				}
 			}
 

--- a/src/core/tools/multiApplyDiffTool.ts
+++ b/src/core/tools/multiApplyDiffTool.ts
@@ -161,7 +161,6 @@ Expected structure:
 Original error: ${errorMessage}`
 			throw new Error(detailedError)
 		}
-
 	} else if (legacyPath && typeof legacyDiffContent === "string") {
 		// Handle legacy parameters (old way)
 		usingLegacyParams = true
@@ -221,6 +220,7 @@ Original error: ${errorMessage}`
 	try {
 		// First validate all files and prepare for batch approval
 		const operationsToApprove: OperationResult[] = []
+		const allDiffErrors: string[] = [] // Collect all diff errors
 
 		for (const operation of operations) {
 			const { path: relPath, diff: diffItems } = operation
@@ -427,6 +427,9 @@ Original error: ${errorMessage}`
 								continue
 							}
 
+							// Collect error for later reporting
+							allDiffErrors.push(`${relPath} - Diff ${i + 1}: ${failPart.error}`)
+
 							const errorDetails = failPart.details ? JSON.stringify(failPart.details, null, 2) : ""
 							formattedError += `<error_details>
 Diff ${i + 1} failed for file: ${relPath}
@@ -471,6 +474,17 @@ ${errorDetails ? `\nTechnical details:\n${errorDetails}\n` : ""}
 						}
 						cline.recordToolError("apply_diff", formattedError)
 						results.push(formattedError)
+
+						// For single file operations, we need to send a complete message to stop the spinner
+						if (operationsToApprove.length === 1) {
+							const sharedMessageProps: ClineSayTool = {
+								tool: "appliedDiff",
+								path: getReadablePath(cline.cwd, relPath),
+								diff: diffItems.map((item) => item.content).join("\n\n"),
+							}
+							// Send a complete message (partial: false) to update the UI and stop the spinner
+							await cline.ask("tool", JSON.stringify(sharedMessageProps), false).catch(() => {})
+						}
 					}
 					continue
 				}
@@ -557,6 +571,11 @@ ${errorDetails ? `\nTechnical details:\n${errorDetails}\n` : ""}
 		// Add filtered operation errors to results
 		if (filteredOperationErrors.length > 0) {
 			results.push(...filteredOperationErrors)
+		}
+
+		// Report all diff errors at once if any
+		if (allDiffErrors.length > 0) {
+			await cline.say("diff_error", allDiffErrors.join("\n"))
 		}
 
 		// Push the final result combining all operation results


### PR DESCRIPTION
This PR fixes several issues with multi-file diff error handling:

- **Fixed nested array structure**: Resolved issue where failed diff parts were creating nested arrays, causing error handling to malfunction
- **Consolidated error reporting**: All diff errors are now collected and reported in a single message instead of multiple separate calls
- **Fixed infinite spinner**: Single file diff failures now properly update the UI to stop the loading spinner

Resolves #4664
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes error handling and UI feedback for multi-file diffs, addressing nested arrays, consolidated error reporting, and UI spinner issues.
> 
>   - **Error Handling**:
>     - Fix nested array issue in `applyDiff()` in `multi-file-search-replace.ts` by flattening `failParts`.
>     - Consolidate error reporting in `applyDiffTool()` in `multiApplyDiffTool.ts` by collecting all errors in `allDiffErrors`.
>   - **UI Feedback**:
>     - Resolve infinite spinner issue in `applyDiffTool()` in `multiApplyDiffTool.ts` by sending a complete message for single file operations.
>   - **Misc**:
>     - Remove unnecessary line in `multiApplyDiffTool.ts` for cleaner code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for f8bd0012da075fbdf9fc2e38e1d6500ea2ae33b9. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->