### PR TITLE
fix: await updateClineMessage calls to prevent duplicate reasoning blocks

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -450,7 +450,7 @@ export class Task extends EventEmitter<ClineEvents> {
 					// data or one whole message at a time so ignore partial for
 					// saves, and only post parts of partial message instead of
 					// whole array in new listener.
-					this.updateClineMessage(lastMessage)
+					await this.updateClineMessage(lastMessage)
 					throw new Error("Current ask promise was ignored (#1)")
 				} else {
 					// This is a new partial message, so add it with partial
@@ -486,7 +486,7 @@ export class Task extends EventEmitter<ClineEvents> {
 					lastMessage.progressStatus = progressStatus
 					lastMessage.isProtected = isProtected
 					await this.saveClineMessages()
-					this.updateClineMessage(lastMessage)
+					await this.updateClineMessage(lastMessage)
 				} else {
 					// This is a new and complete message, so add it like normal.
 					this.askResponse = undefined
@@ -636,7 +636,7 @@ export class Task extends EventEmitter<ClineEvents> {
 					lastMessage.images = images
 					lastMessage.partial = partial
 					lastMessage.progressStatus = progressStatus
-					this.updateClineMessage(lastMessage)
+					await this.updateClineMessage(lastMessage)
 				} else {
 					// This is a new partial message, so add it with partial state.
 					const sayTs = Date.now()
@@ -674,7 +674,7 @@ export class Task extends EventEmitter<ClineEvents> {
 					await this.saveClineMessages()
 
 					// More performant than an entire `postStateToWebview`.
-					this.updateClineMessage(lastMessage)
+					await this.updateClineMessage(lastMessage)
 				} else {
 					// This is a new and complete message, so add it like normal.
 					const sayTs = Date.now()


### PR DESCRIPTION
## Description

This PR fixes an issue where reasoning blocks were being rendered multiple times instead of updating in place during streaming responses.

## Problem

When the AI streams reasoning content, the `ReasoningBlock` component was rendering multiple instances instead of updating a single instance. This was caused by a race condition in the `Task.ts` file where `updateClineMessage` was being called without awaiting its completion.

## Solution

Added `await` to all `updateClineMessage` calls in `Task.ts` to ensure that message updates complete before proceeding with the next update. This prevents the race condition that was causing duplicate rendering.

## Changes

- Added `await` to 4 `updateClineMessage` calls in `src/core/task/Task.ts`

## Testing

The fix ensures that:
- Reasoning blocks update in place during streaming
- No duplicate reasoning blocks are created
- Message updates are properly synchronized

Fixes the issue where reasoning blocks were rendered multiple times during streaming responses.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes race condition in `Task.ts` by adding `await` to `updateClineMessage` calls, preventing duplicate reasoning blocks during streaming responses.
> 
>   - **Behavior**:
>     - Fixes race condition in `Task.ts` by adding `await` to `updateClineMessage` calls, ensuring message updates complete before proceeding.
>     - Prevents duplicate reasoning blocks during streaming responses.
>   - **Changes**:
>     - Added `await` to 4 `updateClineMessage` calls in `Task.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 639cb78e1dd54737d85bc7c2f6a12ac6c98911f0. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->