### PR TITLE
Fixes #4744: Search and replace tool needs to fail if search query not specific enough

### DIFF
--- a/src/core/tools/__tests__/searchAndReplaceTool.test.ts
+++ b/src/core/tools/__tests__/searchAndReplaceTool.test.ts
@@ -1,0 +1,408 @@
+import fs from "fs/promises"
+import path from "path"
+import { jest } from "@jest/globals"
+
+import { searchAndReplaceTool } from "../searchAndReplaceTool"
+import { Task } from "../../task/Task"
+import { ToolUse, AskApproval, HandleError, PushToolResult, RemoveClosingTag } from "../../../shared/tools"
+import { fileExistsAtPath } from "../../../utils/fs"
+
+// Mock dependencies
+jest.mock("fs/promises")
+jest.mock("../../task/Task")
+jest.mock("../../../utils/fs", () => ({
+	fileExistsAtPath: jest.fn(),
+}))
+
+const mockFs = fs as jest.Mocked<typeof fs>
+const mockFileExistsAtPath = fileExistsAtPath as jest.MockedFunction<typeof fileExistsAtPath>
+
+describe("searchAndReplaceTool", () => {
+	let mockTask: jest.Mocked<Task>
+	let mockPushToolResult: PushToolResult
+	let mockAskApproval: AskApproval
+	let mockHandleError: HandleError
+	let mockRemoveClosingTag: RemoveClosingTag
+
+	beforeEach(() => {
+		// Reset all mocks
+		jest.clearAllMocks()
+
+		// Mock Task instance
+		mockTask = {
+			consecutiveMistakeCount: 0,
+			cwd: "/test/workspace",
+			recordToolError: jest.fn(),
+			sayAndCreateMissingParamError: jest.fn(),
+			say: jest.fn(),
+			ask: jest.fn(),
+			diffViewProvider: {
+				editType: "",
+				originalContent: "",
+				isEditing: false,
+				open: jest.fn(),
+				update: jest.fn(),
+				scrollToFirstDiff: jest.fn(),
+				reset: jest.fn(),
+				revertChanges: jest.fn(),
+				saveChanges: jest.fn(),
+				pushToolWriteResult: jest.fn(() => Promise.resolve("File updated successfully")) as any,
+			},
+			rooIgnoreController: {
+				validateAccess: jest.fn().mockReturnValue(true),
+			},
+			rooProtectedController: {
+				isWriteProtected: jest.fn().mockReturnValue(false),
+			},
+			fileContextTracker: {
+				trackFileContext: jest.fn(),
+			},
+			didEditFile: false,
+			recordToolUsage: jest.fn(),
+		} as any
+
+		// Mock helper functions
+		mockPushToolResult = jest.fn() as PushToolResult
+		mockAskApproval = jest.fn(() => Promise.resolve(true)) as jest.MockedFunction<AskApproval>
+		mockHandleError = jest.fn(() => Promise.resolve()) as jest.MockedFunction<HandleError>
+		mockRemoveClosingTag = jest.fn(
+			(tag: string, value?: string) => value || "",
+		) as jest.MockedFunction<RemoveClosingTag>
+
+		// Mock file system
+		mockFs.readFile.mockResolvedValue("test content")
+		mockFileExistsAtPath.mockResolvedValue(true)
+	})
+
+	describe("multiple match detection", () => {
+		it("should fail when search query matches multiple locations in entire file", async () => {
+			const fileContent = `function test() {
+    return true;
+}
+
+function another() {
+    return false;
+}
+
+function third() {
+    return null;
+}`
+
+			mockFs.readFile.mockResolvedValue(fileContent)
+
+			const toolUse: ToolUse = {
+				type: "tool_use",
+				name: "search_and_replace",
+				params: {
+					path: "test.js",
+					search: "}",
+					replace: "} // modified",
+				},
+				partial: false,
+			}
+
+			await searchAndReplaceTool(
+				mockTask,
+				toolUse,
+				mockAskApproval,
+				mockHandleError,
+				mockPushToolResult,
+				mockRemoveClosingTag,
+			)
+
+			expect(mockTask.consecutiveMistakeCount).toBe(1)
+			expect(mockTask.recordToolError).toHaveBeenCalledWith("search_and_replace")
+			expect(mockPushToolResult).toHaveBeenCalledWith(
+				expect.stringContaining("Search query matches 3 locations in the file"),
+			)
+			expect(mockPushToolResult).toHaveBeenCalledWith(
+				expect.stringContaining("This could lead to unintended replacements"),
+			)
+		})
+
+		it("should fail when search query matches multiple locations in line range", async () => {
+			const fileContent = `function test() {
+		  if (true) {
+		      return true;
+		  } else {
+		      return false;
+		  }
+		  return null;
+}`
+
+			mockFs.readFile.mockResolvedValue(fileContent)
+
+			const toolUse: ToolUse = {
+				type: "tool_use",
+				name: "search_and_replace",
+				params: {
+					path: "test.js",
+					search: "}",
+					replace: "} // modified",
+					start_line: "3",
+					end_line: "6",
+				},
+				partial: false,
+			}
+
+			await searchAndReplaceTool(
+				mockTask,
+				toolUse,
+				mockAskApproval,
+				mockHandleError,
+				mockPushToolResult,
+				mockRemoveClosingTag,
+			)
+
+			expect(mockTask.consecutiveMistakeCount).toBe(1)
+			expect(mockTask.recordToolError).toHaveBeenCalledWith("search_and_replace")
+			expect(mockPushToolResult).toHaveBeenCalledWith(
+				expect.stringContaining("Search query matches 2 locations in the specified line range"),
+			)
+		})
+
+		it("should succeed when search query matches exactly one location", async () => {
+			const fileContent = `function test() {
+    return "unique_string";
+}`
+
+			mockFs.readFile.mockResolvedValue(fileContent)
+			mockTask.ask.mockResolvedValue({ response: "yesButtonClicked" })
+
+			const toolUse: ToolUse = {
+				type: "tool_use",
+				name: "search_and_replace",
+				params: {
+					path: "test.js",
+					search: "unique_string",
+					replace: "modified_string",
+				},
+				partial: false,
+			}
+
+			await searchAndReplaceTool(
+				mockTask,
+				toolUse,
+				mockAskApproval,
+				mockHandleError,
+				mockPushToolResult,
+				mockRemoveClosingTag,
+			)
+
+			expect(mockTask.consecutiveMistakeCount).toBe(0)
+			expect(mockTask.recordToolError).not.toHaveBeenCalled()
+			expect(mockTask.recordToolUsage).toHaveBeenCalledWith("search_and_replace")
+		})
+
+		it("should succeed when search query matches no locations", async () => {
+			const fileContent = `function test() {
+    return true;
+}`
+
+			mockFs.readFile.mockResolvedValue(fileContent)
+
+			const toolUse: ToolUse = {
+				type: "tool_use",
+				name: "search_and_replace",
+				params: {
+					path: "test.js",
+					search: "nonexistent_string",
+					replace: "replacement",
+				},
+				partial: false,
+			}
+
+			await searchAndReplaceTool(
+				mockTask,
+				toolUse,
+				mockAskApproval,
+				mockHandleError,
+				mockPushToolResult,
+				mockRemoveClosingTag,
+			)
+
+			expect(mockTask.consecutiveMistakeCount).toBe(0)
+			expect(mockPushToolResult).toHaveBeenCalledWith("No changes needed for 'test.js'")
+		})
+
+		it("should handle regex patterns correctly", async () => {
+			const fileContent = `const var1 = 1;
+const var2 = 2;
+const var3 = 3;`
+
+			mockFs.readFile.mockResolvedValue(fileContent)
+
+			const toolUse: ToolUse = {
+				type: "tool_use",
+				name: "search_and_replace",
+				params: {
+					path: "test.js",
+					search: "var\\d+",
+					replace: "variable",
+					use_regex: "true",
+				},
+				partial: false,
+			}
+
+			await searchAndReplaceTool(
+				mockTask,
+				toolUse,
+				mockAskApproval,
+				mockHandleError,
+				mockPushToolResult,
+				mockRemoveClosingTag,
+			)
+
+			expect(mockTask.consecutiveMistakeCount).toBe(1)
+			expect(mockPushToolResult).toHaveBeenCalledWith(
+				expect.stringContaining("Search query matches 3 locations in the file"),
+			)
+		})
+
+		it("should handle case-insensitive searches correctly", async () => {
+			const fileContent = `const Test = 1;
+const test = 2;
+const TEST = 3;`
+
+			mockFs.readFile.mockResolvedValue(fileContent)
+
+			const toolUse: ToolUse = {
+				type: "tool_use",
+				name: "search_and_replace",
+				params: {
+					path: "test.js",
+					search: "test",
+					replace: "variable",
+					ignore_case: "true",
+				},
+				partial: false,
+			}
+
+			await searchAndReplaceTool(
+				mockTask,
+				toolUse,
+				mockAskApproval,
+				mockHandleError,
+				mockPushToolResult,
+				mockRemoveClosingTag,
+			)
+
+			expect(mockTask.consecutiveMistakeCount).toBe(1)
+			expect(mockPushToolResult).toHaveBeenCalledWith(
+				expect.stringContaining("Search query matches 3 locations in the file"),
+			)
+		})
+
+		it("should limit displayed matches to 10 in error message", async () => {
+			// Create content with many matches
+			const fileContent = Array.from({ length: 15 }, (_, i) => `line${i} {}`).join("\n")
+
+			mockFs.readFile.mockResolvedValue(fileContent)
+
+			const toolUse: ToolUse = {
+				type: "tool_use",
+				name: "search_and_replace",
+				params: {
+					path: "test.js",
+					search: "}",
+					replace: "} // modified",
+				},
+				partial: false,
+			}
+
+			await searchAndReplaceTool(
+				mockTask,
+				toolUse,
+				mockAskApproval,
+				mockHandleError,
+				mockPushToolResult,
+				mockRemoveClosingTag,
+			)
+
+			expect(mockPushToolResult).toHaveBeenCalledWith(expect.stringContaining("... and 5 more matches"))
+		})
+	})
+
+	describe("error handling", () => {
+		it("should handle missing path parameter", async () => {
+			mockTask.sayAndCreateMissingParamError.mockResolvedValue("Missing path parameter")
+
+			const toolUse: ToolUse = {
+				type: "tool_use",
+				name: "search_and_replace",
+				params: {
+					search: "test",
+					replace: "replacement",
+				},
+				partial: false,
+			}
+
+			await searchAndReplaceTool(
+				mockTask,
+				toolUse,
+				mockAskApproval,
+				mockHandleError,
+				mockPushToolResult,
+				mockRemoveClosingTag,
+			)
+
+			expect(mockTask.consecutiveMistakeCount).toBe(1)
+			expect(mockTask.recordToolError).toHaveBeenCalledWith("search_and_replace")
+			expect(mockTask.sayAndCreateMissingParamError).toHaveBeenCalledWith("search_and_replace", "path")
+		})
+
+		it("should handle missing search parameter", async () => {
+			mockTask.sayAndCreateMissingParamError.mockResolvedValue("Missing search parameter")
+
+			const toolUse: ToolUse = {
+				type: "tool_use",
+				name: "search_and_replace",
+				params: {
+					path: "test.js",
+					replace: "replacement",
+				},
+				partial: false,
+			}
+
+			await searchAndReplaceTool(
+				mockTask,
+				toolUse,
+				mockAskApproval,
+				mockHandleError,
+				mockPushToolResult,
+				mockRemoveClosingTag,
+			)
+
+			expect(mockTask.consecutiveMistakeCount).toBe(1)
+			expect(mockTask.recordToolError).toHaveBeenCalledWith("search_and_replace")
+			expect(mockTask.sayAndCreateMissingParamError).toHaveBeenCalledWith("search_and_replace", "search")
+		})
+
+		it("should handle missing replace parameter", async () => {
+			mockTask.sayAndCreateMissingParamError.mockResolvedValue("Missing replace parameter")
+
+			const toolUse: ToolUse = {
+				type: "tool_use",
+				name: "search_and_replace",
+				params: {
+					path: "test.js",
+					search: "test",
+				},
+				partial: false,
+			}
+
+			await searchAndReplaceTool(
+				mockTask,
+				toolUse,
+				mockAskApproval,
+				mockHandleError,
+				mockPushToolResult,
+				mockRemoveClosingTag,
+			)
+
+			expect(mockTask.consecutiveMistakeCount).toBe(1)
+			expect(mockTask.recordToolError).toHaveBeenCalledWith("search_and_replace")
+			expect(mockTask.sayAndCreateMissingParamError).toHaveBeenCalledWith("search_and_replace", "replace")
+		})
+	})
+})


