### PR TITLE
fix: resolve MCP tool eye icon state and hide in chat context (#4993)

### DIFF
--- a/webview-ui/src/components/chat/McpExecution.tsx
+++ b/webview-ui/src/components/chat/McpExecution.tsx
@@ -242,6 +242,7 @@ export const McpExecution = ({
 							serverName={useMcpServer.serverName}
 							serverSource={server?.source}
 							alwaysAllowMcp={alwaysAllowMcp}
+							isInChatContext={true}
 						/>
 					</div>
 				)}
@@ -256,6 +257,7 @@ export const McpExecution = ({
 							serverName={serverName}
 							serverSource={undefined}
 							alwaysAllowMcp={alwaysAllowMcp}
+							isInChatContext={true}
 						/>
 					</div>
 				)}

--- a/webview-ui/src/components/mcp/McpToolRow.tsx
+++ b/webview-ui/src/components/mcp/McpToolRow.tsx
@@ -10,9 +10,10 @@ type McpToolRowProps = {
 	serverName?: string
 	serverSource?: "global" | "project"
 	alwaysAllowMcp?: boolean
+	isInChatContext?: boolean
 }
 
-const McpToolRow = ({ tool, serverName, serverSource, alwaysAllowMcp }: McpToolRowProps) => {
+const McpToolRow = ({ tool, serverName, serverSource, alwaysAllowMcp, isInChatContext = false }: McpToolRowProps) => {
 	const { t } = useAppTranslation()
 	const handleAlwaysAllowChange = () => {
 		if (!serverName) return
@@ -66,25 +67,27 @@ const McpToolRow = ({ tool, serverName, serverSource, alwaysAllowMcp }: McpToolR
 							</VSCodeCheckbox>
 						)}
 
-						{/* Enabled eye button */}
-						<button
-							role="button"
-							aria-pressed={tool.enabledForPrompt}
-							aria-label={t("mcp:tool.togglePromptInclusion")}
-							className={`p-1 rounded hover:bg-vscode-toolbar-hoverBackground transition-colors ${
-								tool.enabledForPrompt
-									? "text-vscode-foreground"
-									: "text-vscode-descriptionForeground opacity-60"
-							}`}
-							onClick={handleEnabledForPromptChange}
-							data-tool-prompt-toggle={tool.name}
-							title={t("mcp:tool.togglePromptInclusion")}>
-							<span
-								className={`codicon ${
-									tool.enabledForPrompt ? "codicon-eye" : "codicon-eye-closed"
-								} text-base`}
-							/>
-						</button>
+						{/* Enabled eye button - only show in settings context */}
+						{!isInChatContext && (
+							<button
+								role="button"
+								aria-pressed={tool.enabledForPrompt}
+								aria-label={t("mcp:tool.togglePromptInclusion")}
+								className={`p-1 rounded hover:bg-vscode-toolbar-hoverBackground transition-colors ${
+									tool.enabledForPrompt
+										? "text-vscode-foreground"
+										: "text-vscode-descriptionForeground opacity-60"
+								}`}
+								onClick={handleEnabledForPromptChange}
+								data-tool-prompt-toggle={tool.name}
+								title={t("mcp:tool.togglePromptInclusion")}>
+								<span
+									className={`codicon ${
+										tool.enabledForPrompt ? "codicon-eye-closed" : "codicon-eye"
+									} text-base`}
+								/>
+							</button>
+						)}
 					</div>
 				)}
 			</div>


### PR DESCRIPTION
## Description

Fixes #4993

This PR addresses two issues with the MCP tool eye icon:
1. The eye icon was showing the wrong state (showed eye when enabled, should show eye-closed)
2. The eye icon was appearing in chat context where it shouldn't be visible

## Changes Made

- Added `isInChatContext` optional prop to `McpToolRow` component in [`webview-ui/src/components/mcp/McpToolRow.tsx`](webview-ui/src/components/mcp/McpToolRow.tsx)
- Fixed the eye icon state logic to show `codicon-eye-closed` when enabled and `codicon-eye` when disabled
- Conditionally hide the eye button when `isInChatContext` is true
- Updated [`webview-ui/src/components/chat/McpExecution.tsx`](webview-ui/src/components/chat/McpExecution.tsx) to pass `isInChatContext={true}` when rendering McpToolRow
- Added comprehensive tests to verify the new behavior

## Testing

- [x] All existing tests pass
- [x] Added tests for the new `isInChatContext` prop
- [x] Added tests to verify eye button is hidden in chat context
- [x] Added tests to verify correct icon state based on `enabledForPrompt`
- [x] Manual testing completed:
  - Eye icon no longer appears in chat when MCP tools are executed
  - Eye icon shows correct state in settings (eye-closed when enabled)

## Verification of Acceptance Criteria

- [x] In chat session: McpToolRow appears without the eye toggle button when Roo requests to use an MCP tool
- [x] In MCP settings page: Eye toggle button is visible and functional
- [x] Eye icon correctly toggles between eye and eye-closed based on enabledForPrompt state

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No breaking changes
- [x] Accessibility checked (keyboard navigation works)

## Screenshots/Demo

![image](https://github.com/user-attachments/assets/19e1dcac-c3ca-49db-b1d0-57561b115d1f)