### PR TITLE
Fixes #4825: Add vscode-webview-resource: to CSP for offline compatibility

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -664,11 +664,11 @@ export class ClineProvider
 
 		const csp = [
 			"default-src 'none'",
-			`font-src ${webview.cspSource}`,
-			`style-src ${webview.cspSource} 'unsafe-inline' https://* http://${localServerUrl} http://0.0.0.0:${localPort}`,
-			`img-src ${webview.cspSource} https://storage.googleapis.com https://img.clerk.com data:`,
-			`media-src ${webview.cspSource}`,
-			`script-src 'unsafe-eval' ${webview.cspSource} https://* https://*.posthog.com http://${localServerUrl} http://0.0.0.0:${localPort} 'nonce-${nonce}'`,
+			`font-src ${webview.cspSource} vscode-webview-resource:`,
+			`style-src ${webview.cspSource} 'unsafe-inline' https://* http://${localServerUrl} http://0.0.0.0:${localPort} vscode-webview-resource:`,
+			`img-src ${webview.cspSource} https://storage.googleapis.com https://img.clerk.com data: vscode-webview-resource:`,
+			`media-src ${webview.cspSource} vscode-webview-resource:`,
+			`script-src 'unsafe-eval' ${webview.cspSource} https://* https://*.posthog.com http://${localServerUrl} http://0.0.0.0:${localPort} 'nonce-${nonce}' vscode-webview-resource:`,
 			`connect-src https://* https://*.posthog.com ws://${localServerUrl} ws://0.0.0.0:${localPort} http://${localServerUrl} http://0.0.0.0:${localPort}`,
 		]
 
@@ -751,7 +751,7 @@ export class ClineProvider
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
             <meta name="theme-color" content="#000000">
-            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; font-src ${webview.cspSource}; style-src ${webview.cspSource} 'unsafe-inline'; img-src ${webview.cspSource} https://storage.googleapis.com https://img.clerk.com data:; media-src ${webview.cspSource}; script-src ${webview.cspSource} 'wasm-unsafe-eval' 'nonce-${nonce}' https://us-assets.i.posthog.com 'strict-dynamic'; connect-src https://openrouter.ai https://api.requesty.ai https://us.i.posthog.com https://us-assets.i.posthog.com;">
+            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; font-src ${webview.cspSource} vscode-webview-resource:; style-src ${webview.cspSource} 'unsafe-inline' vscode-webview-resource:; img-src ${webview.cspSource} https://storage.googleapis.com https://img.clerk.com data: vscode-webview-resource:; media-src ${webview.cspSource} vscode-webview-resource:; script-src ${webview.cspSource} 'wasm-unsafe-eval' 'nonce-${nonce}' https://us-assets.i.posthog.com 'strict-dynamic' vscode-webview-resource:; connect-src https://openrouter.ai https://api.requesty.ai https://us.i.posthog.com https://us-assets.i.posthog.com;">
             <link rel="stylesheet" type="text/css" href="${stylesUri}">
 			<link href="${codiconsUri}" rel="stylesheet" />
 			<script nonce="${nonce}">

--- a/src/core/webview/__tests__/ClineProvider.test.ts
+++ b/src/core/webview/__tests__/ClineProvider.test.ts
@@ -365,10 +365,12 @@ describe("ClineProvider", () => {
 
 		expect(mockWebviewView.webview.html).toContain("<!DOCTYPE html>")
 
-		// Verify Content Security Policy contains the necessary PostHog domains
+		// Verify Content Security Policy contains the necessary PostHog domains and webview resources
 		expect(mockWebviewView.webview.html).toContain(
 			"connect-src https://openrouter.ai https://api.requesty.ai https://us.i.posthog.com https://us-assets.i.posthog.com",
 		)
+		// Verify CSP includes vscode-webview-resource for offline compatibility
+		expect(mockWebviewView.webview.html).toContain("vscode-webview-resource:")
 
 		// Extract the script-src directive section and verify required security elements
 		const html = mockWebviewView.webview.html


### PR DESCRIPTION
- Updated Content Security Policy in both production and development modes
- Added vscode-webview-resource: to font-src, style-src, img-src, media-src, and script-src
- This allows webview resources to load properly in offline mode on VS Code 1.85.2
- Updated test to verify CSP includes vscode-webview-resource for offline compatibility

The issue was caused by the webview CSP being too restrictive and not allowing
local webview resources to load when VS Code is running in offline mode.
The error 'Blocked vscode-webview request' occurred because the CSP didn't
include the vscode-webview-resource: scheme needed for offline resource loading.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `vscode-webview-resource:` to CSP in `ClineProvider.ts` for offline compatibility in VS Code 1.85.2, with updated tests in `ClineProvider.test.ts`.
> 
>   - **CSP Update**:
>     - Add `vscode-webview-resource:` to `font-src`, `style-src`, `img-src`, `media-src`, and `script-src` in `ClineProvider.ts`.
>     - Ensures webview resources load offline in VS Code 1.85.2.
>   - **Testing**:
>     - Update test in `ClineProvider.test.ts` to verify CSP includes `vscode-webview-resource:` for offline compatibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ef0563c35a02ac95564d5b71f78e773b8d832153. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->