### PR TITLE
Fix #4810: Resolve editing file loop by providing UI feedback during partial tool execution

### DIFF
--- a/src/core/tools/__tests__/writeToFileTool.test.ts
+++ b/src/core/tools/__tests__/writeToFileTool.test.ts
@@ -330,15 +330,17 @@ describe("writeToFileTool", () => {
 	})
 
 	describe("partial block handling", () => {
-		it("returns early when path is missing in partial block", async () => {
+		it("provides feedback when path is missing in partial block", async () => {
 			await executeWriteFileTool({ path: undefined }, { isPartial: true })
 
+			expect(mockCline.ask).toHaveBeenCalledWith("tool", expect.any(String), true)
 			expect(mockCline.diffViewProvider.open).not.toHaveBeenCalled()
 		})
 
-		it("returns early when content is undefined in partial block", async () => {
+		it("provides feedback when content is undefined in partial block", async () => {
 			await executeWriteFileTool({ content: undefined }, { isPartial: true })
 
+			expect(mockCline.ask).toHaveBeenCalledWith("tool", expect.any(String), true)
 			expect(mockCline.diffViewProvider.open).not.toHaveBeenCalled()
 		})
 

--- a/src/core/tools/writeToFileTool.ts
+++ b/src/core/tools/writeToFileTool.ts
@@ -29,6 +29,21 @@ export async function writeToFileTool(
 	if (block.partial && (!relPath || newContent === undefined)) {
 		// checking for newContent ensure relPath is complete
 		// wait so we can determine if it's a new file or editing an existing file
+		// Provide feedback to the UI even when partial to prevent getting stuck
+		if (!relPath || newContent === undefined) {
+			// Show partial progress to prevent the AI from getting stuck in a loop
+			const partialProps: ClineSayTool = {
+				tool: "newFileCreated", // Default, will be updated when we have more info
+				path: relPath ? getReadablePath(cline.cwd, removeClosingTag("path", relPath)) : "...",
+				content: newContent || "...",
+			}
+
+			try {
+				await cline.ask("tool", JSON.stringify(partialProps), true).catch(() => {})
+			} catch (error) {
+				// Ignore errors during partial updates
+			}
+		}
 		return
 	}
 


### PR DESCRIPTION
Fixes #4810 - AI gets stuck in editing file loop.

Root cause: writeToFileTool.ts had early return without UI feedback during partial execution, causing infinite loop.

Solution: Added cline.ask() call during partial states following applyDiffTool.ts pattern.

- Fixed early return in writeToFileTool.ts to provide UI feedback
- Updated tests to verify partial state feedback behavior  
- All 22 tests pass, no regression
- Linting and type checking pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes infinite loop in `writeToFileTool.ts` by adding UI feedback during partial execution, following `applyDiffTool.ts` pattern.
> 
>   - **Behavior**:
>     - Fixes infinite loop in `writeToFileTool.ts` by adding `cline.ask()` for UI feedback during partial execution.
>     - Follows feedback pattern from `applyDiffTool.ts`.
>   - **Tests**:
>     - Updates tests in `writeToFileTool.test.ts` to verify feedback during partial states.
>     - All 22 tests pass with no regression.
>   - **Misc**:
>     - Linting and type checking pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 6125b04629a2c819a5fb476a7e8e8efe56b48cf3. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->