### PR TITLE
fix: resolve diff editor issues with markdown preview associations (#4946)

### DIFF
--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -15,7 +15,7 @@ import { Task } from "../../core/task/Task"
 import { DecorationController } from "./DecorationController"
 
 export const DIFF_VIEW_URI_SCHEME = "cline-diff"
-export const DIFF_VIEW_LABEL_SEPARATOR = "↔ Roo's Changes"
+export const DIFF_VIEW_LABEL_CHANGES = "Original ↔ Roo's Changes"
 
 // TODO: https://github.com/cline/cline/pull/3354
 export class DiffViewProvider {
@@ -398,7 +398,7 @@ export class DiffViewProvider {
 				// Also check by tab label for our specific diff views
 				// This catches cases where the diff view might be created differently
 				// when files are pre-opened as text documents
-				if (tab.label.includes(DIFF_VIEW_LABEL_SEPARATOR) && !tab.isDirty) {
+				if (tab.label.includes(DIFF_VIEW_LABEL_CHANGES) && !tab.isDirty) {
 					return true
 				}
 
@@ -513,7 +513,7 @@ export class DiffViewProvider {
 							query: Buffer.from(this.originalContent ?? "").toString("base64"),
 						}),
 						uri,
-						`${fileName}: ${fileExists ? `Original ${DIFF_VIEW_LABEL_SEPARATOR}` : "New File"} (Editable)`,
+						`${fileName}: ${fileExists ? `${DIFF_VIEW_LABEL_CHANGES}` : "New File"} (Editable)`,
 						{ preserveFocus: true },
 					)
 				})

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -15,6 +15,7 @@ import { Task } from "../../core/task/Task"
 import { DecorationController } from "./DecorationController"
 
 export const DIFF_VIEW_URI_SCHEME = "cline-diff"
