### PR TITLE
Fix #4888: Finalize pending api_req_started messages on task completion

### DIFF
--- a/src/core/tools/attemptCompletionTool.ts
+++ b/src/core/tools/attemptCompletionTool.ts
@@ -45,6 +45,7 @@ export async function attemptCompletionTool(
 					// we have command string, which means we have the result as well, so finish it (doesnt have to exist yet)
 					await cline.say("completion_result", removeClosingTag("result", result), undefined, false)
 
+					await cline.finish()
 					TelemetryService.instance.captureTaskCompleted(cline.taskId)
 					cline.emit("taskCompleted", cline.taskId, cline.getTokenUsage(), cline.toolUsage)
 
@@ -68,6 +69,7 @@ export async function attemptCompletionTool(
 			// Command execution is permanently disabled in attempt_completion
 			// Users must use execute_command tool separately before attempt_completion
 			await cline.say("completion_result", result, undefined, false)
+			await cline.finish()
 			TelemetryService.instance.captureTaskCompleted(cline.taskId)
 			cline.emit("taskCompleted", cline.taskId, cline.getTokenUsage(), cline.toolUsage)
 


### PR DESCRIPTION
## Summary

Fixes #4888 by ensuring all pending api_req_started messages are properly finalized when a task completes, preventing UI spinners from persisting in task history.

## Changes

### Core Implementation
- **Added `finish()` method to `Task.ts`**: Finds all `api_req_started` messages without `cost` or `cancelReason` and sets their `cost` to `0`
- **Updated `attemptCompletionTool.ts`**: Calls `finish()` before emitting `taskCompleted` to ensure all API requests are finalized

### Testing
- **Added comprehensive unit tests** in `Task.spec.ts`:
  - Test that all pending `api_req_started` messages get finalized with `cost: 0`
  - Test that no unnecessary saves occur when no updates are needed
  - Test edge case with no `api_req_started` messages
  - Verification that ALL `api_req_started` messages have either `cost` or `cancelReason` after completion

## Problem Solved

The issue occurred because when tasks completed, some `api_req_started` messages in the conversation history lacked both `cost` and `cancelReason` values. The UI component (`ChatRow.tsx`) shows a spinner for ANY `api_req_started` message missing these values, causing spinners to persist in completed task history.

## Solution Approach

While operations run sequentially and theoretically only the last `api_req_started` could be unfinished, the UI checks ALL messages for the spinner condition. Rather than modifying the UI logic (which would require additional complexity), this solution ensures backend compatibility by finalizing all unfinished messages.

## Testing

✅ All existing tests pass  
✅ New unit tests cover the `finish()` method functionality  
✅ Linting and type checking pass  

## Verification

After this fix:
- Completed tasks will have all `api_req_started` messages properly finalized
- No spinners will persist in task history
- UI behavior remains unchanged for active/streaming tasks
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `finish()` method to `Task` to finalize pending `api_req_started` messages, ensuring UI spinners do not persist.
> 
>   - **Behavior**:
>     - Adds `finish()` method to `Task` class in `Task.ts` to finalize `api_req_started` messages with no `cost` or `cancelReason` by setting `cost` to `0`.
>     - Updates `attemptCompletionTool` in `attemptCompletionTool.ts` to call `finish()` before emitting `taskCompleted`.
>   - **Testing**:
>     - Adds unit tests in `Task.spec.ts` to verify `finish()` method finalizes messages correctly, handles cases with no updates, and processes scenarios with no `api_req_started` messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5233f617d0bfd63e10612c47cbe3d382993ad9a8. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->