### PR TITLE
Fixes #4732: Enforce mode file restrictions immediately when path is provided

### DIFF
--- a/src/shared/modes.ts
+++ b/src/shared/modes.ts
@@ -258,11 +258,7 @@ export function isToolAllowedForMode(
 		// For the edit group, check file regex if specified
 		if (groupName === "edit" && options.fileRegex) {
 			const filePath = toolParams?.path
-			if (
-				filePath &&
-				(toolParams.diff || toolParams.content || toolParams.operations) &&
-				!doesFileMatchRegex(filePath, options.fileRegex)
-			) {
+			if (filePath && !doesFileMatchRegex(filePath, options.fileRegex)) {
 				throw new FileRestrictionError(mode.name, options.fileRegex, options.description, filePath)
 			}
 		}


### PR DESCRIPTION
- Fixed bug in isToolAllowedForMode where file regex validation was only
  triggered when content/diff/operations were present
- Mode permissions are now enforced as soon as a file path is provided,
  preventing bypass during streaming/partial tool calls
- Updated tests to reflect correct behavior and added reproduction test
- This prevents modes like Architect from editing restricted files like
  PowerShell scripts when they should only edit markdown/config files