+export const DIFF_VIEW_LABEL_SEPARATOR = "↔ Roo's Changes"
 
 // TODO: https://github.com/cline/cline/pull/3354
 export class DiffViewProvider {
@@ -397,7 +398,7 @@ export class DiffViewProvider {
 				// Also check by tab label for our specific diff views
 				// This catches cases where the diff view might be created differently
 				// when files are pre-opened as text documents
-				if (tab.label.includes("↔ Roo's Changes") && !tab.isDirty) {
+				if (tab.label.includes(DIFF_VIEW_LABEL_SEPARATOR) && !tab.isDirty) {
 					return true
 				}
 
@@ -512,7 +513,7 @@ export class DiffViewProvider {
 							query: Buffer.from(this.originalContent ?? "").toString("base64"),
 						}),
 						uri,
-						`${fileName}: ${fileExists ? "Original ↔ Roo's Changes" : "New File"} (Editable)`,
+						`${fileName}: ${fileExists ? `Original ${DIFF_VIEW_LABEL_SEPARATOR}` : "New File"} (Editable)`,
 						{ preserveFocus: true },
 					)
 				})

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -384,12 +384,25 @@ export class DiffViewProvider {
 	private async closeAllDiffViews(): Promise<void> {
 		const closeOps = vscode.window.tabGroups.all
 			.flatMap((group) => group.tabs)
-			.filter(
-				(tab) =>
+			.filter((tab) => {
+				// Check for standard diff views with our URI scheme
+				if (
 					tab.input instanceof vscode.TabInputTextDiff &&
 					tab.input.original.scheme === DIFF_VIEW_URI_SCHEME &&
-					!tab.isDirty,
-			)
+					!tab.isDirty
+				) {
+					return true
+				}
+
+				// Also check by tab label for our specific diff views
+				// This catches cases where the diff view might be created differently
+				// when files are pre-opened as text documents
+				if (tab.label.includes("↔ Roo's Changes") && !tab.isDirty) {
+					return true
+				}
+
+				return false
+			})
 			.map((tab) =>
 				vscode.window.tabGroups.close(tab).then(
 					() => undefined,
@@ -487,17 +500,22 @@ export class DiffViewProvider {
 				}),
 			)
 
-			// Execute the diff command
-			vscode.commands
-				.executeCommand(
-					"vscode.diff",
-					vscode.Uri.parse(`${DIFF_VIEW_URI_SCHEME}:${fileName}`).with({
-						query: Buffer.from(this.originalContent ?? "").toString("base64"),
-					}),
-					uri,
-					`${fileName}: ${fileExists ? "Original ↔ Roo's Changes" : "New File"} (Editable)`,
-					{ preserveFocus: true },
-				)
+			// Pre-open the file as a text document to ensure it doesn't open in preview mode
+			// This fixes issues with files that have custom editor associations (like markdown preview)
+			vscode.window
+				.showTextDocument(uri, { preview: false, viewColumn: vscode.ViewColumn.Active })
+				.then(() => {
+					// Execute the diff command after ensuring the file is open as text
+					return vscode.commands.executeCommand(
+						"vscode.diff",
+						vscode.Uri.parse(`${DIFF_VIEW_URI_SCHEME}:${fileName}`).with({
+							query: Buffer.from(this.originalContent ?? "").toString("base64"),
+						}),
+						uri,
+						`${fileName}: ${fileExists ? "Original ↔ Roo's Changes" : "New File"} (Editable)`,
+						{ preserveFocus: true },
+					)
+				})
 				.then(
 					() => {
 						// Command executed successfully, now wait for the editor to appear

--- a/src/integrations/editor/__tests__/DiffViewProvider.spec.ts
+++ b/src/integrations/editor/__tests__/DiffViewProvider.spec.ts
@@ -1,4 +1,4 @@
-import { DiffViewProvider, DIFF_VIEW_URI_SCHEME, DIFF_VIEW_LABEL_SEPARATOR } from "../DiffViewProvider"
+import { DiffViewProvider, DIFF_VIEW_URI_SCHEME, DIFF_VIEW_LABEL_CHANGES } from "../DiffViewProvider"
 import * as vscode from "vscode"
 import * as path from "path"
 
@@ -219,7 +219,7 @@ describe("DiffViewProvider", () => {
 				"vscode.diff",
 				expect.any(Object),
 				expect.any(Object),
-				`test.md: Original ${DIFF_VIEW_LABEL_SEPARATOR} (Editable)`,
+				`test.md: ${DIFF_VIEW_LABEL_CHANGES} (Editable)`,
 				{ preserveFocus: true },
 			)
 		})
@@ -255,7 +255,7 @@ describe("DiffViewProvider", () => {
 						original: { scheme: DIFF_VIEW_URI_SCHEME },
 						modified: { fsPath: "/test/file1.ts" },
 					},
-					label: `file1.ts: Original ${DIFF_VIEW_LABEL_SEPARATOR} (Editable)`,
+					label: `file1.ts: ${DIFF_VIEW_LABEL_CHANGES} (Editable)`,
 					isDirty: false,
 				},
 				// Diff view identified by label (for pre-opened files)
@@ -265,7 +265,7 @@ describe("DiffViewProvider", () => {
 						original: { scheme: "file" }, // Different scheme due to pre-opening
 						modified: { fsPath: "/test/file2.md" },
 					},
-					label: `file2.md: Original ${DIFF_VIEW_LABEL_SEPARATOR} (Editable)`,
+					label: `file2.md: ${DIFF_VIEW_LABEL_CHANGES} (Editable)`,
 					isDirty: false,
 				},
 				// Regular file tab (should not be closed)
@@ -284,7 +284,7 @@ describe("DiffViewProvider", () => {
 						original: { scheme: DIFF_VIEW_URI_SCHEME },
 						modified: { fsPath: "/test/file4.ts" },
 					},
-					label: `file4.ts: Original ${DIFF_VIEW_LABEL_SEPARATOR} (Editable)`,
+					label: `file4.ts: ${DIFF_VIEW_LABEL_CHANGES} (Editable)`,
 					isDirty: true,
 				},
 			]
@@ -317,15 +317,13 @@ describe("DiffViewProvider", () => {
 
 			// Verify that only the appropriate tabs were closed
 			expect(closedTabs).toHaveLength(2)
-			expect(closedTabs[0].label).toBe(`file1.ts: Original ${DIFF_VIEW_LABEL_SEPARATOR} (Editable)`)
-			expect(closedTabs[1].label).toBe(`file2.md: Original ${DIFF_VIEW_LABEL_SEPARATOR} (Editable)`)
+			expect(closedTabs[0].label).toBe(`file1.ts: ${DIFF_VIEW_LABEL_CHANGES} (Editable)`)
+			expect(closedTabs[1].label).toBe(`file2.md: ${DIFF_VIEW_LABEL_CHANGES} (Editable)`)
 
 			// Verify that the regular file and dirty diff were not closed
 			expect(closedTabs.find((t) => t.label === "file3.js")).toBeUndefined()
 			expect(
-				closedTabs.find(
-					(t) => t.label === `file4.ts: Original ${DIFF_VIEW_LABEL_SEPARATOR} (Editable)` && t.isDirty,
-				),
+				closedTabs.find((t) => t.label === `file4.ts: ${DIFF_VIEW_LABEL_CHANGES} (Editable)` && t.isDirty),
 			).toBeUndefined()
 		})
 	})

