### PR TITLE
fix: update marketplace branding to 'Roo Marketplace' (#4706)

### DIFF
--- a/webview-ui/src/i18n/locales/ca/marketplace.json
+++ b/webview-ui/src/i18n/locales/ca/marketplace.json
@@ -1,5 +1,5 @@
 {
-	"title": "Marketplace",
+	"title": "Roo Marketplace",
 	"tabs": {
 		"installed": "Instal·lat",
 		"settings": "Configuració",

--- a/webview-ui/src/i18n/locales/de/marketplace.json
+++ b/webview-ui/src/i18n/locales/de/marketplace.json
@@ -1,5 +1,5 @@
 {
-	"title": "Marketplace",
+	"title": "Roo Marketplace",
 	"tabs": {
 		"installed": "Installiert",
 		"settings": "Einstellungen",

--- a/webview-ui/src/i18n/locales/en/marketplace.json
+++ b/webview-ui/src/i18n/locales/en/marketplace.json
@@ -1,5 +1,5 @@
 {
-	"title": "Marketplace",
+	"title": "Roo Marketplace",
 	"tabs": {
 		"installed": "Installed",
 		"settings": "Settings",

--- a/webview-ui/src/i18n/locales/es/marketplace.json
+++ b/webview-ui/src/i18n/locales/es/marketplace.json
@@ -1,5 +1,5 @@
 {
-	"title": "Marketplace",
+	"title": "Roo Marketplace",
 	"tabs": {
 		"installed": "Instalado",
 		"settings": "Configuración",

--- a/webview-ui/src/i18n/locales/fr/marketplace.json
+++ b/webview-ui/src/i18n/locales/fr/marketplace.json
@@ -1,5 +1,5 @@
 {
-	"title": "Marketplace",
+	"title": "Roo Marketplace",
 	"tabs": {
 		"installed": "Installé",
 		"settings": "Paramètres",

--- a/webview-ui/src/i18n/locales/hi/marketplace.json
+++ b/webview-ui/src/i18n/locales/hi/marketplace.json
@@ -1,5 +1,5 @@
 {
-	"title": "Marketplace",
+	"title": "Roo Marketplace",
 	"tabs": {
 		"installed": "इंस्टॉल किया गया",
 		"settings": "सेटिंग्स",

--- a/webview-ui/src/i18n/locales/id/marketplace.json
+++ b/webview-ui/src/i18n/locales/id/marketplace.json
@@ -1,5 +1,5 @@
 {
-	"title": "Marketplace",
+	"title": "Roo Marketplace",
 	"tabs": {
 		"installed": "Terinstal",
 		"settings": "Pengaturan",

--- a/webview-ui/src/i18n/locales/it/marketplace.json
+++ b/webview-ui/src/i18n/locales/it/marketplace.json
@@ -1,5 +1,5 @@
 {
-	"title": "Marketplace",
+	"title": "Roo Marketplace",
 	"tabs": {
 		"installed": "Installati",
 		"settings": "Impostazioni",

--- a/webview-ui/src/i18n/locales/ja/marketplace.json
+++ b/webview-ui/src/i18n/locales/ja/marketplace.json
@@ -1,5 +1,5 @@
 {
-	"title": "Marketplace",
+	"title": "Roo Marketplace",
 	"tabs": {
 		"installed": "インストール済み",
 		"settings": "設定",

--- a/webview-ui/src/i18n/locales/ko/marketplace.json
+++ b/webview-ui/src/i18n/locales/ko/marketplace.json
@@ -1,5 +1,5 @@
 {
-	"title": "Marketplace",
+	"title": "Roo Marketplace",
 	"tabs": {
 		"installed": "설치됨",
 		"settings": "설정",

--- a/webview-ui/src/i18n/locales/nl/marketplace.json
+++ b/webview-ui/src/i18n/locales/nl/marketplace.json
@@ -1,5 +1,5 @@
 {
-	"title": "Marketplace",
+	"title": "Roo Marketplace",
 	"tabs": {
 		"installed": "Geïnstalleerd",
 		"settings": "Instellingen",

--- a/webview-ui/src/i18n/locales/pl/marketplace.json
+++ b/webview-ui/src/i18n/locales/pl/marketplace.json
@@ -1,5 +1,5 @@
 {
-	"title": "Marketplace",
+	"title": "Roo Marketplace",
 	"tabs": {
 		"installed": "Zainstalowane",
 		"settings": "Ustawienia",

--- a/webview-ui/src/i18n/locales/pt-BR/marketplace.json
+++ b/webview-ui/src/i18n/locales/pt-BR/marketplace.json
@@ -1,5 +1,5 @@
 {
-	"title": "Marketplace",
+	"title": "Roo Marketplace",
 	"tabs": {
 		"installed": "Instalado",
 		"settings": "Configurações",

--- a/webview-ui/src/i18n/locales/ru/marketplace.json
+++ b/webview-ui/src/i18n/locales/ru/marketplace.json
@@ -1,5 +1,5 @@
 {
-	"title": "Marketplace",
+	"title": "Roo Marketplace",
 	"tabs": {
 		"installed": "Установлено",
 		"settings": "Настройки",

--- a/webview-ui/src/i18n/locales/tr/marketplace.json
+++ b/webview-ui/src/i18n/locales/tr/marketplace.json
@@ -1,5 +1,5 @@
 {
-	"title": "Marketplace",
+	"title": "Roo Marketplace",
 	"tabs": {
 		"installed": "Yüklü",
 		"settings": "Ayarlar",

--- a/webview-ui/src/i18n/locales/vi/marketplace.json
+++ b/webview-ui/src/i18n/locales/vi/marketplace.json
@@ -1,5 +1,5 @@
 {
-	"title": "Marketplace",
+	"title": "Roo Marketplace",
 	"tabs": {
 		"installed": "Đã cài đặt",
 		"settings": "Cài đặt",

--- a/webview-ui/src/i18n/locales/zh-CN/marketplace.json
+++ b/webview-ui/src/i18n/locales/zh-CN/marketplace.json
@@ -1,5 +1,5 @@
 {
-	"title": "Marketplace",
+	"title": "Roo Marketplace",
 	"tabs": {
 		"installed": "已安装",
 		"settings": "设置",

--- a/webview-ui/src/i18n/locales/zh-TW/marketplace.json
+++ b/webview-ui/src/i18n/locales/zh-TW/marketplace.json
@@ -1,5 +1,5 @@
 {
-	"title": "Marketplace",
+	"title": "Roo Marketplace",
 	"tabs": {
 		"installed": "已安裝",
 		"settings": "設定",


### PR DESCRIPTION
## Description

Fixes #4706

Updated the marketplace UI branding from "Marketplace" to "Roo Marketplace" for consistent branding across the application.

## Changes Made

- Updated the `title` field in all marketplace translation files from "Marketplace" to "Roo Marketplace"
- Modified 18 language locale files to maintain consistency across all supported languages:
  - English (en)
  - French (fr)
  - Spanish (es)
  - German (de)
  - Italian (it)
  - Portuguese Brazil (pt-BR)
  - Russian (ru)
  - Dutch (nl)
  - Polish (pl)
  - Turkish (tr)
  - Vietnamese (vi)
  - Chinese Simplified (zh-CN)
  - Chinese Traditional (zh-TW)
  - Japanese (ja)
  - Korean (ko)
  - Indonesian (id)
  - Hindi (hi)
  - Catalan (ca)

## Testing

- [x] All existing marketplace tests pass
- [x] Linting checks pass
- [x] Type checking passes
- [x] Build process completes successfully
- [x] All translation files updated consistently

## Verification of Acceptance Criteria

- [x] UI element labeled 'Marketplace' updated to 'Roo Marketplace'
- [x] Consistent branding maintained across all language locales
- [x] No breaking changes introduced
- [x] All tests continue to pass

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No breaking changes
- [x] All translation files updated consistently
- [x] Tests pass
- [x] Linting and type checking pass

## Screenshots/Demo

The change affects the marketplace title displayed in the UI. The title will now show "Roo Marketplace" instead of "Marketplace" in all supported languages, providing consistent branding throughout the application.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update marketplace branding to 'Roo Marketplace' in 18 language locale files for consistent UI branding.
> 
>   - **Behavior**:
>     - Updated `title` field from "Marketplace" to "Roo Marketplace" in 18 language locale files for consistent branding.
>   - **Locales**:
>     - Affected languages include English, French, Spanish, German, Italian, Portuguese (Brazil), Russian, Dutch, Polish, Turkish, Vietnamese, Chinese (Simplified and Traditional), Japanese, Korean, Indonesian, Hindi, and Catalan.
>   - **Testing**:
>     - All existing marketplace tests pass.
>     - Linting and type checking pass.
>     - Build process completes successfully.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for bc9e8033da3626e44fdd758eea3f893d8f5cf50e. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->