### PR TITLE
fix: improve prompt history navigation to not interfere with text editing

### DIFF
--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -159,13 +159,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		const [isFocused, setIsFocused] = useState(false)
 
 		// Use custom hook for prompt history navigation
-		const {
-			inputValueWithCursor,
-			setInputValueWithCursor,
-			handleHistoryNavigation,
-			resetHistoryNavigation,
-			resetOnInputChange,
-		} = usePromptHistory({
+		const { handleHistoryNavigation, resetHistoryNavigation, resetOnInputChange } = usePromptHistory({
 			clineMessages,
 			taskHistory,
 			cwd,
@@ -465,27 +459,6 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				setIntendedCursorPosition(null) // Reset the state.
 			}
 		}, [inputValue, intendedCursorPosition])
-
-		// Handle cursor positioning after history navigation
-		useLayoutEffect(() => {
-			if (!inputValueWithCursor.afterRender || !textAreaRef.current) return
-
-			if (inputValueWithCursor.afterRender === "SET_CURSOR_FIRST_LINE") {
-				const firstLineEnd =
-					inputValueWithCursor.value.indexOf("\n") === -1
-						? inputValueWithCursor.value.length
-						: inputValueWithCursor.value.indexOf("\n")
-				textAreaRef.current.setSelectionRange(firstLineEnd, firstLineEnd)
-			} else if (inputValueWithCursor.afterRender === "SET_CURSOR_LAST_LINE") {
-				const lines = inputValueWithCursor.value.split("\n")
-				const lastLineStart = inputValueWithCursor.value.length - lines[lines.length - 1].length
-				textAreaRef.current.setSelectionRange(lastLineStart, lastLineStart)
-			} else if (inputValueWithCursor.afterRender === "SET_CURSOR_START") {
-				textAreaRef.current.setSelectionRange(0, 0)
-			}
-
-			setInputValueWithCursor({ value: inputValueWithCursor.value })
-		}, [inputValueWithCursor, setInputValueWithCursor])
 
 		// Ref to store the search timeout.
 		const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null)


### PR DESCRIPTION
This PR fixes the issue where up/down arrows would load old prompts instead of moving the cursor when editing multi-line text.

Changes:
- Up arrow only triggers history navigation when cursor is at the beginning of text
- Added Alt+Up/Down for explicit history navigation at any cursor position
- Down arrow in history mode works intelligently at both beginning and end of text
- History navigation resets when user types to avoid accidental loads
- Extracted prompt history logic into dedicated usePromptHistory hook

The default behavior now allows normal text editing with arrow keys, while still providing convenient access to prompt history when needed.

Fixes #4669