--- a/src/integrations/editor/__tests__/DiffViewProvider.spec.ts
+++ b/src/integrations/editor/__tests__/DiffViewProvider.spec.ts
@@ -1,23 +1,77 @@
-import { DiffViewProvider } from "../DiffViewProvider"
+import { DiffViewProvider, DIFF_VIEW_URI_SCHEME } from "../DiffViewProvider"
 import * as vscode from "vscode"
+import * as path from "path"
+
+// Mock fs/promises
+vi.mock("fs/promises", () => ({
+	readFile: vi.fn().mockResolvedValue("file content"),
+	writeFile: vi.fn().mockResolvedValue(undefined),
+}))
+
+// Mock utils
+vi.mock("../../../utils/fs", () => ({
+	createDirectoriesForFile: vi.fn().mockResolvedValue([]),
+}))
+
+// Mock path
+vi.mock("path", () => ({
+	resolve: vi.fn((cwd, relPath) => `${cwd}/${relPath}`),
+	basename: vi.fn((path) => path.split("/").pop()),
+}))
 
 // Mock vscode
 vi.mock("vscode", () => ({
 	workspace: {
 		applyEdit: vi.fn(),
+		onDidOpenTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
+		textDocuments: [],
+		fs: {
+			stat: vi.fn(),
+		},
 	},
 	window: {
 		createTextEditorDecorationType: vi.fn(),
+		showTextDocument: vi.fn(),
+		onDidChangeVisibleTextEditors: vi.fn(() => ({ dispose: vi.fn() })),
+		tabGroups: {
+			all: [],
+			close: vi.fn(),
+		},
+		visibleTextEditors: [],
+	},
+	commands: {
+		executeCommand: vi.fn(),
+	},
+	languages: {
+		getDiagnostics: vi.fn(() => []),
 	},
 	WorkspaceEdit: vi.fn().mockImplementation(() => ({
 		replace: vi.fn(),
 		delete: vi.fn(),
 	})),
+	ViewColumn: {
+		Active: 1,
+		Beside: 2,
+		One: 1,
+		Two: 2,
+		Three: 3,
+		Four: 4,
+		Five: 5,
+		Six: 6,
+		Seven: 7,
+		Eight: 8,
+		Nine: 9,
+	},
 	Range: vi.fn(),
 	Position: vi.fn(),
 	Selection: vi.fn(),
 	TextEditorRevealType: {
 		InCenter: 2,
+	},
+	TabInputTextDiff: class TabInputTextDiff {},
+	Uri: {
+		file: vi.fn((path) => ({ fsPath: path })),
+		parse: vi.fn((uri) => ({ with: vi.fn(() => ({})) })),
 	},
 }))
 
@@ -26,6 +80,7 @@ vi.mock("../DecorationController", () => ({
 	DecorationController: vi.fn().mockImplementation(() => ({
 		setActiveLine: vi.fn(),
 		updateOverlayAfterLine: vi.fn(),
+		addLines: vi.fn(),
 		clear: vi.fn(),
 	})),
 }))
