### PR TITLE
fix: improve Bedrock error handling for throttling and streaming contexts (#4745)

### DIFF
--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -102,6 +102,7 @@ const bedrockSchema = apiModelIdProviderModelSchema.extend({
 	awsModelContextWindow: z.number().optional(),
 	awsBedrockEndpointEnabled: z.boolean().optional(),
 	awsBedrockEndpoint: z.string().optional(),
+	awsBedrockVerboseErrors: z.boolean().optional(),
 })
 
 const vertexSchema = apiModelIdProviderModelSchema.extend({

--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -102,7 +102,6 @@ const bedrockSchema = apiModelIdProviderModelSchema.extend({
 	awsModelContextWindow: z.number().optional(),
 	awsBedrockEndpointEnabled: z.boolean().optional(),
 	awsBedrockEndpoint: z.string().optional(),
-	awsBedrockVerboseErrors: z.boolean().optional(),
 })
 
 const vertexSchema = apiModelIdProviderModelSchema.extend({

--- a/src/api/providers/__tests__/bedrock-error-handling.spec.ts
+++ b/src/api/providers/__tests__/bedrock-error-handling.spec.ts
@@ -242,8 +242,12 @@ describe("AwsBedrockHandler Error Handling", () => {
 			})
 
 			const mockStream = {
-				async *[Symbol.asyncIterator]() {
-					throw throttleError
+				[Symbol.asyncIterator]() {
+					return {
+						async next() {
+							throw throttleError
+						},
+					}
 				},
 			}
 
@@ -267,8 +271,12 @@ describe("AwsBedrockHandler Error Handling", () => {
 			})
 
 			const mockStream = {
-				async *[Symbol.asyncIterator]() {
-					throw genericError
+				[Symbol.asyncIterator]() {
+					return {
+						async next() {
+							throw genericError
+						},
+					}
 				},
 			}
 

--- a/src/api/providers/__tests__/bedrock-error-handling.spec.ts
+++ b/src/api/providers/__tests__/bedrock-error-handling.spec.ts
@@ -1,0 +1,347 @@
+import { vi } from "vitest"
+
+// Mock BedrockRuntimeClient and commands
+const mockSend = vi.fn()
+
+// Mock AWS SDK credential providers
+vi.mock("@aws-sdk/credential-providers", () => {
+	return {
+		fromIni: vi.fn().mockReturnValue({
+			accessKeyId: "profile-access-key",
+			secretAccessKey: "profile-secret-key",
+		}),
+	}
+})
+
+vi.mock("@aws-sdk/client-bedrock-runtime", () => ({
+	BedrockRuntimeClient: vi.fn().mockImplementation(() => ({
+		send: mockSend,
+	})),
+	ConverseStreamCommand: vi.fn(),
+	ConverseCommand: vi.fn(),
+}))
+
+import { AwsBedrockHandler } from "../bedrock"
+import { Anthropic } from "@anthropic-ai/sdk"
+
+describe("AwsBedrockHandler Error Handling", () => {
+	let handler: AwsBedrockHandler
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		handler = new AwsBedrockHandler({
+			apiModelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+			awsAccessKey: "test-access-key",
+			awsSecretKey: "test-secret-key",
+			awsRegion: "us-east-1",
+		})
+	})
+
+	const createMockError = (options: {
+		message?: string
+		name?: string
+		status?: number
+		__type?: string
+		$metadata?: { httpStatusCode?: number }
+	}): Error => {
+		const error = new Error(options.message || "Test error") as any
+		if (options.name) error.name = options.name
+		if (options.status) error.status = options.status
+		if (options.__type) error.__type = options.__type
+		if (options.$metadata) error.$metadata = options.$metadata
+		return error
+	}
+
+	describe("Throttling Error Detection", () => {
+		it("should detect throttling from HTTP 429 status code", async () => {
+			const throttleError = createMockError({
+				message: "Request failed",
+				status: 429,
+			})
+
+			mockSend.mockRejectedValueOnce(throttleError)
+
+			try {
+				const result = await handler.completePrompt("test")
+				expect(result).toContain("throttled or rate limited")
+			} catch (error) {
+				expect(error.message).toContain("throttled or rate limited")
+			}
+		})
+
+		it("should detect throttling from AWS SDK $metadata.httpStatusCode", async () => {
+			const throttleError = createMockError({
+				message: "Request failed",
+				$metadata: { httpStatusCode: 429 },
+			})
+
+			mockSend.mockRejectedValueOnce(throttleError)
+
+			try {
+				const result = await handler.completePrompt("test")
+				expect(result).toContain("throttled or rate limited")
+			} catch (error) {
+				expect(error.message).toContain("throttled or rate limited")
+			}
+		})
+
+		it("should detect throttling from ThrottlingException name", async () => {
+			const throttleError = createMockError({
+				message: "Request failed",
+				name: "ThrottlingException",
+			})
+
+			mockSend.mockRejectedValueOnce(throttleError)
+
+			try {
+				const result = await handler.completePrompt("test")
+				expect(result).toContain("throttled or rate limited")
+			} catch (error) {
+				expect(error.message).toContain("throttled or rate limited")
+			}
+		})
+
+		it("should detect throttling from __type field", async () => {
+			const throttleError = createMockError({
+				message: "Request failed",
+				__type: "ThrottlingException",
+			})
+
+			mockSend.mockRejectedValueOnce(throttleError)
+
+			try {
+				const result = await handler.completePrompt("test")
+				expect(result).toContain("throttled or rate limited")
+			} catch (error) {
+				expect(error.message).toContain("throttled or rate limited")
+			}
+		})
+
+		it("should detect throttling from 'Bedrock is unable to process your request' message", async () => {
+			const throttleError = createMockError({
+				message: "Bedrock is unable to process your request",
+			})
+
+			mockSend.mockRejectedValueOnce(throttleError)
+
+			try {
+				const result = await handler.completePrompt("test")
+				expect(result).toContain("throttled or rate limited")
+			} catch (error) {
+				expect(error.message).toContain("throttled or rate limited")
+			}
+		})
+
+		it("should detect throttling from various message patterns", async () => {
+			const throttlingMessages = [
+				"Request throttled",
+				"Rate limit exceeded",
+				"Too many requests",
+				"Service unavailable due to high demand",
+				"Server is overloaded",
+				"System is busy",
+				"Please wait and try again",
+			]
+
+			for (const message of throttlingMessages) {
+				const throttleError = createMockError({ message })
+				mockSend.mockRejectedValueOnce(throttleError)
+
+				try {
+					await handler.completePrompt("test")
+					// Should not reach here as completePrompt should throw
+					throw new Error("Expected error to be thrown")
+				} catch (error) {
+					expect(error.message).toContain("throttled or rate limited")
+				}
+			}
+		})
+	})
+
+	describe("Service Quota Exceeded Detection", () => {
+		it("should detect service quota exceeded errors", async () => {
+			const quotaError = createMockError({
+				message: "Service quota exceeded for model requests",
+			})
+
+			mockSend.mockRejectedValueOnce(quotaError)
+
+			try {
+				const result = await handler.completePrompt("test")
+				expect(result).toContain("Service quota exceeded")
+			} catch (error) {
+				expect(error.message).toContain("Service quota exceeded")
+			}
+		})
+	})
+
+	describe("Model Not Ready Detection", () => {
+		it("should detect model not ready errors", async () => {
+			const modelError = createMockError({
+				message: "Model is not ready, please try again later",
+			})
+
+			mockSend.mockRejectedValueOnce(modelError)
+
+			try {
+				const result = await handler.completePrompt("test")
+				expect(result).toContain("Model is not ready")
+			} catch (error) {
+				expect(error.message).toContain("Model is not ready")
+			}
+		})
+	})
+
+	describe("Internal Server Error Detection", () => {
+		it("should detect internal server errors", async () => {
+			const serverError = createMockError({
+				message: "Internal server error occurred",
+			})
+
+			mockSend.mockRejectedValueOnce(serverError)
+
+			try {
+				const result = await handler.completePrompt("test")
+				expect(result).toContain("internal server error")
+			} catch (error) {
+				expect(error.message).toContain("internal server error")
+			}
+		})
+	})
+
+	describe("Token Limit Detection", () => {
+		it("should detect enhanced token limit errors", async () => {
+			const tokenErrors = [
+				"Too many tokens in request",
+				"Token limit exceeded",
+				"Maximum context length reached",
+				"Context length exceeds limit",
+			]
+
+			for (const message of tokenErrors) {
+				const tokenError = createMockError({ message })
+				mockSend.mockRejectedValueOnce(tokenError)
+
+				try {
+					await handler.completePrompt("test")
+					// Should not reach here as completePrompt should throw
+					throw new Error("Expected error to be thrown")
+				} catch (error) {
+					// Either "Too many tokens" for token-specific errors or "throttled" for limit-related errors
+					expect(error.message).toMatch(/Too many tokens|throttled or rate limited/)
+				}
+			}
+		})
+	})
+
+	describe("Streaming Context Error Handling", () => {
+		it("should handle throttling errors in streaming context", async () => {
+			const throttleError = createMockError({
+				message: "Bedrock is unable to process your request",
+				status: 429,
+			})
+
+			const mockStream = {
+				async *[Symbol.asyncIterator]() {
+					throw throttleError
+				},
+			}
+
+			mockSend.mockResolvedValueOnce({ stream: mockStream })
+
+			const generator = handler.createMessage("system", [{ role: "user", content: "test" }])
+
+			// For throttling errors, it should throw immediately without yielding chunks
+			// This allows the retry mechanism to catch and handle it
+			await expect(async () => {
+				for await (const chunk of generator) {
+					// Should not yield any chunks for throttling errors
+				}
+			}).rejects.toThrow("Bedrock is unable to process your request")
+		})
+
+		it("should yield error chunks for non-throttling errors in streaming context", async () => {
+			const genericError = createMockError({
+				message: "Some other error",
+				status: 500,
+			})
+
+			const mockStream = {
+				async *[Symbol.asyncIterator]() {
+					throw genericError
+				},
+			}
+
+			mockSend.mockResolvedValueOnce({ stream: mockStream })
+
+			const generator = handler.createMessage("system", [{ role: "user", content: "test" }])
+
+			const chunks: any[] = []
+			try {
+				for await (const chunk of generator) {
+					chunks.push(chunk)
+				}
+			} catch (error) {
+				// Expected to throw after yielding chunks
+			}
+
+			// Should have yielded error chunks before throwing for non-throttling errors
+			expect(
+				chunks.some((chunk) => chunk.type === "text" && chunk.text && chunk.text.includes("Some other error")),
+			).toBe(true)
+		})
+	})
+
+	describe("Error Priority and Specificity", () => {
+		it("should prioritize HTTP status codes over message patterns", async () => {
+			// Error with both 429 status and generic message should be detected as throttling
+			const mixedError = createMockError({
+				message: "Some generic error message",
+				status: 429,
+			})
+
+			mockSend.mockRejectedValueOnce(mixedError)
+
+			try {
+				const result = await handler.completePrompt("test")
+				expect(result).toContain("throttled or rate limited")
+			} catch (error) {
+				expect(error.message).toContain("throttled or rate limited")
+			}
+		})
+
+		it("should prioritize AWS error types over message patterns", async () => {
+			// Error with ThrottlingException name but different message should still be throttling
+			const specificError = createMockError({
+				message: "Some other error occurred",
+				name: "ThrottlingException",
+			})
+
+			mockSend.mockRejectedValueOnce(specificError)
+
+			try {
+				const result = await handler.completePrompt("test")
+				expect(result).toContain("throttled or rate limited")
+			} catch (error) {
+				expect(error.message).toContain("throttled or rate limited")
+			}
+		})
+	})
+
+	describe("Unknown Error Fallback", () => {
+		it("should still show unknown error for truly unrecognized errors", async () => {
+			const unknownError = createMockError({
+				message: "Something completely unexpected happened",
+			})
+
+			mockSend.mockRejectedValueOnce(unknownError)
+
+			try {
+				const result = await handler.completePrompt("test")
+				expect(result).toContain("Unknown Error")
+			} catch (error) {
+				expect(error.message).toContain("Unknown Error")
+			}
+		})
+	})
+})

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -1104,7 +1104,7 @@ Please verify:
 2. If using a provisioned model, check its throughput settings
 3. Contact AWS support to request a quota increase if needed
 
-{formattedErrorDetails}
+
 
 `,
 			logLevel: "error",
@@ -1125,7 +1125,7 @@ Suggestions:
 4. If rate limited, reduce request frequency
 5. Check your Amazon Bedrock quotas and limits
 
-{formattedErrorDetails}`,
+`,
 			logLevel: "error",
 		},
 		SERVICE_QUOTA_EXCEEDED: {
@@ -1138,7 +1138,7 @@ Please try:
 3. Check your AWS Bedrock quotas in the AWS console
 4. Consider using a different model or region with available capacity
 
-{formattedErrorDetails}`,
+`,
 			logLevel: "error",
 		},
 		MODEL_NOT_READY: {
@@ -1153,7 +1153,7 @@ Please try:
 2. Check the model status in AWS Bedrock console
 3. Verify the model is properly provisioned
 
-{formattedErrorDetails}`,
+`,
 			logLevel: "error",
 		},
 		INTERNAL_SERVER_ERROR: {
@@ -1165,7 +1165,7 @@ Please try:
 2. If the error persists, check AWS service health
 3. Contact AWS support if the issue continues
 
-{formattedErrorDetails}`,
+`,
 			logLevel: "error",
 		},
 		ON_DEMAND_NOT_SUPPORTED: {
@@ -1280,7 +1280,6 @@ Please check:
 			const modelConfig = this.getModel()
 			templateVars.modelId = modelConfig.id
 			templateVars.contextWindow = String(modelConfig.info.contextWindow || "unknown")
-			templateVars.formattedErrorDetails = ""
 		}
 
 		// Add context-specific template variables


### PR DESCRIPTION
## Description

Fixes #4745

This PR improves AWS Bedrock error handling by addressing two critical issues:

1. **Better throttling error detection**: The error message "Bedrock is unable to process your request" is now properly identified as a throttling error
2. **Enhanced streaming error handling**: Throttling errors in streaming contexts now throw immediately (without yielding error chunks), enabling the retry mechanism to work properly

## Changes Made

- **`src/api/providers/bedrock.ts`**: 
  - Added "bedrock is unable to process your request" to throttling error patterns (line 1051)
  - Enhanced streaming error handler to differentiate throttling vs. non-throttling errors (lines 560-577)
  - For throttling errors: throw immediately without yielding chunks (enables retry)
  - For non-throttling errors: maintain existing behavior (yield error chunks then throw)

- **`src/api/providers/__tests__/bedrock-error-handling.spec.ts`**: 
  - Created comprehensive test suite with 15 test cases
  - Covers all error detection scenarios including the specific "Bedrock is unable to process" message
  - Tests streaming context error handling for both throttling and non-throttling errors
  - Validates error priority and specificity rules

## Testing

- [x] All existing tests pass
- [x] Added 15 new tests covering error handling scenarios:
  - [x] Throttling error detection from various sources (HTTP status, AWS error types, message patterns)
  - [x] Specific test for "Bedrock is unable to process your request" message
  - [x] Streaming context error handling (throttling vs. non-throttling)
  - [x] Error priority validation
  - [x] Service quota, model readiness, and token limit detection
- [x] Manual testing completed:
  - [x] Throttling errors now properly trigger retry mechanism
  - [x] "Bedrock is unable to process your request" shows appropriate user guidance

## Verification of Acceptance Criteria

- [x] **Criterion 1**: AWS throttling errors with message "Bedrock is unable to process your request" are now properly identified as THROTTLING errors, display appropriate guidance, and trigger auto-retry when enabled
- [x] **Criterion 2**: Throttling errors during streaming are handled gracefully by throwing immediately (without yielding error chunks), allowing the retry mechanism to work while providing proper user messaging

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] No breaking changes
- [x] Comprehensive test coverage added
- [x] All tests passing
- [x] Linting passes
- [x] TypeScript checks pass

This fix significantly improves the user experience when encountering AWS Bedrock throttling errors by providing proper error identification, user guidance, and automatic retry functionality.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improves AWS Bedrock error handling by enhancing throttling detection and streaming error management, with comprehensive tests added.
> 
>   - **Behavior**:
>     - Improved throttling error detection in `bedrock.ts` by recognizing "Bedrock is unable to process your request" as a throttling error.
>     - Enhanced streaming error handling in `bedrock.ts` to immediately throw throttling errors, enabling retry mechanisms.
>     - Non-throttling errors in streaming contexts yield error chunks before throwing.
>   - **Error Handling**:
>     - Updated `getErrorType()` in `bedrock.ts` to prioritize error types and include new patterns for throttling and other errors.
>     - Added comprehensive error handling tests in `bedrock-error-handling.spec.ts` with 15 test cases covering various error scenarios.
>   - **Testing**:
>     - Added tests for throttling detection from HTTP status, AWS error types, and specific messages.
>     - Validated error handling in streaming contexts for both throttling and non-throttling errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 88e2eaef1fff69e1982d2ec1339cd023be94c7ab. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->


https://github.com/user-attachments/assets/91d4ee27-7900-4790-a16b-b2a03ba8529f

