### PR TITLE
Fixes #4881: Preserve subtask completion state during task resumption

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -812,7 +812,27 @@ export class Task extends EventEmitter<ClineEvents> {
 		if (lastClineMessage?.ask === "completion_result") {
 			askType = "resume_completed_task"
 		} else {
-			askType = "resume_task"
+			// Check if this is a completed subtask by looking for finishTask tool completion
+			const isCompletedSubtask = this.clineMessages
+				.slice()
+				.reverse()
+				.some((m) => {
+					if (m.type === "ask" && m.ask === "tool" && m.text) {
+						try {
+							const tool = JSON.parse(m.text)
+							return tool.tool === "finishTask"
+						} catch {
+							return false
+						}
+					}
+					return false
+				})
+
+			if (isCompletedSubtask && this.parentTask) {
+				askType = "resume_completed_task"
+			} else {
+				askType = "resume_task"
+			}
 		}
 
 		this.isInitialized = true


### PR DESCRIPTION
- Modified task resumption logic in Task.ts to detect completed subtasks
- Added check for finishTask tool completion when determining resume type
- Ensures completed subtasks show 'Start New Task' button instead of 'Resume Task'
- Prevents unnecessary re-execution of completed subtasks and token costs
