### PR TITLE
Add 'Use custom base URL' option to Vertex AI provider

### DIFF
--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -109,6 +109,7 @@ const vertexSchema = apiModelIdProviderModelSchema.extend({
 	vertexJsonCredentials: z.string().optional(),
 	vertexProjectId: z.string().optional(),
 	vertexRegion: z.string().optional(),
+	vertexBaseUrl: z.string().optional(),
 })
 
 const openAiSchema = baseProviderSettingsSchema.extend({
@@ -151,6 +152,7 @@ const lmStudioSchema = baseProviderSettingsSchema.extend({
 const geminiSchema = apiModelIdProviderModelSchema.extend({
 	geminiApiKey: z.string().optional(),
 	googleGeminiBaseUrl: z.string().optional(),
+	isVertex: z.boolean().optional(),
 })
 
 const openAiNativeSchema = apiModelIdProviderModelSchema.extend({

--- a/src/api/providers/gemini.ts
+++ b/src/api/providers/gemini.ts
@@ -24,11 +24,11 @@ type GeminiHandlerOptions = ApiHandlerOptions & {
 }
 
 export class GeminiHandler extends BaseProvider implements SingleCompletionHandler {
-	protected options: ApiHandlerOptions
+	protected options: GeminiHandlerOptions
 
 	private client: GoogleGenAI
 
-	constructor({ isVertex, ...options }: GeminiHandlerOptions) {
+	constructor(options: GeminiHandlerOptions) {
 		super()
 
 		this.options = options
@@ -53,7 +53,7 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 						location,
 						googleAuthOptions: { keyFile: this.options.vertexKeyFile },
 					})
-				: isVertex
+				: this.options.isVertex
 					? new GoogleGenAI({ vertexai: true, project, location })
 					: new GoogleGenAI({ apiKey })
 	}
@@ -69,7 +69,13 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 
 		const config: GenerateContentConfig = {
 			systemInstruction,
-			httpOptions: this.options.googleGeminiBaseUrl ? { baseUrl: this.options.googleGeminiBaseUrl } : undefined,
+			httpOptions: this.options.isVertex
+				? this.options.vertexBaseUrl
+					? { baseUrl: this.options.vertexBaseUrl }
+					: undefined
+				: this.options.googleGeminiBaseUrl
+					? { baseUrl: this.options.googleGeminiBaseUrl }
+					: undefined,
 			thinkingConfig,
 			maxOutputTokens: this.options.modelMaxTokens ?? maxTokens ?? undefined,
 			temperature: this.options.modelTemperature ?? 0,
@@ -150,9 +156,13 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 				model,
 				contents: [{ role: "user", parts: [{ text: prompt }] }],
 				config: {
-					httpOptions: this.options.googleGeminiBaseUrl
-						? { baseUrl: this.options.googleGeminiBaseUrl }
-						: undefined,
+					httpOptions: this.options.isVertex
+						? this.options.vertexBaseUrl
+							? { baseUrl: this.options.vertexBaseUrl }
+							: undefined
+						: this.options.googleGeminiBaseUrl
+							? { baseUrl: this.options.googleGeminiBaseUrl }
+							: undefined,
 					temperature: this.options.modelTemperature ?? 0,
 				},
 			})

--- a/src/api/providers/vertex.ts
+++ b/src/api/providers/vertex.ts
@@ -9,7 +9,7 @@ import { SingleCompletionHandler } from "../index"
 
 export class VertexHandler extends GeminiHandler implements SingleCompletionHandler {
 	constructor(options: ApiHandlerOptions) {
-		super({ ...options, isVertex: true })
+		super({ ...options, isVertex: true, vertexBaseUrl: options.vertexBaseUrl })
 	}
 
 	override getModel() {

--- a/webview-ui/src/components/settings/providers/Vertex.tsx
+++ b/webview-ui/src/components/settings/providers/Vertex.tsx
@@ -1,4 +1,5 @@
-import { useCallback } from "react"
+import { useCallback, useState } from "react"
+import { Checkbox } from "vscrui"
 import { VSCodeLink, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 
 import { type ProviderSettings, VERTEX_REGIONS } from "@roo-code/types"
@@ -16,6 +17,8 @@ type VertexProps = {
 export const Vertex = ({ apiConfiguration, setApiConfigurationField }: VertexProps) => {
 	const { t } = useAppTranslation()
 
+	const [vertexBaseUrlSelected, setVertexBaseUrlSelected] = useState(!!apiConfiguration?.vertexBaseUrl)
+
 	const handleInputChange = useCallback(
 		<K extends keyof ProviderSettings, E>(
 			field: K,
@@ -29,6 +32,28 @@ export const Vertex = ({ apiConfiguration, setApiConfigurationField }: VertexPro
 
 	return (
 		<>
+			<div>
+				<Checkbox
+					checked={vertexBaseUrlSelected}
+					onChange={(checked: boolean) => {
+						setVertexBaseUrlSelected(checked)
+
+						if (!checked) {
+							setApiConfigurationField("vertexBaseUrl", "")
+						}
+					}}>
+					{t("settings:providers.useCustomBaseUrl")}
+				</Checkbox>
+				{vertexBaseUrlSelected && (
+					<VSCodeTextField
+						value={apiConfiguration?.vertexBaseUrl || ""}
+						type="url"
+						onInput={handleInputChange("vertexBaseUrl")}
+						placeholder={t("settings:defaults.vertexUrl")}
+						className="w-full mt-1"
+					/>
+				)}
+			</div>
 			<div className="text-sm text-vscode-descriptionForeground">
 				<div>{t("settings:providers.googleCloudSetup.title")}</div>
 				<div>

--- a/webview-ui/src/i18n/locales/ca/settings.json
+++ b/webview-ui/src/i18n/locales/ca/settings.json
@@ -608,7 +608,8 @@
 	"defaults": {
 		"ollamaUrl": "Per defecte: http://localhost:11434",
 		"lmStudioUrl": "Per defecte: http://localhost:1234",
-		"geminiUrl": "Per defecte: https://generativelanguage.googleapis.com"
+		"geminiUrl": "Per defecte: https://generativelanguage.googleapis.com",
+		"vertexUrl": "Per defecte: http://localhost:1234"
 	},
 	"labels": {
 		"customArn": "ARN personalitzat",

--- a/webview-ui/src/i18n/locales/de/settings.json
+++ b/webview-ui/src/i18n/locales/de/settings.json
@@ -608,7 +608,8 @@
 	"defaults": {
 		"ollamaUrl": "Standard: http://localhost:11434",
 		"lmStudioUrl": "Standard: http://localhost:1234",
-		"geminiUrl": "Standard: https://generativelanguage.googleapis.com"
+		"geminiUrl": "Standard: https://generativelanguage.googleapis.com",
+		"vertexUrl": "Standard: http://localhost:1234"
 	},
 	"labels": {
 		"customArn": "Benutzerdefinierte ARN",

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -608,7 +608,8 @@
 	"defaults": {
 		"ollamaUrl": "Default: http://localhost:11434",
 		"lmStudioUrl": "Default: http://localhost:1234",
-		"geminiUrl": "Default: https://generativelanguage.googleapis.com"
+		"geminiUrl": "Default: https://generativelanguage.googleapis.com",
+		"vertexUrl": "Default: http://localhost:1234"
 	},
 	"labels": {
 		"customArn": "Custom ARN",

--- a/webview-ui/src/i18n/locales/es/settings.json
+++ b/webview-ui/src/i18n/locales/es/settings.json
@@ -608,7 +608,8 @@
 	"defaults": {
 		"ollamaUrl": "Predeterminado: http://localhost:11434",
 		"lmStudioUrl": "Predeterminado: http://localhost:1234",
-		"geminiUrl": "Predeterminado: https://generativelanguage.googleapis.com"
+		"geminiUrl": "Predeterminado: https://generativelanguage.googleapis.com",
+		"vertexUrl": "Predeterminado: http://localhost:1234"
 	},
 	"labels": {
 		"customArn": "ARN personalizado",

--- a/webview-ui/src/i18n/locales/fr/settings.json
+++ b/webview-ui/src/i18n/locales/fr/settings.json
@@ -608,7 +608,8 @@
 	"defaults": {
 		"ollamaUrl": "Par défaut : http://localhost:11434",
 		"lmStudioUrl": "Par défaut : http://localhost:1234",
-		"geminiUrl": "Par défaut : https://generativelanguage.googleapis.com"
+		"geminiUrl": "Par défaut : https://generativelanguage.googleapis.com",
+		"vertexUrl": "Par défaut : http://localhost:1234"
 	},
 	"labels": {
 		"customArn": "ARN personnalisé",

--- a/webview-ui/src/i18n/locales/hi/settings.json
+++ b/webview-ui/src/i18n/locales/hi/settings.json
@@ -608,7 +608,8 @@
 	"defaults": {
 		"ollamaUrl": "डिफ़ॉल्ट: http://localhost:11434",
 		"lmStudioUrl": "डिफ़ॉल्ट: http://localhost:1234",
-		"geminiUrl": "डिफ़ॉल्ट: https://generativelanguage.googleapis.com"
+		"geminiUrl": "डिफ़ॉल्ट: https://generativelanguage.googleapis.com",
+		"vertexUrl": "डिफ़ॉल्ट: http://localhost:1234"
 	},
 	"labels": {
 		"customArn": "कस्टम ARN",

--- a/webview-ui/src/i18n/locales/id/settings.json
+++ b/webview-ui/src/i18n/locales/id/settings.json
@@ -637,7 +637,8 @@
 	"defaults": {
 		"ollamaUrl": "Default: http://localhost:11434",
 		"lmStudioUrl": "Default: http://localhost:1234",
-		"geminiUrl": "Default: https://generativelanguage.googleapis.com"
+		"geminiUrl": "Default: https://generativelanguage.googleapis.com",
+		"vertexUrl": "Default: http://localhost:1234"
 	},
 	"labels": {
 		"customArn": "ARN Kustom",

--- a/webview-ui/src/i18n/locales/it/settings.json
+++ b/webview-ui/src/i18n/locales/it/settings.json
@@ -608,7 +608,8 @@
 	"defaults": {
 		"ollamaUrl": "Predefinito: http://localhost:11434",
 		"lmStudioUrl": "Predefinito: http://localhost:1234",
-		"geminiUrl": "Predefinito: https://generativelanguage.googleapis.com"
+		"geminiUrl": "Predefinito: https://generativelanguage.googleapis.com",
+		"vertexUrl": "Predefinito: http://localhost:1234"
 	},
 	"labels": {
 		"customArn": "ARN personalizzato",

--- a/webview-ui/src/i18n/locales/ja/settings.json
+++ b/webview-ui/src/i18n/locales/ja/settings.json
@@ -608,7 +608,8 @@
 	"defaults": {
 		"ollamaUrl": "デフォルト：http://localhost:11434",
 		"lmStudioUrl": "デフォルト：http://localhost:1234",
-		"geminiUrl": "デフォルト：https://generativelanguage.googleapis.com"
+		"geminiUrl": "デフォルト：https://generativelanguage.googleapis.com",
+		"vertexUrl": "デフォルト：http://localhost:1234"
 	},
 	"labels": {
 		"customArn": "カスタム ARN",

--- a/webview-ui/src/i18n/locales/ko/settings.json
+++ b/webview-ui/src/i18n/locales/ko/settings.json
@@ -608,7 +608,8 @@
 	"defaults": {
 		"ollamaUrl": "기본값: http://localhost:11434",
 		"lmStudioUrl": "기본값: http://localhost:1234",
-		"geminiUrl": "기본값: https://generativelanguage.googleapis.com"
+		"geminiUrl": "기본값: https://generativelanguage.googleapis.com",
+		"vertexUrl": "기본값: http://localhost:1234"
 	},
 	"labels": {
 		"customArn": "사용자 지정 ARN",

--- a/webview-ui/src/i18n/locales/nl/settings.json
+++ b/webview-ui/src/i18n/locales/nl/settings.json
@@ -608,7 +608,8 @@
 	"defaults": {
 		"ollamaUrl": "Standaard: http://localhost:11434",
 		"lmStudioUrl": "Standaard: http://localhost:1234",
-		"geminiUrl": "Standaard: https://generativelanguage.googleapis.com"
+		"geminiUrl": "Standaard: https://generativelanguage.googleapis.com",
+		"vertexUrl": "Standaard: http://localhost:1234"
 	},
 	"labels": {
 		"customArn": "Aangepaste ARN",

--- a/webview-ui/src/i18n/locales/pl/settings.json
+++ b/webview-ui/src/i18n/locales/pl/settings.json
@@ -608,7 +608,8 @@
 	"defaults": {
 		"ollamaUrl": "Domyślnie: http://localhost:11434",
 		"lmStudioUrl": "Domyślnie: http://localhost:1234",
-		"geminiUrl": "Domyślnie: https://generativelanguage.googleapis.com"
+		"geminiUrl": "Domyślnie: https://generativelanguage.googleapis.com",
+		"vertexUrl": "Domyślnie: http://localhost:1234"
 	},
 	"labels": {
 		"customArn": "Niestandardowy ARN",

--- a/webview-ui/src/i18n/locales/pt-BR/settings.json
+++ b/webview-ui/src/i18n/locales/pt-BR/settings.json
@@ -608,7 +608,8 @@
 	"defaults": {
 		"ollamaUrl": "Padrão: http://localhost:11434",
 		"lmStudioUrl": "Padrão: http://localhost:1234",
-		"geminiUrl": "Padrão: https://generativelanguage.googleapis.com"
+		"geminiUrl": "Padrão: https://generativelanguage.googleapis.com",
+		"vertexUrl": "Padrão: http://localhost:1234"
 	},
 	"labels": {
 		"customArn": "ARN personalizado",

--- a/webview-ui/src/i18n/locales/ru/settings.json
+++ b/webview-ui/src/i18n/locales/ru/settings.json
@@ -608,7 +608,8 @@
 	"defaults": {
 		"ollamaUrl": "По умолчанию: http://localhost:11434",
 		"lmStudioUrl": "По умолчанию: http://localhost:1234",
-		"geminiUrl": "По умолчанию: https://generativelanguage.googleapis.com"
+		"geminiUrl": "По умолчанию: https://generativelanguage.googleapis.com",
+		"vertexUrl": "По умолчанию: http://localhost:1234"
 	},
 	"labels": {
 		"customArn": "Пользовательский ARN",

--- a/webview-ui/src/i18n/locales/tr/settings.json
+++ b/webview-ui/src/i18n/locales/tr/settings.json
@@ -608,7 +608,8 @@
 	"defaults": {
 		"ollamaUrl": "Varsayılan: http://localhost:11434",
 		"lmStudioUrl": "Varsayılan: http://localhost:1234",
-		"geminiUrl": "Varsayılan: https://generativelanguage.googleapis.com"
+		"geminiUrl": "Varsayılan: https://generativelanguage.googleapis.com",
+		"vertexUrl": "Varsayılan: http://localhost:1234"
 	},
 	"labels": {
 		"customArn": "Özel ARN",

--- a/webview-ui/src/i18n/locales/vi/settings.json
+++ b/webview-ui/src/i18n/locales/vi/settings.json
@@ -608,7 +608,8 @@
 	"defaults": {
 		"ollamaUrl": "Mặc định: http://localhost:11434",
 		"lmStudioUrl": "Mặc định: http://localhost:1234",
-		"geminiUrl": "Mặc định: https://generativelanguage.googleapis.com"
+		"geminiUrl": "Mặc định: https://generativelanguage.googleapis.com",
+		"vertexUrl": "Mặc định: http://localhost:1234"
 	},
 	"labels": {
 		"customArn": "ARN tùy chỉnh",

--- a/webview-ui/src/i18n/locales/zh-CN/settings.json
+++ b/webview-ui/src/i18n/locales/zh-CN/settings.json
@@ -608,7 +608,8 @@
 	"defaults": {
 		"ollamaUrl": "默认值：http://localhost:11434",
 		"lmStudioUrl": "默认值：http://localhost:1234",
-		"geminiUrl": "默认值：https://generativelanguage.googleapis.com"
+		"geminiUrl": "默认值：https://generativelanguage.googleapis.com",
+		"vertexUrl": "默认值：http://localhost:1234"
 	},
 	"labels": {
 		"customArn": "自定义 ARN",

--- a/webview-ui/src/i18n/locales/zh-TW/settings.json
+++ b/webview-ui/src/i18n/locales/zh-TW/settings.json
@@ -608,7 +608,8 @@
 	"defaults": {
 		"ollamaUrl": "預設：http://localhost:11434",
 		"lmStudioUrl": "預設：http://localhost:1234",
-		"geminiUrl": "預設：https://generativelanguage.googleapis.com"
+		"geminiUrl": "預設：https://generativelanguage.googleapis.com",
+		"vertexUrl": "預設：http://localhost:1234"
 	},
 	"labels": {
 		"customArn": "自訂 ARN",


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #3114

### Description

<!--
Briefly summarize the changes in this PR and how they address the linked issue.
The issue should cover the "what" and "why"; this section should focus on:
- The "how": key implementation details, design choices, or trade-offs made.
- Anything specific reviewers should pay attention to in this PR.
-->

This PR adds a "Use custom base URL" option to the Vertex AI provider just like the Google Gemini provider has. This will allow us to run requests to Vertex AI through a proxy. @shwuhk [mentioned](https://github.com/RooCodeInc/Roo-Code/issues/3114#issuecomment-2853127955) needing this feature in the linked issue as well to help solve an issue they're experiencing.

### Test Procedure

<!--
Detail the steps to test your changes. This helps reviewers verify your work.
- How did you test this specific implementation? (e.g., unit tests, manual testing steps)
- How can reviewers reproduce your tests or verify the fix/feature?
- Include relevant testing environment details if applicable.
-->

Unit tests were added and manual testing was performed for:
1. Use of both Google Gemini and Vertex AI continue to work without this setting checked
2. Specifying a custom base URL in only Google Gemini or Vertex AI does not affect the other.
3. Configuration changes are saved properly
4. UI displays correctly

### Type of Change

<!-- Mark all applicable boxes with an 'x'. -->

- [ ] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [X] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [X] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [X] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [X] **Self-Review**: I have performed a thorough self-review of my code.
- [X] **Code Quality**:
    - [X] My code adheres to the project's style guidelines.
    - [X] There are no new linting errors or warnings (`npm run lint`).
    - [X] All debug code (e.g., `console.log`) has been removed.
- [X] **Testing**:
    - [X] New and/or updated tests have been added to cover my changes.
    - [X] All tests pass locally (`npm test`).
    - [X] The application builds successfully with my changes.
- [X] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [X] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [X] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->

<img width="369" alt="Screenshot 2025-06-18 at 2 20 40 AM" src="https://github.com/user-attachments/assets/a0264d93-a51c-48fb-89fe-79299126e476" />

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [X] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

The documentation should be updated to mention this capability. However, I noticed the documentation does not mention that the Google Gemini provider has this capability.

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->

### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->
jferrell_sayari
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds custom base URL option for Vertex AI provider, updates handlers and UI, and includes tests and i18n updates.
> 
>   - **Behavior**:
>     - Adds `vertexBaseUrl` option to Vertex AI provider in `provider-settings.ts`.
>     - Updates `VertexHandler` in `vertex.ts` to use `vertexBaseUrl` for HTTP requests.
>     - UI updated in `Vertex.tsx` to include checkbox and input for custom base URL.
>   - **Testing**:
>     - Adds unit tests in `vertex.spec.ts` to verify `vertexBaseUrl` usage in `createMessage` and `completePrompt`.
>   - **Misc**:
>     - Updates i18n files for multiple languages to include default `vertexUrl`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5d774dae6165c2cfab265fa3158e8ca00cfc0aee. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->