### PR TITLE
Fix #4896: Orchestrator subtask cancellation fails to return to parent task after API streaming error

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1422,10 +1422,17 @@ export class Task extends EventEmitter<ClineEvents> {
 						error.message ?? JSON.stringify(serializeError(error), null, 2),
 					)
 
-					const history = await provider?.getTaskWithId(this.taskId)
+					// Check if this is a subtask - if so, return to parent instead of reinitializing
+					if (this.parentTask) {
+						// For subtasks, finish the subtask and return to parent
+						await provider?.finishSubTask(`API streaming error: ${error.message ?? "Unknown error"}`)
+					} else {
+						// For main tasks, reinitialize with history as before
+						const history = await provider?.getTaskWithId(this.taskId)
 
-					if (history) {
-						await provider?.initClineWithHistoryItem(history.historyItem)
+						if (history) {
+							await provider?.initClineWithHistoryItem(history.historyItem)
+						}
 					}
 				}
 			} finally {


### PR DESCRIPTION
When an API streaming error occurs in a subtask, instead of reinitializing
the subtask with history (which keeps it stuck in subtask view), properly
return control to the parent task by calling finishSubTask().

This ensures that orchestrator mode can properly resume the parent task
after a subtask encounters an API streaming failure during cancellation.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes subtask cancellation in orchestrator mode by returning control to the parent task after an API streaming error in `Task.ts`.
> 
>   - **Behavior**:
>     - In `Task.ts`, modify error handling for API streaming errors in subtasks.
>     - If a subtask encounters an API streaming error, call `finishSubTask()` to return control to the parent task.
>     - For main tasks, continue to reinitialize with history as before.
>   - **Error Handling**:
>     - Specifically addresses API streaming failures during subtask cancellation in orchestrator mode.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for dc3359a22425751279048b4805602504162295f1. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->