### PR TITLE
Fix errant maxReadFileLine default

### DIFF
--- a/src/core/tools/readFileTool.ts
+++ b/src/core/tools/readFileTool.ts
@@ -429,7 +429,7 @@ export async function readFileTool(
 
 			const relPath = fileResult.path
 			const fullPath = path.resolve(cline.cwd, relPath)
-			const { maxReadFileLine = 500 } = (await cline.providerRef.deref()?.getState()) ?? {}
+			const { maxReadFileLine = -1 } = (await cline.providerRef.deref()?.getState()) ?? {}
 
 			// Process approved files
 			try {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default `maxReadFileLine` from `500` to `-1` in `readFileTool()` to allow unlimited lines by default.
> 
>   - **Behavior**:
>     - Change default value of `maxReadFileLine` from `500` to `-1` in `readFileTool()` in `readFileTool.ts`.
>     - Affects how files are read when `maxReadFileLine` is not set, potentially allowing unlimited lines to be read by default.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1e97ad360c6ec57399e479dfd619ddb106f7a00a. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->