### PR TITLE
fix: resolve orchestrator subtask cancellation during API streaming error (#4896)

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -758,6 +758,14 @@ export class Task extends EventEmitter<ClineEvents> {
 		// this is the result of what it has done  add the message to the chat
 		// history and to the webview ui.
 		try {
+			// Check if the task is aborted or abandoned before trying to add messages
+			if (this.abort || this.abandoned) {
+				this.providerRef
+					.deref()
+					?.log(`[subtasks] Parent task ${this.taskId} is aborted/abandoned, skipping resume message`)
+				return
+			}
+
 			await this.say("subtask_result", lastMessage)
 
 			await this.addToApiConversationHistory({
@@ -769,7 +777,8 @@ export class Task extends EventEmitter<ClineEvents> {
 				.deref()
 				?.log(`Error failed to add reply from subtask into conversation of parent task, error: ${error}`)
 
-			throw error
+			// Don't throw the error - we still want the parent task to be unpaused
+			// even if we couldn't add the message
 		}
 	}
 


### PR DESCRIPTION
## Description

Fixes #4896

This PR resolves an issue where orchestrator subtask cancellation would fail to return to the parent task when an API streaming error occurred. The fix ensures proper cleanup and parent task resumption even in error states.

## Changes Made

- **Enhanced race condition handling**: Added a descriptive comment explaining the `setTimeout` usage in `webviewMessageHandler.ts` to clarify why it's needed for preventing race conditions during stream abortion
- **Improved error logging**: Enhanced error messages in `finishSubTask` to include the parent task ID for better debugging context
- **Robust error handling**: Made error handling non-throwing to ensure parent task resumption isn't blocked by errors
- **Resilient task resumption**: Made `resumePausedTask` in `Task.ts` more resilient to handle aborted/abandoned states

## Testing

- [x] All existing tests pass (62 passed, 6 skipped)
- [x] Added specific test case for subtask cancellation during API streaming error
- [x] Manual testing completed:
  - Tested subtask cancellation during normal operation
  - Tested subtask cancellation during API streaming
  - Tested subtask cancellation during error states
  - Verified parent task properly resumes in all cases

## Verification of Acceptance Criteria

- [x] Subtask cancellation during API streaming error now properly returns to parent task
- [x] Parent task resumes correctly even when errors occur during cleanup
- [x] No regression in normal subtask cancellation behavior
- [x] Enhanced debugging capabilities with improved error messages

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (race condition handling)
- [x] Documentation updated (inline comments)
- [x] No breaking changes
- [x] All tests pass
- [x] Linting passes with no warnings
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes subtask cancellation during API streaming errors, ensuring parent task resumption and improving error handling in `Task.ts` and `webviewMessageHandler.ts`.
> 
>   - **Behavior**:
>     - Fixes subtask cancellation issue during API streaming errors, ensuring parent task resumption in `Task.ts` and `webviewMessageHandler.ts`.
>     - Improves error handling in `resumePausedTask` in `Task.ts` to prevent blocking parent task resumption.
>   - **Error Handling**:
>     - Adds error logging in `finishSubTask` to include parent task ID for better debugging.
>     - Makes error handling non-throwing in `resumePausedTask` to ensure task continuation.
>   - **Race Condition Handling**:
>     - Adds `setTimeout` in `webviewMessageHandler.ts` to prevent race conditions during stream abortion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5c11f205381cea7c1b45d283c13288e75480a98b. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->