### PR TITLE
Handle initial session refresh when checking compliance

### DIFF
--- a/packages/cloud/src/CloudService.ts
+++ b/packages/cloud/src/CloudService.ts
@@ -41,6 +41,7 @@ export class CloudService {
 
 			this.authService.on("inactive-session", this.authListener)
 			this.authService.on("active-session", this.authListener)
+			this.authService.on("refreshing-session", this.authListener)
 			this.authService.on("logged-out", this.authListener)
 			this.authService.on("user-info", this.authListener)
 
@@ -85,6 +86,11 @@ export class CloudService {
 	public hasActiveSession(): boolean {
 		this.ensureInitialized()
 		return this.authService!.hasActiveSession()
+	}
+
+	public isRefreshingSession(): boolean {
+		this.ensureInitialized()
+		return this.authService!.isRefreshingSession()
 	}
 
 	public getUserInfo(): CloudUserInfo | null {
@@ -150,7 +156,9 @@ export class CloudService {
 
 	public dispose(): void {
 		if (this.authService) {
+			this.authService.off("inactive-session", this.authListener)
 			this.authService.off("active-session", this.authListener)
+			this.authService.off("refreshing-session", this.authListener)
 			this.authService.off("logged-out", this.authListener)
 			this.authService.off("user-info", this.authListener)
 		}

--- a/packages/cloud/src/__tests__/AuthService.test.ts
+++ b/packages/cloud/src/__tests__/AuthService.test.ts
@@ -1,0 +1,125 @@
+// npx vitest run src/__tests__/AuthService.test.ts
+
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import * as vscode from "vscode"
+import { AuthService } from "../AuthService"
+
+// Mock vscode
+vi.mock("vscode", () => ({
+	ExtensionContext: vi.fn(),
+	window: {
+		showInformationMessage: vi.fn(),
+	},
+	env: {
+		openExternal: vi.fn(),
+		uriScheme: "vscode",
+	},
+	Uri: {
+		parse: vi.fn(),
+	},
+}))
+
+// Mock axios
+vi.mock("axios", () => ({
+	default: {
+		post: vi.fn(),
+		get: vi.fn(),
+	},
+}))
+
+// Mock other dependencies
+vi.mock("../Config", () => ({
+	getClerkBaseUrl: vi.fn(() => "https://clerk.test"),
+	getRooCodeApiUrl: vi.fn(() => "https://api.test"),
+}))
+
+vi.mock("../RefreshTimer", () => ({
+	RefreshTimer: vi.fn().mockImplementation(() => ({
+		start: vi.fn(),
+		stop: vi.fn(),
+	})),
+}))
+
+vi.mock("../utils", () => ({
+	getUserAgent: vi.fn(() => "test-agent"),
+}))
+
+describe("AuthService", () => {
+	let mockContext: Partial<vscode.ExtensionContext>
+	let authService: AuthService
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+
+		mockContext = {
+			secrets: {
+				store: vi.fn(),
+				get: vi.fn(),
+				delete: vi.fn(),
+				onDidChange: vi.fn(() => ({ dispose: vi.fn() })),
+			} as Partial<vscode.SecretStorage> as vscode.SecretStorage,
+			globalState: {
+				update: vi.fn(),
+				get: vi.fn(),
+				keys: vi.fn(() => []),
+				setKeysForSync: vi.fn(),
+			} as Partial<vscode.Memento & { setKeysForSync(keys: readonly string[]): void }> as vscode.Memento & {
+				setKeysForSync(keys: readonly string[]): void
+			},
+			subscriptions: [],
+			extension: {
+				packageJSON: {
+					publisher: "test",
+					name: "test-extension",
+				},
+			} as Partial<vscode.Extension<unknown>> as vscode.Extension<unknown>,
+		}
+
+		authService = new AuthService(mockContext as vscode.ExtensionContext)
+	})
+
+	describe("State Management", () => {
+		it("should initialize with 'initializing' state", () => {
+			expect(authService.getState()).toBe("initializing")
+		})
+
+		it("should have isRefreshingSession method that returns false initially", () => {
+			expect(authService.isRefreshingSession()).toBe(false)
+		})
+
+		it("should include refreshing-session in AuthState type", () => {
+			// This test verifies that the new state is properly typed
+			// by checking that the method exists and returns a boolean
+			expect(typeof authService.isRefreshingSession).toBe("function")
+			expect(typeof authService.isRefreshingSession()).toBe("boolean")
+		})
+	})
+
+	describe("Event Emission", () => {
+		it("should emit refreshing-session event when transitioning to refreshing state", async () => {
+			// Set up the auth service to have credentials
+			const mockCredentials = {
+				clientToken: "test-token",
+				sessionId: "test-session",
+			}
+
+			// Mock the secrets.get to return credentials
+			vi.mocked(mockContext.secrets!.get).mockResolvedValue(JSON.stringify(mockCredentials))
+
+			// Create a promise to wait for the event
+			const eventPromise = new Promise((resolve) => {
+				authService.on("refreshing-session", (data) => {
+					expect(data).toHaveProperty("previousState")
+					resolve(data)
+				})
+			})
+
+			// This would trigger the refresh process in a real scenario
+			// For this test, we're just verifying the event structure exists
+			// We can manually emit the event to test the interface
+			authService.emit("refreshing-session", { previousState: "inactive-session" })
+
+			await eventPromise
+		})
+	})
+})

--- a/packages/cloud/src/__tests__/CloudService.test.ts
+++ b/packages/cloud/src/__tests__/CloudService.test.ts
@@ -36,6 +36,7 @@ describe("CloudService", () => {
 		logout: ReturnType<typeof vi.fn>
 		isAuthenticated: ReturnType<typeof vi.fn>
 		hasActiveSession: ReturnType<typeof vi.fn>
+		isRefreshingSession: ReturnType<typeof vi.fn>
 		getUserInfo: ReturnType<typeof vi.fn>
 		getState: ReturnType<typeof vi.fn>
 		getSessionToken: ReturnType<typeof vi.fn>
@@ -84,6 +85,7 @@ describe("CloudService", () => {
 			logout: vi.fn(),
 			isAuthenticated: vi.fn().mockReturnValue(false),
 			hasActiveSession: vi.fn().mockReturnValue(false),
+			isRefreshingSession: vi.fn().mockReturnValue(false),
 			getUserInfo: vi.fn(),
 			getState: vi.fn().mockReturnValue("logged-out"),
 			getSessionToken: vi.fn(),
@@ -176,6 +178,12 @@ describe("CloudService", () => {
 		it("should delegate hasActiveSession to AuthService", () => {
 			const result = cloudService.hasActiveSession()
 			expect(mockAuthService.hasActiveSession).toHaveBeenCalled()
+			expect(result).toBe(false)
+		})
+
+		it("should delegate isRefreshingSession to AuthService", () => {
+			const result = cloudService.isRefreshingSession()
+			expect(mockAuthService.isRefreshingSession).toHaveBeenCalled()
 			expect(result).toBe(false)
 		})
 

--- a/src/services/mdm/MdmService.ts
+++ b/src/services/mdm/MdmService.ts
@@ -85,8 +85,12 @@ export class MdmService {
 			return { compliant: true }
 		}
 
-		// Check if cloud service is available and authenticated
-		if (!CloudService.hasInstance() || !CloudService.instance.hasActiveSession()) {
+		const cloudService = CloudService.instance
+		const hasActiveSession = cloudService?.hasActiveSession()
+		const isRefreshingSession = cloudService?.isRefreshingSession()
+
+		// Allow only if user has active session or is refreshing session
+		if (!hasActiveSession && !isRefreshingSession) {
 			return {
 				compliant: false,
 				reason: "Your organization requires Roo Code Cloud authentication. Please sign in to continue.",


### PR DESCRIPTION
Running into an issue where the initial session refresh is showing up as non-compliant. This fixes it by adding a new state.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `refreshing-session` state to handle session refreshes in `AuthService`, update `CloudService` and `MdmService` for compliance.
> 
>   - **Behavior**:
>     - Add `refreshing-session` state to `AuthService` in `AuthService.ts` to handle initial session refreshes.
>     - Update `CloudService` in `CloudService.ts` to listen for `refreshing-session` events.
>     - Modify `MdmService` in `MdmService.ts` to consider `refreshing-session` as compliant.
>   - **Functions**:
>     - Add `isRefreshingSession()` to `AuthService` and `CloudService`.
>   - **Tests**:
>     - Add tests for `refreshing-session` state in `AuthService.test.ts`.
>     - Update `CloudService.test.ts` to test `isRefreshingSession()` delegation.
>     - Update `MdmService.spec.ts` to test compliance with `refreshing-session`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c327badc0da08977a7115b2116ab972ba3a5c76c. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->