### PR TITLE
Yield the cost in usage data for Anthropic

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1439,6 +1439,7 @@ export class Task extends EventEmitter<ClineEvents> {
 			} finally {
 				this.isStreaming = false
 			}
+
 			if (
 				inputTokens > 0 ||
 				outputTokens > 0 ||

--- a/src/shared/cost.ts
+++ b/src/shared/cost.ts
@@ -15,7 +15,8 @@ function calculateApiCostInternal(
 	return totalCost
 }
 
-// For Anthropic compliant usage, the input tokens count does NOT include the cached tokens
+// For Anthropic compliant usage, the input tokens count does NOT include the
+// cached tokens.
 export function calculateApiCostAnthropic(
 	modelInfo: ModelInfo,
 	inputTokens: number,
@@ -23,18 +24,16 @@ export function calculateApiCostAnthropic(
 	cacheCreationInputTokens?: number,
 	cacheReadInputTokens?: number,
 ): number {
-	const cacheCreationInputTokensNum = cacheCreationInputTokens || 0
-	const cacheReadInputTokensNum = cacheReadInputTokens || 0
 	return calculateApiCostInternal(
 		modelInfo,
 		inputTokens,
 		outputTokens,
-		cacheCreationInputTokensNum,
-		cacheReadInputTokensNum,
+		cacheCreationInputTokens || 0,
+		cacheReadInputTokens || 0,
 	)
 }
 
-// For OpenAI compliant usage, the input tokens count INCLUDES the cached tokens
+// For OpenAI compliant usage, the input tokens count INCLUDES the cached tokens.
 export function calculateApiCostOpenAI(
 	modelInfo: ModelInfo,
 	inputTokens: number,
@@ -45,6 +44,7 @@ export function calculateApiCostOpenAI(
 	const cacheCreationInputTokensNum = cacheCreationInputTokens || 0
 	const cacheReadInputTokensNum = cacheReadInputTokens || 0
 	const nonCachedInputTokens = Math.max(0, inputTokens - cacheCreationInputTokensNum - cacheReadInputTokensNum)
+
 	return calculateApiCostInternal(
 		modelInfo,
 		nonCachedInputTokens,


### PR DESCRIPTION
### Description

Some providers aren't set up to yield costs in real-time. In some of these cases we sum the cost ourselves and yield a final usage with the total cost. For providers that don't do this there is a final fallback:

```typescript
const updateApiReqMsg = (cancelReason?: ClineApiReqCancelReason, streamingFailedMessage?: string) => {
  this.clineMessages[lastApiReqIndex].text = JSON.stringify({
    ...JSON.parse(this.clineMessages[lastApiReqIndex].text || "{}"),
    tokensIn: inputTokens,
    tokensOut: outputTokens,
    cacheWrites: cacheWriteTokens,
    cacheReads: cacheReadTokens,
    cost:
      totalCost ??
      calculateApiCostAnthropic(
        this.api.getModel().info,
        inputTokens,
        outputTokens,
        cacheWriteTokens,
        cacheReadTokens,
      ),
    cancelReason,
    streamingFailedMessage,
  } satisfies ClineApiReqInfo)
}
```

This incorrectly assumes that the total cost calculation is the Anthropic variant, and it also happens *after* we emit the `LLM Completion` event that Roo Code Cloud uses.

The option that makes sense to me is to have our provider classes emit a `usage` with the total cost. Here's the fix for the Anthropic provider and I'm having Roo Code audit all of the others.