### PR TITLE
Skip e2e test that often prompts you

### DIFF
--- a/apps/vscode-e2e/src/suite/tools/use-mcp-tool.test.ts
+++ b/apps/vscode-e2e/src/suite/tools/use-mcp-tool.test.ts
@@ -767,7 +767,7 @@ suite("Roo Code use_mcp_tool Tool", function () {
 		}
 	})
 
-	test("Should validate MCP request message format and complete successfully", async function () {
+	test.skip("Should validate MCP request message format and complete successfully", async function () {
 		const api = globalThis.api
 		const messages: ClineMessage[] = []
 		let _taskCompleted = false


### PR DESCRIPTION
### Description

I'm seeing this locally, which I think is causing the CI failures:
<img width="376" alt="Screenshot 2025-06-23 at 7 59 47 AM" src="https://github.com/user-attachments/assets/5872ed60-3019-4143-8e89-187648126b14" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Skip test in `use-mcp-tool.test.ts` that causes CI failures due to frequent prompts.
> 
>   - **Tests**:
>     - Skips the test `"Should validate MCP request message format and complete successfully"` in `use-mcp-tool.test.ts` due to frequent prompts causing CI failures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 15cca80c166423cdbe4667fdcd5009cacd51463f. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->