### PR DESCRIPTION
## Summary

This PR fixes issue #4744 by adding validation to the search and replace tool to prevent unintended replacements when the search query matches multiple locations in a file.

## Changes Made

### Core Implementation
- **Enhanced **: Added validation logic to check if search patterns match multiple locations
- **Multiple match detection**: Tool now counts matches before performing replacements
- **Descriptive error messages**: Provides clear feedback when search query is too broad
- **Smart suggestions**: Recommends using more specific queries, line ranges, or the apply_diff tool

### Key Features
- **Global file validation**: Checks for multiple matches across entire file
- **Line range validation**: Validates matches within specified line ranges (start_line/end_line)
- **Error message limiting**: Displays up to 10 matches in error messages for readability
- **Comprehensive guidance**: Suggests alternative approaches for precise targeting

### Test Coverage
- **New test suite**: Added comprehensive tests in 
- **Multiple scenarios**: Tests cover global matches, line range matches, regex patterns, case-insensitive searches
- **Edge cases**: Handles single matches, no matches, and various error conditions
- **Mock validation**: Proper mocking of file system and task dependencies

## Problem Solved

Previously, when a user provided a search query like  that matched multiple locations, the tool would replace ALL occurrences, potentially causing unintended modifications in wrong locations (like JSON documentation strings). 

Now the tool:
1. **Detects multiple matches** before making any changes
2. **Fails safely** with a descriptive error message
3. **Guides users** toward more precise alternatives
4. **Prevents data corruption** from overly broad search patterns

## Example Error Message



## Testing

- ✅ All existing tests pass
- ✅ New comprehensive test suite covers all scenarios
- ✅ Manual testing confirms proper error handling
- ✅ Linting and type checking pass

## Related Issue

Closes #4744

## Breaking Changes

None - this is a safety enhancement that only adds validation. Single-match scenarios continue to work exactly as before.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances `searchAndReplaceTool` with validation to prevent unintended replacements by detecting multiple matches and providing error messages and suggestions.
> 
>   - **Behavior**:
>     - Adds validation in `searchAndReplaceTool` to detect multiple matches before replacements.
>     - Provides error messages and suggestions for more specific queries.
>     - Limits error message to 10 matches for readability.
>   - **Tests**:
>     - New tests in `searchAndReplaceTool.test.ts` for multiple matches, line range, regex, and case-insensitive searches.
>     - Tests handle single matches, no matches, and missing parameters.
>   - **Misc**:
>     - Adds `escapeRegExp()` function to handle special regex characters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1699e28850987378d5173562780cc51f2b272a22. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->