@@ -60,7 +115,11 @@ describe("DiffViewProvider", () => {
 			revealRange: vi.fn(),
 		}
 		;(diffViewProvider as any).activeLineController = { setActiveLine: vi.fn(), clear: vi.fn() }
-		;(diffViewProvider as any).fadedOverlayController = { updateOverlayAfterLine: vi.fn(), clear: vi.fn() }
+		;(diffViewProvider as any).fadedOverlayController = {
+			updateOverlayAfterLine: vi.fn(),
+			addLines: vi.fn(),
+			clear: vi.fn(),
+		}
 	})
 
 	describe("update method", () => {
@@ -91,6 +150,181 @@ describe("DiffViewProvider", () => {
 			await diffViewProvider.update("New content", true)
 
 			expect(mockWorkspaceEdit.replace).toHaveBeenCalledWith(expect.anything(), expect.anything(), "New content")
+		})
+	})
+
+	describe("open method", () => {
+		it("should pre-open file as text document before executing diff command", async () => {
+			// Setup
+			const mockEditor = {
+				document: {
+					uri: { fsPath: `${mockCwd}/test.md` },
+					getText: vi.fn().mockReturnValue(""),
+					lineCount: 0,
+				},
+				selection: {
+					active: { line: 0, character: 0 },
+					anchor: { line: 0, character: 0 },
+				},
+				edit: vi.fn().mockResolvedValue(true),
+				revealRange: vi.fn(),
+			}
+
+			// Track the order of calls
+			const callOrder: string[] = []
+
+			// Mock showTextDocument to track when it's called
+			vi.mocked(vscode.window.showTextDocument).mockImplementation(async (uri, options) => {
+				callOrder.push("showTextDocument")
+				expect(options).toEqual({ preview: false, viewColumn: vscode.ViewColumn.Active })
+				return mockEditor as any
+			})
+
+			// Mock executeCommand to track when it's called
+			vi.mocked(vscode.commands.executeCommand).mockImplementation(async (command) => {
+				callOrder.push("executeCommand")
+				expect(command).toBe("vscode.diff")
+				return undefined
+			})
+
+			// Mock workspace.onDidOpenTextDocument to trigger immediately
+			vi.mocked(vscode.workspace.onDidOpenTextDocument).mockImplementation((callback) => {
+				// Trigger the callback immediately with the document
+				setTimeout(() => {
+					callback({ uri: { fsPath: `${mockCwd}/test.md` } } as any)
+				}, 0)
+				return { dispose: vi.fn() }
+			})
+
+			// Mock window.visibleTextEditors to return our editor
+			vi.mocked(vscode.window).visibleTextEditors = [mockEditor as any]
+
+			// Set up for file
+			;(diffViewProvider as any).editType = "modify"
+
+			// Execute open
+			await diffViewProvider.open("test.md")
+
+			// Verify that showTextDocument was called before executeCommand
+			expect(callOrder).toEqual(["showTextDocument", "executeCommand"])
+
+			// Verify that showTextDocument was called with preview: false
+			expect(vscode.window.showTextDocument).toHaveBeenCalledWith(
+				expect.objectContaining({ fsPath: `${mockCwd}/test.md` }),
+				{ preview: false, viewColumn: vscode.ViewColumn.Active },
+			)
+
+			// Verify that the diff command was executed
+			expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+				"vscode.diff",
+				expect.any(Object),
+				expect.any(Object),
+				"test.md: Original ↔ Roo's Changes (Editable)",
+				{ preserveFocus: true },
+			)
+		})
+
+		it("should handle showTextDocument failure", async () => {
+			// Mock showTextDocument to fail
+			vi.mocked(vscode.window.showTextDocument).mockRejectedValue(new Error("Cannot open file"))
+
+			// Mock workspace.onDidOpenTextDocument
+			vi.mocked(vscode.workspace.onDidOpenTextDocument).mockReturnValue({ dispose: vi.fn() })
+
+			// Mock window.onDidChangeVisibleTextEditors
+			vi.mocked(vscode.window.onDidChangeVisibleTextEditors).mockReturnValue({ dispose: vi.fn() })
+
+			// Set up for file
+			;(diffViewProvider as any).editType = "modify"
+
+			// Try to open and expect rejection
+			await expect(diffViewProvider.open("test.md")).rejects.toThrow(
+				"Failed to execute diff command for /mock/cwd/test.md: Cannot open file",
+			)
+		})
+	})
+
+	describe("closeAllDiffViews method", () => {
+		it("should close diff views including those identified by label", async () => {
+			// Mock tab groups with various types of tabs
+			const mockTabs = [
+				// Normal diff view
+				{
+					input: {
+						constructor: { name: "TabInputTextDiff" },
+						original: { scheme: DIFF_VIEW_URI_SCHEME },
+						modified: { fsPath: "/test/file1.ts" },
+					},
+					label: "file1.ts: Original ↔ Roo's Changes (Editable)",
+					isDirty: false,
+				},
+				// Diff view identified by label (for pre-opened files)
+				{
+					input: {
+						constructor: { name: "TabInputTextDiff" },
+						original: { scheme: "file" }, // Different scheme due to pre-opening
+						modified: { fsPath: "/test/file2.md" },
+					},
+					label: "file2.md: Original ↔ Roo's Changes (Editable)",
+					isDirty: false,
+				},
+				// Regular file tab (should not be closed)
+				{
+					input: {
+						constructor: { name: "TabInputText" },
+						uri: { fsPath: "/test/file3.js" },
+					},
+					label: "file3.js",
+					isDirty: false,
+				},
+				// Dirty diff view (should not be closed)
+				{
+					input: {
+						constructor: { name: "TabInputTextDiff" },
+						original: { scheme: DIFF_VIEW_URI_SCHEME },
+						modified: { fsPath: "/test/file4.ts" },
+					},
+					label: "file4.ts: Original ↔ Roo's Changes (Editable)",
+					isDirty: true,
+				},
+			]
+
+			// Make tabs appear as TabInputTextDiff instances
+			mockTabs.forEach((tab) => {
+				if (tab.input.constructor.name === "TabInputTextDiff") {
+					Object.setPrototypeOf(tab.input, vscode.TabInputTextDiff.prototype)
+				}
+			})
+
+			// Mock the tabGroups getter
+			Object.defineProperty(vscode.window.tabGroups, "all", {
+				get: () => [
+					{
+						tabs: mockTabs as any,
+					},
+				],
+				configurable: true,
+			})
+
+			const closedTabs: any[] = []
+			vi.mocked(vscode.window.tabGroups.close).mockImplementation((tab) => {
+				closedTabs.push(tab)
+				return Promise.resolve(true)
+			})
+
+			// Execute closeAllDiffViews
+			await (diffViewProvider as any).closeAllDiffViews()
+
+			// Verify that only the appropriate tabs were closed
+			expect(closedTabs).toHaveLength(2)
+			expect(closedTabs[0].label).toBe("file1.ts: Original ↔ Roo's Changes (Editable)")
+			expect(closedTabs[1].label).toBe("file2.md: Original ↔ Roo's Changes (Editable)")
+
+			// Verify that the regular file and dirty diff were not closed
+			expect(closedTabs.find((t) => t.label === "file3.js")).toBeUndefined()
+			expect(
+				closedTabs.find((t) => t.label === "file4.ts: Original ↔ Roo's Changes (Editable)" && t.isDirty),
+			).toBeUndefined()
 		})
 	})
 })

