### PR TITLE
fix: update MarketplaceViewStateManager test to match default isFetching state

### DIFF
--- a/webview-ui/src/components/marketplace/__tests__/MarketplaceViewStateManager.spec.ts
+++ b/webview-ui/src/components/marketplace/__tests__/MarketplaceViewStateManager.spec.ts
@@ -58,7 +58,7 @@ describe("MarketplaceViewStateManager", () => {
 
 			expect(state.allItems).toEqual([])
 			expect(state.displayItems).toEqual([])
-			expect(state.isFetching).toBe(false)
+			expect(state.isFetching).toBe(true)
 			expect(state.activeTab).toBe("mcp")
 			expect(state.filters).toEqual({
 				type: "",


### PR DESCRIPTION
## Summary

This PR fixes a failing test in the MarketplaceViewStateManager test suite.

## Problem

The test "should initialize with default state" was expecting `isFetching` to be `false`, but the implementation correctly initializes it as `true` to show a loading state on initial load.

## Solution

Updated the test expectation to match the actual behavior of the implementation, changing the expected value from `false` to `true`.

## Changes

- Modified `webview-ui/src/components/marketplace/__tests__/MarketplaceViewStateManager.spec.ts` to expect `isFetching: true` in the default state

## Testing

- ✅ The test now passes correctly
- ✅ No changes were made to the implementation logic
- ✅ All type checks pass
- ✅ All linting passes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes test in `MarketplaceViewStateManager.spec.ts` to expect `isFetching: true` in default state.
> 
>   - **Test Fix**:
>     - Update `MarketplaceViewStateManager.spec.ts` to expect `isFetching: true` in the default state.
>   - **Testing**:
>     - Test now passes correctly.
>     - No changes to implementation logic.
>     - All type checks and linting pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a67d4dd0270ed2bf0645b188364810ce40ef0970. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->