### PR TITLE
fix(qdrant): add URL prefix handling for QdrantClient initialization

### DIFF
--- a/src/services/code-index/vector-store/__tests__/qdrant-client.spec.ts
+++ b/src/services/code-index/vector-store/__tests__/qdrant-client.spec.ts
@@ -420,6 +420,25 @@ describe("QdrantVectorStore", () => {
 			expect((vectorStoreWithTrailingSlash as any).qdrantUrl).toBe("http://localhost:6333/api/")
 		})
 
+		it("should normalize URL pathname by removing multiple trailing slashes for prefix", () => {
+			const vectorStoreWithMultipleTrailingSlashes = new QdrantVectorStore(
+				mockWorkspacePath,
+				"http://localhost:6333/api///",
+				mockVectorSize,
+			)
+			expect(QdrantClient).toHaveBeenLastCalledWith({
+				host: "localhost",
+				https: false,
+				port: 6333,
+				prefix: "/api", // All trailing slashes should be removed
+				apiKey: undefined,
+				headers: {
+					"User-Agent": "Roo-Code",
+				},
+			})
+			expect((vectorStoreWithMultipleTrailingSlashes as any).qdrantUrl).toBe("http://localhost:6333/api///")
+		})
+
 		it("should handle multiple path segments correctly for prefix", () => {
 			const vectorStoreWithMultiSegment = new QdrantVectorStore(
 				mockWorkspacePath,
@@ -438,14 +457,10 @@ describe("QdrantVectorStore", () => {
 			})
 			expect((vectorStoreWithMultiSegment as any).qdrantUrl).toBe("http://localhost:6333/api/v1/qdrant")
 		})
-		
-		it("should handle complex URL with multiple segments, trailing slash, query params, and fragment", () => {
-			const complexUrl = "https://example.com/ollama/api/v1/?key=value#pos"
-			const vectorStoreComplex = new QdrantVectorStore(
-				mockWorkspacePath,
-				complexUrl,
-				mockVectorSize,
-			)
+
+		it("should handle complex URL with multiple segments, multiple trailing slashes, query params, and fragment", () => {
+			const complexUrl = "https://example.com/ollama/api/v1///?key=value#pos"
+			const vectorStoreComplex = new QdrantVectorStore(mockWorkspacePath, complexUrl, mockVectorSize)
 			expect(QdrantClient).toHaveBeenLastCalledWith({
 				host: "example.com",
 				https: true,

--- a/src/services/code-index/vector-store/__tests__/qdrant-client.spec.ts
+++ b/src/services/code-index/vector-store/__tests__/qdrant-client.spec.ts
@@ -113,6 +113,7 @@ describe("QdrantVectorStore", () => {
 					host: "qdrant.ashbyfam.com",
 					https: true,
 					port: 443,
+					prefix: undefined, // No prefix for root path
 					apiKey: undefined,
 					headers: {
 						"User-Agent": "Roo-Code",
@@ -127,6 +128,7 @@ describe("QdrantVectorStore", () => {
 					host: "example.com",
 					https: true,
 					port: 9000,
+					prefix: undefined, // No prefix for root path
 					apiKey: undefined,
 					headers: {
 						"User-Agent": "Roo-Code",
@@ -145,6 +147,7 @@ describe("QdrantVectorStore", () => {
 					host: "example.com",
 					https: true,
 					port: 443,
+					prefix: "/api/v1", // Should have prefix
 					apiKey: undefined,
 					headers: {
 						"User-Agent": "Roo-Code",
@@ -161,6 +164,7 @@ describe("QdrantVectorStore", () => {
 					host: "example.com",
 					https: false,
 					port: 80,
+					prefix: undefined, // No prefix for root path
 					apiKey: undefined,
 					headers: {
 						"User-Agent": "Roo-Code",
@@ -175,6 +179,7 @@ describe("QdrantVectorStore", () => {
 					host: "localhost",
 					https: false,
 					port: 8080,
+					prefix: undefined, // No prefix for root path
 					apiKey: undefined,
 					headers: {
 						"User-Agent": "Roo-Code",
@@ -193,6 +198,7 @@ describe("QdrantVectorStore", () => {
 					host: "example.com",
 					https: false,
 					port: 80,
+					prefix: "/api/v1", // Should have prefix
 					apiKey: undefined,
 					headers: {
 						"User-Agent": "Roo-Code",
@@ -334,6 +340,65 @@ describe("QdrantVectorStore", () => {
 				})
 				expect((vectorStore as any).qdrantUrl).toBe("http://invalid-url-format")
 			})
+		})
+	})
+
+	describe("URL Prefix Handling", () => {
+		it("should pass the URL pathname as prefix to QdrantClient if not root", () => {
+			const vectorStoreWithPrefix = new QdrantVectorStore(
+				mockWorkspacePath,
+				"http://localhost:6333/some/path",
+				mockVectorSize,
+			)
+			expect(QdrantClient).toHaveBeenLastCalledWith({
+				host: "localhost",
+				https: false,
+				port: 6333,
+				prefix: "/some/path",
+				apiKey: undefined,
+				headers: {
+					"User-Agent": "Roo-Code",
+				},
+			})
+			expect((vectorStoreWithPrefix as any).qdrantUrl).toBe("http://localhost:6333/some/path")
+		})
+
+		it("should not pass prefix if the URL pathname is root ('/')", () => {
+			const vectorStoreWithoutPrefix = new QdrantVectorStore(
+				mockWorkspacePath,
+				"http://localhost:6333/",
+				mockVectorSize,
+			)
+			expect(QdrantClient).toHaveBeenLastCalledWith({
+				host: "localhost",
+				https: false,
+				port: 6333,
+				prefix: undefined,
+				apiKey: undefined,
+				headers: {
+					"User-Agent": "Roo-Code",
+				},
+			})
+			expect((vectorStoreWithoutPrefix as any).qdrantUrl).toBe("http://localhost:6333/")
+		})
+
+		it("should handle HTTPS URL with path as prefix", () => {
+			const vectorStoreWithHttpsPrefix = new QdrantVectorStore(
+				mockWorkspacePath,
+				"https://qdrant.ashbyfam.com/api",
+				mockVectorSize,
+			)
+			expect(QdrantClient).toHaveBeenLastCalledWith({
+				host: "qdrant.ashbyfam.com",
+				https: true,
+				port: 443,
+				prefix: "/api",
+				apiKey: undefined,
+				headers: {
+					"User-Agent": "Roo-Code",
+				},
+			})
+			expect((vectorStoreWithHttpsPrefix as any).qdrantUrl).toBe("https://qdrant.ashbyfam.com/api")
 		})
 	})
 

--- a/src/services/code-index/vector-store/qdrant-client.ts
+++ b/src/services/code-index/vector-store/qdrant-client.ts
@@ -57,6 +57,7 @@ export class QdrantVectorStore implements IVectorStore {
 				host: urlObj.hostname,
 				https: useHttps,
 				port: port,
+				prefix: urlObj.pathname === "/" ? undefined : urlObj.pathname,
 				apiKey,
 				headers: {
 					"User-Agent": "Roo-Code",
@@ -64,6 +65,7 @@ export class QdrantVectorStore implements IVectorStore {
 			})
 		} catch (urlError) {
 			// If URL parsing fails, fall back to URL-based config
+			// Note: This fallback won't correctly handle prefixes, but it's a last resort for malformed URLs.
 			this.client = new QdrantClient({
 				url: parsedUrl,
 				apiKey,

--- a/src/services/code-index/vector-store/qdrant-client.ts
+++ b/src/services/code-index/vector-store/qdrant-client.ts
@@ -57,7 +57,7 @@ export class QdrantVectorStore implements IVectorStore {
 				host: urlObj.hostname,
 				https: useHttps,
 				port: port,
-				prefix: urlObj.pathname === "/" ? undefined : urlObj.pathname,
+				prefix: urlObj.pathname === "/" ? undefined : urlObj.pathname.replace(/\/$/, ""),
 				apiKey,
 				headers: {
 					"User-Agent": "Roo-Code",

--- a/src/services/code-index/vector-store/qdrant-client.ts
+++ b/src/services/code-index/vector-store/qdrant-client.ts
@@ -57,7 +57,7 @@ export class QdrantVectorStore implements IVectorStore {
 				host: urlObj.hostname,
 				https: useHttps,
 				port: port,
-				prefix: urlObj.pathname === "/" ? undefined : urlObj.pathname.replace(/\/$/, ""),
+				prefix: urlObj.pathname === "/" ? undefined : urlObj.pathname.replace(/\/+$/, ""),
 				apiKey,
 				headers: {
 					"User-Agent": "Roo-Code",


### PR DESCRIPTION
### Related GitHub Issue

Closes: #5032

Potentially (along with #4992) Resolves: #4092

### Description

This PR fixes a bug in the `QdrantVectorStore` constructor where the `QdrantClient` was not correctly configured to handle URLs with path prefixes. Previously, the `prefix` parameter was not being extracted from the URL's pathname, leading to connection issues for certain Qdrant deployments.

The fix involves:
- Modifying the `QdrantClient` instantiation in `src/services/code-index/vector-store/qdrant-client.ts` to extract the `pathname` from the parsed URL and pass it as the `prefix` option to the `QdrantClient` constructor, but only if the pathname is not the root (`/`).

### Test Procedure

**Manual Verification (Realistic Scenarios):**
I have tested with the following type of URLs:
* `https://example.com/qdrant`
* `https://example.com`
* `https://example.com:6333`
* `http://example.com`
* `http://example.com:6333`

**Unit Tests (Mocked Environment):**
New unit test cases have been added to `src/services/code-index/vector-store/__tests__/qdrant-client.spec.ts` under a new "URL Prefix Handling" describe block. These tests verify:
- That the `prefix` is correctly passed to `QdrantClient` when the URL has a non-root pathname (e.g., `http://localhost:6333/some/path`).
- That the `prefix` is `undefined` when the URL has a root pathname (e.g., `http://localhost:6333/`).
- That HTTPS URLs with paths also correctly set the prefix.

To run the unit tests:
1. Navigate to the `src/` directory: `cd src/`
2. Execute the test command: `npm test`
All unit tests, including the newly added ones, should pass.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

N/A (Backend logic change)

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

None.

### Get in Touch

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes URL prefix handling in `QdrantVectorStore` by correctly setting `prefix` in `QdrantClient` initialization.
> 
>   - **Behavior**:
>     - Fixes URL prefix handling in `QdrantVectorStore` constructor in `qdrant-client.ts` by extracting `pathname` from URL and passing it as `prefix` to `QdrantClient` if not root.
>   - **Tests**:
>     - Adds tests in `qdrant-client.spec.ts` to verify `prefix` is set correctly for non-root path URLs and is `undefined` for root path URLs.
>     - Tests HTTPS URLs with paths to ensure correct prefix setting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 9b09f08d95fec4e5b1a7ec1551b3391fe6d57b34. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->