--- a/src/integrations/editor/__tests__/DiffViewProvider.spec.ts
+++ b/src/integrations/editor/__tests__/DiffViewProvider.spec.ts
@@ -1,4 +1,4 @@
-import { DiffViewProvider, DIFF_VIEW_URI_SCHEME } from "../DiffViewProvider"
+import { DiffViewProvider, DIFF_VIEW_URI_SCHEME, DIFF_VIEW_LABEL_SEPARATOR } from "../DiffViewProvider"
 import * as vscode from "vscode"
 import * as path from "path"
 
@@ -219,7 +219,7 @@ describe("DiffViewProvider", () => {
 				"vscode.diff",
 				expect.any(Object),
 				expect.any(Object),
-				"test.md: Original ↔ Roo's Changes (Editable)",
+				`test.md: Original ${DIFF_VIEW_LABEL_SEPARATOR} (Editable)`,
 				{ preserveFocus: true },
 			)
 		})
@@ -255,7 +255,7 @@ describe("DiffViewProvider", () => {
 						original: { scheme: DIFF_VIEW_URI_SCHEME },
 						modified: { fsPath: "/test/file1.ts" },
 					},
-					label: "file1.ts: Original ↔ Roo's Changes (Editable)",
+					label: `file1.ts: Original ${DIFF_VIEW_LABEL_SEPARATOR} (Editable)`,
 					isDirty: false,
 				},
 				// Diff view identified by label (for pre-opened files)
@@ -265,7 +265,7 @@ describe("DiffViewProvider", () => {
 						original: { scheme: "file" }, // Different scheme due to pre-opening
 						modified: { fsPath: "/test/file2.md" },
 					},
-					label: "file2.md: Original ↔ Roo's Changes (Editable)",
+					label: `file2.md: Original ${DIFF_VIEW_LABEL_SEPARATOR} (Editable)`,
 					isDirty: false,
 				},
 				// Regular file tab (should not be closed)
@@ -284,7 +284,7 @@ describe("DiffViewProvider", () => {
 						original: { scheme: DIFF_VIEW_URI_SCHEME },
 						modified: { fsPath: "/test/file4.ts" },
 					},
-					label: "file4.ts: Original ↔ Roo's Changes (Editable)",
+					label: `file4.ts: Original ${DIFF_VIEW_LABEL_SEPARATOR} (Editable)`,
 					isDirty: true,
 				},
 			]
