### PR TITLE
Fix MCP test independence

### DIFF
--- a/apps/vscode-e2e/src/suite/tools/use-mcp-tool.test.ts
+++ b/apps/vscode-e2e/src/suite/tools/use-mcp-tool.test.ts
@@ -353,7 +353,40 @@ suite("Roo Code use_mcp_tool Tool", function () {
 			}
 		}
 		api.on("taskCompleted", taskCompletedHandler)
+		await sleep(2000) // Wait for Roo Code to fully initialize
 
+		// Trigger MCP server detection by opening and modifying the file
+		console.log("Triggering MCP server detection by modifying the config file...")
+		try {
+			const mcpConfigUri = vscode.Uri.file(testFiles.mcpConfig)
+			const document = await vscode.workspace.openTextDocument(mcpConfigUri)
+			const editor = await vscode.window.showTextDocument(document)
+
+			// Make a small modification to trigger the save event, without this Roo Code won't load the MCP server
+			const edit = new vscode.WorkspaceEdit()
+			const currentContent = document.getText()
+			const modifiedContent = currentContent.replace(
+				'"alwaysAllow": []',
+				'"alwaysAllow": ["read_file", "read_multiple_files", "write_file", "edit_file", "create_directory", "list_directory", "directory_tree", "move_file", "search_files", "get_file_info", "list_allowed_directories"]',
+			)
+
+			const fullRange = new vscode.Range(document.positionAt(0), document.positionAt(document.getText().length))
+
+			edit.replace(mcpConfigUri, fullRange, modifiedContent)
+			await vscode.workspace.applyEdit(edit)
+
+			// Save the document to trigger MCP server detection
+			await editor.document.save()
+
+			// Close the editor
+			await vscode.commands.executeCommand("workbench.action.closeActiveEditor")
+
+			console.log("MCP config file modified and saved successfully")
+		} catch (error) {
+			console.error("Failed to modify/save MCP config file:", error)
+		}
+
+		await sleep(5000) // Wait for MCP servers to initialize
 		let taskId: string
 		try {
 			// Start task requesting to use MCP filesystem write_file tool
@@ -481,7 +514,40 @@ suite("Roo Code use_mcp_tool Tool", function () {
 			}
 		}
 		api.on("taskCompleted", taskCompletedHandler)
+		await sleep(2000) // Wait for Roo Code to fully initialize
 
+		// Trigger MCP server detection by opening and modifying the file
+		console.log("Triggering MCP server detection by modifying the config file...")
+		try {
+			const mcpConfigUri = vscode.Uri.file(testFiles.mcpConfig)
+			const document = await vscode.workspace.openTextDocument(mcpConfigUri)
+			const editor = await vscode.window.showTextDocument(document)
+
+			// Make a small modification to trigger the save event, without this Roo Code won't load the MCP server
+			const edit = new vscode.WorkspaceEdit()
+			const currentContent = document.getText()
+			const modifiedContent = currentContent.replace(
+				'"alwaysAllow": []',
+				'"alwaysAllow": ["read_file", "read_multiple_files", "write_file", "edit_file", "create_directory", "list_directory", "directory_tree", "move_file", "search_files", "get_file_info", "list_allowed_directories"]',
+			)
+
+			const fullRange = new vscode.Range(document.positionAt(0), document.positionAt(document.getText().length))
+
+			edit.replace(mcpConfigUri, fullRange, modifiedContent)
+			await vscode.workspace.applyEdit(edit)
+
+			// Save the document to trigger MCP server detection
+			await editor.document.save()
+
+			// Close the editor
+			await vscode.commands.executeCommand("workbench.action.closeActiveEditor")
+
+			console.log("MCP config file modified and saved successfully")
+		} catch (error) {
+			console.error("Failed to modify/save MCP config file:", error)
+		}
+
+		await sleep(5000) // Wait for MCP servers to initialize
 		let taskId: string
 		try {
 			// Start task requesting MCP filesystem list_directory tool
@@ -620,7 +686,40 @@ suite("Roo Code use_mcp_tool Tool", function () {
 			}
 		}
 		api.on("taskCompleted", taskCompletedHandler)
+		await sleep(2000) // Wait for Roo Code to fully initialize
 
+		// Trigger MCP server detection by opening and modifying the file
+		console.log("Triggering MCP server detection by modifying the config file...")
+		try {
+			const mcpConfigUri = vscode.Uri.file(testFiles.mcpConfig)
+			const document = await vscode.workspace.openTextDocument(mcpConfigUri)
+			const editor = await vscode.window.showTextDocument(document)
+
+			// Make a small modification to trigger the save event, without this Roo Code won't load the MCP server
+			const edit = new vscode.WorkspaceEdit()
+			const currentContent = document.getText()
+			const modifiedContent = currentContent.replace(
+				'"alwaysAllow": []',
+				'"alwaysAllow": ["read_file", "read_multiple_files", "write_file", "edit_file", "create_directory", "list_directory", "directory_tree", "move_file", "search_files", "get_file_info", "list_allowed_directories"]',
+			)
+
+			const fullRange = new vscode.Range(document.positionAt(0), document.positionAt(document.getText().length))
+
+			edit.replace(mcpConfigUri, fullRange, modifiedContent)
+			await vscode.workspace.applyEdit(edit)
+
+			// Save the document to trigger MCP server detection
+			await editor.document.save()
+
+			// Close the editor
+			await vscode.commands.executeCommand("workbench.action.closeActiveEditor")
+
+			console.log("MCP config file modified and saved successfully")
+		} catch (error) {
+			console.error("Failed to modify/save MCP config file:", error)
+		}
+
+		await sleep(5000) // Wait for MCP servers to initialize
 		let taskId: string
 		try {
 			// Start task requesting MCP filesystem directory_tree tool
@@ -841,7 +940,40 @@ suite("Roo Code use_mcp_tool Tool", function () {
 			}
 		}
 		api.on("taskCompleted", taskCompletedHandler)
+		await sleep(2000) // Wait for Roo Code to fully initialize
 
+		// Trigger MCP server detection by opening and modifying the file
+		console.log("Triggering MCP server detection by modifying the config file...")
+		try {
+			const mcpConfigUri = vscode.Uri.file(testFiles.mcpConfig)
+			const document = await vscode.workspace.openTextDocument(mcpConfigUri)
+			const editor = await vscode.window.showTextDocument(document)
+
+			// Make a small modification to trigger the save event, without this Roo Code won't load the MCP server
+			const edit = new vscode.WorkspaceEdit()
+			const currentContent = document.getText()
+			const modifiedContent = currentContent.replace(
+				'"alwaysAllow": []',
+				'"alwaysAllow": ["read_file", "read_multiple_files", "write_file", "edit_file", "create_directory", "list_directory", "directory_tree", "move_file", "search_files", "get_file_info", "list_allowed_directories"]',
+			)
+
+			const fullRange = new vscode.Range(document.positionAt(0), document.positionAt(document.getText().length))
+
+			edit.replace(mcpConfigUri, fullRange, modifiedContent)
+			await vscode.workspace.applyEdit(edit)
+
+			// Save the document to trigger MCP server detection
+			await editor.document.save()
+
+			// Close the editor
+			await vscode.commands.executeCommand("workbench.action.closeActiveEditor")
+
+			console.log("MCP config file modified and saved successfully")
+		} catch (error) {
+			console.error("Failed to modify/save MCP config file:", error)
+		}
+
+		await sleep(5000) // Wait for MCP servers to initialize
 		let taskId: string
 		try {
 			// Start task requesting MCP filesystem get_file_info tool
@@ -857,7 +989,7 @@ suite("Roo Code use_mcp_tool Tool", function () {
 			})
 
 			// Wait for attempt_completion to be called (indicating task finished)
-			await waitFor(() => attemptCompletionCalled, { timeout: 45_000 })
+			await waitFor(() => attemptCompletionCalled, { timeout: 50_000 })
 
 			// Verify the MCP tool was requested with valid format
 			assert.ok(mcpToolRequested, "The use_mcp_tool should have been requested")

--- a/apps/vscode-e2e/src/suite/tools/use-mcp-tool.test.ts
+++ b/apps/vscode-e2e/src/suite/tools/use-mcp-tool.test.ts
@@ -26,11 +26,16 @@ suite("Roo Code use_mcp_tool Tool", function () {
 		// Create test files in VSCode workspace directory
 		const workspaceDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || tempDir
 
+		// Resolve the real path to avoid symlink issues on macOS
+		const realWorkspaceDir = await fs.realpath(workspaceDir)
+		console.log("Original workspace dir:", workspaceDir)
+		console.log("Real workspace dir:", realWorkspaceDir)
+
 		// Create test files for MCP filesystem operations
 		testFiles = {
-			simple: path.join(workspaceDir, `mcp-test-${Date.now()}.txt`),
-			testData: path.join(workspaceDir, `mcp-data-${Date.now()}.json`),
-			mcpConfig: path.join(workspaceDir, ".roo", "mcp.json"),
+			simple: path.join(realWorkspaceDir, `mcp-test-${Date.now()}.txt`),
+			testData: path.join(realWorkspaceDir, `mcp-data-${Date.now()}.json`),
+			mcpConfig: path.join(realWorkspaceDir, ".roo", "mcp.json"),
 		}
 
 		// Create initial test files
@@ -38,21 +43,21 @@ suite("Roo Code use_mcp_tool Tool", function () {
 		await fs.writeFile(testFiles.testData, JSON.stringify({ test: "data", value: 42 }, null, 2))
 
 		// Create .roo directory and MCP configuration file
-		const rooDir = path.join(workspaceDir, ".roo")
+		const rooDir = path.join(realWorkspaceDir, ".roo")
 		await fs.mkdir(rooDir, { recursive: true })
 
 		const mcpConfig = {
 			mcpServers: {
 				filesystem: {
 					command: "npx",
-					args: ["-y", "@modelcontextprotocol/server-filesystem", workspaceDir],
+					args: ["-y", "@modelcontextprotocol/server-filesystem", realWorkspaceDir],
 					alwaysAllow: [],
 				},
 			},
 		}
 		await fs.writeFile(testFiles.mcpConfig, JSON.stringify(mcpConfig, null, 2))
 
-		console.log("MCP test files created in:", workspaceDir)
+		console.log("MCP test files created in:", realWorkspaceDir)
 		console.log("Test files:", testFiles)
 	})
 
@@ -76,7 +81,8 @@ suite("Roo Code use_mcp_tool Tool", function () {
 
 		// Clean up .roo directory
 		const workspaceDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || tempDir
-		const rooDir = path.join(workspaceDir, ".roo")
+		const realWorkspaceDir = await fs.realpath(workspaceDir)
+		const rooDir = path.join(realWorkspaceDir, ".roo")
 		try {
 			await fs.rm(rooDir, { recursive: true, force: true })
 		} catch {
@@ -353,7 +359,6 @@ suite("Roo Code use_mcp_tool Tool", function () {
 			}
 		}
 		api.on("taskCompleted", taskCompletedHandler)
-		await sleep(2000) // Wait for Roo Code to fully initialize
 
 		// Trigger MCP server detection by opening and modifying the file
 		console.log("Triggering MCP server detection by modifying the config file...")
@@ -386,7 +391,9 @@ suite("Roo Code use_mcp_tool Tool", function () {
 			console.error("Failed to modify/save MCP config file:", error)
 		}
 
-		await sleep(5000) // Wait for MCP servers to initialize
+		// Give MCP servers a moment to be ready (they should already be initialized)
+		await sleep(1000)
+
 		let taskId: string
 		try {
 			// Start task requesting to use MCP filesystem write_file tool
@@ -514,7 +521,6 @@ suite("Roo Code use_mcp_tool Tool", function () {
 			}
 		}
 		api.on("taskCompleted", taskCompletedHandler)
-		await sleep(2000) // Wait for Roo Code to fully initialize
 
 		// Trigger MCP server detection by opening and modifying the file
 		console.log("Triggering MCP server detection by modifying the config file...")
@@ -547,7 +553,9 @@ suite("Roo Code use_mcp_tool Tool", function () {
 			console.error("Failed to modify/save MCP config file:", error)
 		}
 
-		await sleep(5000) // Wait for MCP servers to initialize
+		// Give MCP servers a moment to be ready (they should already be initialized)
+		await sleep(1000)
+
 		let taskId: string
 		try {
 			// Start task requesting MCP filesystem list_directory tool
@@ -686,7 +694,6 @@ suite("Roo Code use_mcp_tool Tool", function () {
 			}
 		}
 		api.on("taskCompleted", taskCompletedHandler)
-		await sleep(2000) // Wait for Roo Code to fully initialize
 
 		// Trigger MCP server detection by opening and modifying the file
 		console.log("Triggering MCP server detection by modifying the config file...")
@@ -719,7 +726,9 @@ suite("Roo Code use_mcp_tool Tool", function () {
 			console.error("Failed to modify/save MCP config file:", error)
 		}
 
-		await sleep(5000) // Wait for MCP servers to initialize
+		// Give MCP servers a moment to be ready (they should already be initialized)
+		await sleep(1000)
+
 		let taskId: string
 		try {
 			// Start task requesting MCP filesystem directory_tree tool
@@ -940,7 +949,8 @@ suite("Roo Code use_mcp_tool Tool", function () {
 			}
 		}
 		api.on("taskCompleted", taskCompletedHandler)
-		await sleep(2000) // Wait for Roo Code to fully initialize
+
+		// Wait for MCP servers to be initialized instead of using sleep
 
 		// Trigger MCP server detection by opening and modifying the file
 		console.log("Triggering MCP server detection by modifying the config file...")
@@ -973,7 +983,9 @@ suite("Roo Code use_mcp_tool Tool", function () {
 			console.error("Failed to modify/save MCP config file:", error)
 		}
 
-		await sleep(5000) // Wait for MCP servers to initialize
+		// Give MCP servers a moment to be ready (they should already be initialized)
+		await sleep(1000)
+
 		let taskId: string
 		try {
 			// Start task requesting MCP filesystem get_file_info tool

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -21,6 +21,7 @@ export interface RooCodeAPIEvents {
 	taskCompleted: [taskId: string, tokenUsage: TokenUsage, toolUsage: ToolUsage, isSubtask: IsSubtask]
 	taskTokenUsageUpdated: [taskId: string, tokenUsage: TokenUsage]
 	taskToolFailed: [taskId: string, toolName: ToolName, error: string]
+	mcpServersInitialized: []
 }
 
 export interface RooCodeAPI extends EventEmitter<RooCodeAPIEvents> {

--- a/packages/types/src/ipc.ts
+++ b/packages/types/src/ipc.ts
@@ -29,6 +29,7 @@ export enum RooCodeEventName {
 	TaskCompleted = "taskCompleted",
 	TaskTokenUsageUpdated = "taskTokenUsageUpdated",
 	TaskToolFailed = "taskToolFailed",
+	McpServersInitialized = "mcpServersInitialized",
 	EvalPass = "evalPass",
 	EvalFail = "evalFail",
 }
@@ -52,6 +53,7 @@ export const rooCodeEventsSchema = z.object({
 	[RooCodeEventName.TaskCompleted]: z.tuple([z.string(), tokenUsageSchema, toolUsageSchema, isSubtaskSchema]),
 	[RooCodeEventName.TaskTokenUsageUpdated]: z.tuple([z.string(), tokenUsageSchema]),
 	[RooCodeEventName.TaskToolFailed]: z.tuple([z.string(), toolNamesSchema, z.string()]),
+	[RooCodeEventName.McpServersInitialized]: z.tuple([]),
 })
 
 export type RooCodeEvents = z.infer<typeof rooCodeEventsSchema>
@@ -163,6 +165,11 @@ export const taskEventSchema = z.discriminatedUnion("eventName", [
 	z.object({
 		eventName: z.literal(RooCodeEventName.TaskToolFailed),
 		payload: rooCodeEventsSchema.shape[RooCodeEventName.TaskToolFailed],
+		taskId: z.number().optional(),
+	}),
+	z.object({
+		eventName: z.literal(RooCodeEventName.McpServersInitialized),
+		payload: rooCodeEventsSchema.shape[RooCodeEventName.McpServersInitialized],
 		taskId: z.number().optional(),
 	}),
 	z.object({

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -76,6 +76,7 @@ import { ProfileValidator } from "../../shared/ProfileValidator"
 
 export type ClineProviderEvents = {
 	clineCreated: [cline: Task]
+	mcpServersInitialized: []
 }
 
 class OrganizationAllowListViolationError extends Error {

--- a/src/extension/api.ts
+++ b/src/extension/api.ts
@@ -248,6 +248,11 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 
 			this.emit(RooCodeEventName.TaskCreated, cline.taskId)
 		})
+
+		// Listen for MCP servers initialized event
+		provider.on("mcpServersInitialized", () => {
+			this.emit(RooCodeEventName.McpServersInitialized)
+		})
 	}
 
 	// Logging

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -995,6 +995,11 @@ export class McpHub {
 		await this.notifyWebviewOfServerChanges()
 		if (manageConnectingState) {
 			this.isConnecting = false
+			// Emit MCP servers initialized event
+			const provider = this.providerRef.deref()
+			if (provider) {
+				provider.emit("mcpServersInitialized")
+			}
 		}
 	}
 


### PR DESCRIPTION
Ensures each MCP test sets up its own configuration independently by adding alwaysAllow permissions setup to all tests. This prevents test failures when tests run in different orders.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Ensures MCP test independence by setting up individual configurations and introduces `mcpServersInitialized` event for server initialization handling.
> 
>   - **Behavior**:
>     - Ensures each MCP test in `use-mcp-tool.test.ts` sets up its own configuration independently by modifying the `mcpConfig` to include `alwaysAllow` permissions.
>     - Adds logic to modify and save the MCP config file to trigger server detection in `use-mcp-tool.test.ts`.
>     - Introduces a 1-second delay after modifying the config to allow server initialization.
>   - **Events**:
>     - Adds `mcpServersInitialized` event to `RooCodeAPIEvents` in `api.ts` and `ipc.ts`.
>     - Emits `mcpServersInitialized` in `McpHub` after server connections are updated.
>   - **Misc**:
>     - Extends `ClineProviderEvents` in `ClineProvider.ts` to include `mcpServersInitialized`.
>     - Updates `API` in `api.ts` to listen for `mcpServersInitialized` and emit it.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e52478fac304561f55f10881f48245eb41cfaa09. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->