### PR TITLE
Add UI for file regex editing

### DIFF
--- a/FILE_REGEX_UI_IMPLEMENTATION.md
+++ b/FILE_REGEX_UI_IMPLEMENTATION.md
@@ -1,0 +1,119 @@
+# File Regex UI Implementation for Modes Tab
+
+## Summary
+
+I have successfully implemented a UI in the modes tab for displaying and editing the file regex for the edit files tool group. This allows users to configure which files can be edited when a specific mode is active.
+
+## Features Implemented
+
+### 1. **Display Current File Regex**
+
+- Shows the current file regex pattern and description for the edit tool group
+- Displays "all files" when no regex is configured
+- Shows either the description or the regex pattern (formatted as `/pattern/`)
+
+### 2. **Edit Mode UI**
+
+- **File Regex Input**: Text input field for entering regex patterns (e.g., `.*\.(js|ts|jsx|tsx)$`)
+- **Description Input**: Text input field for entering a human-readable description (e.g., "JavaScript/TypeScript files")
+- **Save/Cancel Buttons**: Action buttons to save or discard changes
+
+### 3. **Edit Button**
+
+- Small edit icon button that appears next to the file regex display
+- Only visible for custom modes (built-in modes cannot be edited)
+- Triggers the edit mode when clicked
+
+### 4. **Input Validation**
+
+- Handles both existing file regex configurations and new ones
+- Properly converts simple "edit" groups to array format with options
+- Preserves existing options when updating
+
+## Files Modified
+
+### 1. `webview-ui/src/components/modes/ModesView.tsx`
+
+#### **State Added:**
+
+```typescript
+const [editingFileRegex, setEditingFileRegex] = useState<string | null>(null)
+const [fileRegexValue, setFileRegexValue] = useState("")
+const [fileRegexDescription, setFileRegexDescription] = useState("")
+```
+
+#### **Functions Added:**
+
+- `startEditingFileRegex()`: Initializes edit mode with current values
+- `saveFileRegex()`: Saves changes to the mode configuration
+- `cancelEditingFileRegex()`: Cancels editing and resets state
+
+#### **UI Changes:**
+
+- Replaced static file regex display with conditional rendering
+- Added input fields and buttons that appear when editing
+- Added edit button that shows only for custom modes
+
+### 2. `webview-ui/src/i18n/locales/en/prompts.json`
+
+#### **Translation Keys Added:**
+
+```json
+{
+	"tools": {
+		"fileRegex": "File Regex",
+		"description": "Description",
+		"save": "Save",
+		"cancel": "Cancel",
+		"editFileRegex": "Edit file regex"
+	}
+}
+```
+
+## Technical Implementation Details
+
+### **Data Structure Handling**
+
+The implementation properly handles the `GroupEntry` union type:
+
+- Simple string groups: `"edit"`
+- Array groups with options: `["edit", { fileRegex: "pattern", description: "desc" }]`
+
+### **Type Safety**
+
+- Uses proper TypeScript types throughout
+- Handles the `GroupEntry` type correctly
+- Maintains type safety when updating group configurations
+
+### **User Experience**
+
+- Immediate visual feedback when entering edit mode
+- Clear labeling of input fields with placeholders
+- Non-destructive editing (changes only saved on explicit save)
+- Edit button only appears for modes that can be modified
+
+## Usage
+
+1. **Navigate to Modes Tab**: Open the prompts/modes configuration
+2. **Select Custom Mode**: Choose a custom mode (not built-in)
+3. **Find Edit Tool Group**: Look for the "Edit Files" tool group section
+4. **Click Edit Button**: Click the small edit icon next to the file regex display
+5. **Configure Regex**: Enter the desired file pattern and description
+6. **Save Changes**: Click "Save" to apply or "Cancel" to discard
+
+## Example Use Cases
+
+- **JavaScript Projects**: `.*\.(js|jsx|ts|tsx)$` - "JavaScript/TypeScript files"
+- **Python Projects**: `.*\.py$` - "Python files"
+- **Documentation**: `.*\.(md|txt|rst)$` - "Documentation files"
+- **Config Files**: `.*\.(json|yaml|yml|toml)$` - "Configuration files"
+
+## Benefits
+
+1. **Enhanced Control**: Users can precisely control which files modes can edit
+2. **Safety**: Prevents accidental modification of sensitive files
+3. **Workflow Optimization**: Modes can be tailored for specific file types
+4. **User-Friendly**: Intuitive UI that doesn't require manual JSON editing
+5. **Backward Compatible**: Works with existing mode configurations
+
+The implementation follows the existing code patterns and design system used throughout the Roo Code extension, ensuring consistency and maintainability.

--- a/webview-ui/src/i18n/locales/en/prompts.json
+++ b/webview-ui/src/i18n/locales/en/prompts.json
@@ -20,6 +20,11 @@
 		"editTools": "Edit tools",
 		"doneEditing": "Done editing",
 		"allowedFiles": "Allowed files:",
+		"fileRegex": "File Regex",
+		"description": "Description",
+		"save": "Save",
+		"cancel": "Cancel",
+		"editFileRegex": "Edit file regex",
 		"toolNames": {
 			"read": "Read Files",
 			"edit": "Edit Files",


### PR DESCRIPTION
A UI was added to the modes tab for displaying and editing the `fileRegex` property of the "edit" tool group.

Changes include:

*   **`webview-ui/src/components/modes/ModesView.tsx`**:
    *   New state variables (`editingFileRegex`, `fileRegexValue`, `fileRegexDescription`) were introduced to manage the editing state and input values.
    *   Functions `startEditingFileRegex`, `saveFileRegex`, and `cancelEditingFileRegex` were added to handle the lifecycle of the editing process.
    *   The UI for the "edit" tool group was updated to conditionally render either the display-only view or an editable form with input fields for `fileRegex` and `description`, along with "Save" and "Cancel" buttons.
    *   An edit icon button was added, visible only for custom modes, to initiate the editing process.
    *   The `saveFileRegex` function now correctly handles `GroupEntry` types, converting simple `"edit"` strings to `["edit", { fileRegex, description }]` tuples when options are added, and updating existing tuples.
*   **`webview-ui/src/i18n/locales/en/prompts.json`**:
    *   New translation keys (`fileRegex`, `description`, `save`, `cancel`, `editFileRegex`) were added to support the new UI elements.

This allows users to visually configure file regex patterns and descriptions for custom modes directly within the UI.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds UI for editing `fileRegex` in custom modes, with new state management and localization in `ModesView.tsx` and `prompts.json`.
> 
>   - **Behavior**:
>     - Adds UI for editing `fileRegex` in custom modes in `ModesView.tsx`.
>     - Introduces `editingFileRegex`, `fileRegexValue`, and `fileRegexDescription` state variables.
>     - Adds `startEditingFileRegex`, `saveFileRegex`, and `cancelEditingFileRegex` functions.
>     - Updates UI to conditionally render input fields and buttons for `fileRegex` and `description`.
>     - Edit button visible only for custom modes.
>     - `saveFileRegex` updates `GroupEntry` types, converting "edit" strings to tuples with options.
>   - **Localization**:
>     - Adds translation keys in `prompts.json` for `fileRegex`, `description`, `save`, `cancel`, and `editFileRegex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c093e96882f8de1975cecb4f6e03e52d4a1bcea9. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->