@@ -317,13 +317,15 @@ describe("DiffViewProvider", () => {
 
 			// Verify that only the appropriate tabs were closed
 			expect(closedTabs).toHaveLength(2)
-			expect(closedTabs[0].label).toBe("file1.ts: Original ↔ Roo's Changes (Editable)")
-			expect(closedTabs[1].label).toBe("file2.md: Original ↔ Roo's Changes (Editable)")
+			expect(closedTabs[0].label).toBe(`file1.ts: Original ${DIFF_VIEW_LABEL_SEPARATOR} (Editable)`)
+			expect(closedTabs[1].label).toBe(`file2.md: Original ${DIFF_VIEW_LABEL_SEPARATOR} (Editable)`)
 
 			// Verify that the regular file and dirty diff were not closed
 			expect(closedTabs.find((t) => t.label === "file3.js")).toBeUndefined()
 			expect(
-				closedTabs.find((t) => t.label === "file4.ts: Original ↔ Roo's Changes (Editable)" && t.isDirty),
+				closedTabs.find(
+					(t) => t.label === `file4.ts: Original ${DIFF_VIEW_LABEL_SEPARATOR} (Editable)` && t.isDirty,
+				),
 			).toBeUndefined()
 		})
 	})


### PR DESCRIPTION
## Description

Fixes #2360

This PR resolves an issue where file editing tools (apply_diff, write_to_file, search_and_replace) fail for files that have custom editor associations configured in VS Code, particularly markdown files with preview mode associations.

## Root Cause

When VS Code has `workbench.editorAssociations` configured to open certain file types (like `"*.md": "vscode.markdown.preview.editor"`), the `vscode.diff` command opens the file in preview mode instead of as an editable text document. This causes:

1. "Illegal value for lineNumber" errors when trying to edit
2. Diff views that can't be properly detected and closed

## Solution

Implemented a simple and reliable approach:

1. **Pre-open files as text documents**: Before executing the diff command, always call `vscode.window.showTextDocument()` with `preview: false` to ensure the file opens in text editing mode
2. **Enhanced diff view detection**: Updated `closeAllDiffViews()` to identify diff tabs both by URI scheme and by label pattern ("↔ Roo's Changes")

This PR doesn't affect the normal behavior of editing files at all. Files were being opened when edited, but this happened after the edit itself. Now it happens before the edit. Ultimately, the result is exactly the same.

## Changes Made

- **`src/integrations/editor/DiffViewProvider.ts`**:
  - Modified `openDiffEditor()` to pre-open files as text documents before executing diff command
  - Enhanced `closeAllDiffViews()` to detect diff views by label pattern as fallback
  - Added comprehensive comments explaining the fix

- **`src/integrations/editor/__tests__/DiffViewProvider.spec.ts`**:
  - Updated mocks to include all required VSCode APIs
  - Added tests verifying the pre-opening behavior
  - Added tests for enhanced diff view closing logic
  - All existing tests continue to pass

## Testing

- [x] All existing tests pass
- [x] Added new tests for pre-opening behavior
- [x] Added tests for enhanced diff view detection
- [x] Manual testing with markdown files and preview associations
- [x] Verified no performance regression

## Verification of Acceptance Criteria

- [x] File editing tools work correctly with markdown files that have preview associations
- [x] Diff views are properly opened and closed
- [x] No "Illegal value for lineNumber" errors
- [x] Solution works for all file types, not just markdown
- [x] Backward compatibility maintained

## Impact

- **Positive**: Fixes a blocking issue for users with custom editor associations
- **Performance**: Minimal impact - adds one additional `showTextDocument` call per diff operation
- **Compatibility**: Fully backward compatible, no breaking changes
- **Scope**: Affects only the diff editor functionality

## Screenshots/Demo

Before: File editing tools would fail with "Illegal value for lineNumber" errors for markdown files with preview associations.

After: File editing tools work seamlessly regardless of editor associations.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] All tests pass
- [x] No breaking changes
- [x] Issue requirements fully addressed
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes diff editor issues in VS Code by pre-opening files as text documents and enhancing diff view detection.
> 
>   - **Behavior**:
>     - Fixes issue with `vscode.diff` command opening files in preview mode due to `workbench.editorAssociations`.
>     - Pre-opens files as text documents using `vscode.window.showTextDocument()` with `preview: false`.
>     - Enhances `closeAllDiffViews()` in `DiffViewProvider.ts` to detect diff views by URI scheme and label pattern.
>   - **Testing**:
>     - Updates `DiffViewProvider.spec.ts` to mock necessary VSCode APIs.
>     - Adds tests for pre-opening behavior and enhanced diff view detection.
>     - Verifies no performance regression and maintains backward compatibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7909ee1bee12245683858b9ef5e300fd99c11f93. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->