### PR TITLE
Remove warning about commands switching working directory

### DIFF
--- a/src/core/tools/executeCommandTool.ts
+++ b/src/core/tools/executeCommandTool.ts
@@ -269,10 +269,6 @@ export async function executeCommand(
 		let workingDirInfo = ` within working directory '${workingDir.toPosix()}'`
 		const newWorkingDir = terminal.getCurrentWorkingDirectory()
 
-		if (newWorkingDir !== workingDir) {
-			workingDirInfo += `\nNOTICE: Your command changed the working directory for this terminal to '${newWorkingDir.toPosix()}' so you MUST adjust future commands accordingly because they will be executed in this directory`
-		}
-
 		return [false, `Command executed in terminal ${workingDirInfo}. ${exitStatus}\nOutput:\n${result}`]
 	} else {
 		return [


### PR DESCRIPTION
I think #4783 handles this
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes warning about working directory change in `executeCommand` in `executeCommandTool.ts`.
> 
>   - **Behavior**:
>     - Removes warning about working directory change in `executeCommand` in `executeCommandTool.ts`.
>     - Simplifies command execution output by omitting directory change notice.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1c6c42b20b2ce60be771bbb6019448c6cd532c8b. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->