### PR TITLE
Add option for allowed MCPs

### DIFF
--- a/packages/types/src/mode.ts
+++ b/packages/types/src/mode.ts
@@ -26,6 +26,7 @@ export const groupOptionsSchema = z.object({
 			{ message: "Invalid regular expression pattern" },
 		),
 	description: z.string().optional(),
+	allowedMcpServers: z.array(z.string()).optional(),
 })
 
 export type GroupOptions = z.infer<typeof groupOptionsSchema>

--- a/src/core/config/__tests__/ModeConfig.spec.ts
+++ b/src/core/config/__tests__/ModeConfig.spec.ts
@@ -176,6 +176,67 @@ describe("CustomModeSchema", () => {
 		})
 	})
 
+	describe("allowedMcpServers", () => {
+		it("validates a mode with MCP server restrictions", () => {
+			const modeWithMcpRestrictions = {
+				slug: "weather-mode",
+				name: "Weather Mode",
+				roleDefinition: "Weather analysis mode",
+				groups: ["read", ["mcp", { allowedMcpServers: ["weather-server", "climate-server"] }]],
+			}
+
+			const modeWithDescription = {
+				slug: "data-mode",
+				name: "Data Mode",
+				roleDefinition: "Data analysis mode",
+				groups: [
+					"read",
+					["mcp", { allowedMcpServers: ["database-server"], description: "Database server only" }],
+				],
+			}
+
+			expect(() => modeConfigSchema.parse(modeWithMcpRestrictions)).not.toThrow()
+			expect(() => modeConfigSchema.parse(modeWithDescription)).not.toThrow()
+		})
+
+		it("accepts empty allowedMcpServers array", () => {
+			const modeWithEmptyMcpList = {
+				slug: "no-mcp-mode",
+				name: "No MCP Mode",
+				roleDefinition: "Mode without MCP access",
+				groups: ["read", ["mcp", { allowedMcpServers: [] }]],
+			}
+
+			expect(() => modeConfigSchema.parse(modeWithEmptyMcpList)).not.toThrow()
+		})
+
+		it("validates that allowedMcpServers contains only strings", () => {
+			const modeWithInvalidMcpList = {
+				slug: "invalid-mode",
+				name: "Invalid Mode",
+				roleDefinition: "Invalid mode",
+				groups: ["read", ["mcp", { allowedMcpServers: ["valid-server", 123, "another-server"] }]],
+			}
+
+			expect(() => modeConfigSchema.parse(modeWithInvalidMcpList)).toThrow()
+		})
+
+		it("allows combining fileRegex and allowedMcpServers in different groups", () => {
+			const modeWithBothRestrictions = {
+				slug: "restricted-mode",
+				name: "Restricted Mode",
+				roleDefinition: "Mode with multiple restrictions",
+				groups: [
+					"read",
+					["edit", { fileRegex: "\\.md$", description: "Markdown files only" }],
+					["mcp", { allowedMcpServers: ["weather-server"], description: "Weather server only" }],
+				],
+			}
+
+			expect(() => modeConfigSchema.parse(modeWithBothRestrictions)).not.toThrow()
+		})
+	})
+
 	const validBaseMode = {
 		slug: "123e4567-e89b-12d3-a456-426614174000",
 		name: "Test Mode",

--- a/src/shared/modes.ts
+++ b/src/shared/modes.ts
@@ -205,6 +205,16 @@ export class FileRestrictionError extends Error {
 	}
 }
 
+// Custom error class for MCP server restrictions
+export class McpServerRestrictionError extends Error {
+	constructor(mode: string, allowedServers: string[], description: string | undefined, serverName: string) {
+		super(
+			`This mode (${mode}) can only use MCP servers: ${allowedServers.join(", ")}${description ? ` (${description})` : ""}. Got: ${serverName}`,
+		)
+		this.name = "McpServerRestrictionError"
+	}
+}
+
 export function isToolAllowedForMode(
 	tool: string,
 	modeSlug: string,
@@ -264,6 +274,19 @@ export function isToolAllowedForMode(
 				!doesFileMatchRegex(filePath, options.fileRegex)
 			) {
 				throw new FileRestrictionError(mode.name, options.fileRegex, options.description, filePath)
+			}
+		}
+
+		// For the mcp group, check allowed MCP servers if specified
+		if (groupName === "mcp" && options.allowedMcpServers) {
+			const serverName = toolParams?.server_name
+			if (serverName && !options.allowedMcpServers.includes(serverName)) {
+				throw new McpServerRestrictionError(
+					mode.name,
+					options.allowedMcpServers,
+					options.description,
+					serverName,
+				)
 			}
 		}
 


### PR DESCRIPTION
A new `allowedMcpServers` option was added to the mode configuration, enabling restrictions on MCP server access.

*   The `groupOptionsSchema` in `packages/types/src/mode.ts` was updated to include an optional `allowedMcpServers` array of strings.
*   A new `McpServerRestrictionError` class was introduced in `src/shared/modes.ts` to provide specific error messages when restrictions are violated.
*   The `isToolAllowedForMode` function in `src/shared/modes.ts` was modified to enforce these restrictions for `use_mcp_tool` and `access_mcp_resource` calls.
    *   If a `server_name` is provided and not in the allowed list, an `McpServerRestrictionError` is thrown.
    *   Requests without a `server_name` (e.g., partial streaming requests) are permitted.
*   Comprehensive tests were added to `src/shared/__tests__/modes.spec.ts` to validate the restriction logic, covering permitted/rejected servers, unrestricted modes, and error messages.
*   Schema validation tests were added to `src/core/config/__tests__/ModeConfig.spec.ts` to ensure the `allowedMcpServers` field is correctly parsed and validated.

This change provides granular control over which MCP servers a mode can interact with.