### PR TITLE
The goal of this change is to give the mode writer access to a list o…

### DIFF
--- a/.roomodes
+++ b/.roomodes
@@ -25,6 +25,8 @@ customModes:
         - fileRegex: (\.roomodes$|\.roo/.*\.xml$|\.yaml$)
           description: Mode configuration files and XML instructions
       - command
+      - mcp
+    source: project
   - slug: test
     name: 🧪 Test
     roleDefinition: >-


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `mcp` command to `mode-writer` group in `.roomodes`, expanding mode writer capabilities.
> 
>   - **Behavior**:
>     - Adds `mcp` command to `mode-writer` group in `.roomodes`, allowing mode writers to use this command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b3aa051e0156f7b434602b3de511a7e693071442. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->