### PR TITLE
Remove type of change from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,19 +30,6 @@ Detail the steps to test your changes. This helps reviewers verify your work.
 - Include relevant testing environment details if applicable.
 -->
 
-### Type of Change
-
-<!-- Mark all applicable boxes with an 'x'. -->
-
-- [ ] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
-- [ ] ✨ **New Feature**: Non-breaking change that adds functionality.
-- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
-- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
-- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
-- [ ] 📚 **Documentation**: Updates to documentation files.
-- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
-- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.
-
 ### Pre-Submission Checklist
 
 <!-- Go through this checklist before marking your PR as ready for review. -->


### PR DESCRIPTION
The "Type of Change" section was removed from the pull request template located at `.github/pull_request_template.md`.

This modification was implemented to enable automatic labeling of pull request types, as the previous section required manual selection via checkboxes for categories such as bug fixes, new features, or breaking changes.

The template now transitions directly from the "Test Procedure" section to the "Pre-Submission Checklist", streamlining the PR creation process.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove "Type of Change" section from PR template to streamline process and enable automatic labeling.
> 
>   - **Template Update**:
>     - Removes "Type of Change" section from `.github/pull_request_template.md`.
>     - Streamlines PR process by transitioning directly from "Test Procedure" to "Pre-Submission Checklist".
>     - Enables automatic labeling of PR types, eliminating manual checkbox selection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 50be80b6b233636b13d1bf4fc5b81c7e1b3e1c16. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->