### PR TITLE
Include the cwd in the terminal details

### DIFF
--- a/src/core/environment/getEnvironmentDetails.ts
+++ b/src/core/environment/getEnvironmentDetails.ts
@@ -103,7 +103,10 @@ export async function getEnvironmentDetails(cline: Task, includeFileDetails: boo
 		terminalDetails += "\n\n# Actively Running Terminals"
 
 		for (const busyTerminal of busyTerminals) {
-			terminalDetails += `\n## Original command: \`${busyTerminal.getLastCommand()}\``
+			const cwd = busyTerminal.getCurrentWorkingDirectory()
+			terminalDetails += `\n## Terminal ${busyTerminal.id} (Active)`
+			terminalDetails += `\n### Working Directory: \`${cwd}\``
+			terminalDetails += `\n### Original command: \`${busyTerminal.getLastCommand()}\``
 			let newOutput = TerminalRegistry.getUnretrievedOutput(busyTerminal.id)
 
 			if (newOutput) {
@@ -145,7 +148,9 @@ export async function getEnvironmentDetails(cline: Task, includeFileDetails: boo
 
 			// Add this terminal's outputs to the details.
 			if (terminalOutputs.length > 0) {
-				terminalDetails += `\n## Terminal ${inactiveTerminal.id}`
+				const cwd = inactiveTerminal.getCurrentWorkingDirectory()
+				terminalDetails += `\n## Terminal ${inactiveTerminal.id} (Inactive)`
+				terminalDetails += `\n### Working Directory: \`${cwd}\``
 				terminalOutputs.forEach((output) => {
 					terminalDetails += `\n### New Output\n${output}`
 				})


### PR DESCRIPTION
Hopefully this helps with the LLM not knowing the current directory when executing commands.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `getEnvironmentDetails` now includes the current working directory for active and inactive terminals, with updated tests to verify this behavior.
> 
>   - **Behavior**:
>     - `getEnvironmentDetails` in `getEnvironmentDetails.ts` now includes the current working directory for both active and inactive terminals.
>     - Active terminals display "### Working Directory" and "### Original command".
>     - Inactive terminals display "### Working Directory" and "Command".
>   - **Tests**:
>     - Updated `getEnvironmentDetails.spec.ts` to test inclusion of working directory for active and inactive terminals.
>     - Added mock implementations for `getCurrentWorkingDirectory` in terminal mocks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4e7696910c123fc9f56ba93aae09d3c2463014fe. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->