### PR TITLE
Fix TemperatureControl test flake

### DIFF
--- a/webview-ui/src/components/settings/__tests__/TemperatureControl.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/TemperatureControl.spec.tsx
@@ -1,6 +1,6 @@
 // npx vitest src/components/settings/__tests__/TemperatureControl.spec.tsx
 
-import { render, screen, fireEvent } from "@testing-library/react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 
 import { TemperatureControl } from "../TemperatureControl"
 
@@ -64,16 +64,18 @@ describe("TemperatureControl", () => {
 		// Uncheck - should clear temperature.
 		fireEvent.click(checkbox)
 
-		// Waiting for debounce.
-		await new Promise((x) => setTimeout(x, 100))
-		expect(onChange).toHaveBeenCalledWith(null)
+		// Wait for debounced onChange call.
+		await waitFor(() => {
+			expect(onChange).toHaveBeenCalledWith(null)
+		})
 
 		// Check - should restore previous temperature.
 		fireEvent.click(checkbox)
 
-		// Waiting for debounce.
-		await new Promise((x) => setTimeout(x, 100))
-		expect(onChange).toHaveBeenCalledWith(0.7)
+		// Wait for debounced onChange call.
+		await waitFor(() => {
+			expect(onChange).toHaveBeenCalledWith(0.7)
+		})
 	})
 
 	it("syncs checkbox state when value prop changes", () => {


### PR DESCRIPTION
Flake example: https://github.com/RooCodeInc/Roo-Code/actions/runs/15827839172/job/44612609101?pr=5044

From Roo Code:

Fixed the flaky TemperatureControl test that was failing on win32 CI by replacing hardcoded `setTimeout` delays with [`waitFor`](webview-ui/src/components/settings/__tests__/TemperatureControl.spec.tsx:3) from `@testing-library/react`.

**Problem**: The test was using a fixed 100ms timeout to wait for the debounced onChange callback, but the component uses [`useDebounce`](webview-ui/src/components/settings/TemperatureControl.tsx:19) with only a 50ms delay. On slower CI environments like win32, this timing mismatch caused intermittent failures.

**Solution**: Replaced the hardcoded delays with `waitFor` utility that polls until the expected condition is met, making the test timing-independent and more reliable across different environments.

**Changes**:
- Added [`waitFor`](webview-ui/src/components/settings/__tests__/TemperatureControl.spec.tsx:3) import
- Replaced both `setTimeout` calls with [`waitFor`](webview-ui/src/components/settings/__tests__/TemperatureControl.spec.tsx:71) blocks that wait for the specific expectations

The test now passes consistently and all 457 tests in the webview test suite continue to pass.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaced `setTimeout` with `waitFor` in `TemperatureControl.spec.tsx` to fix flaky test on win32 CI.
> 
>   - **Test Reliability**:
>     - Replaced `setTimeout` with `waitFor` in `TemperatureControl.spec.tsx` to fix flaky test on win32 CI.
>     - Ensures `onChange` callback is called correctly by waiting for debounced changes.
>   - **Imports**:
>     - Added `waitFor` import from `@testing-library/react` in `TemperatureControl.spec.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 28d9cdb761ba18421ad60d83fba0b935594aece2. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->