### PR TITLE
fix: resolve Claude Code provider JSON parsing and reasoning block display

### DIFF
--- a/src/api/providers/__tests__/claude-code.spec.ts
+++ b/src/api/providers/__tests__/claude-code.spec.ts
@@ -85,14 +85,12 @@ describe("ClaudeCodeHandler", () => {
 		}
 
 		// Emit the thinking response and wait for processing
-		setTimeout(() => {
+		setImmediate(() => {
 			mockProcess.stdout.emit("data", JSON.stringify(thinkingResponse) + "\n")
-		}, 10)
-
-		// Emit process close after data
-		setTimeout(() => {
-			mockProcess.emit("close", 0)
-		}, 50)
+			setImmediate(() => {
+				mockProcess.emit("close", 0)
+			})
+		})
 
 		// Get the result
 		const result = await streamGenerator.next()
@@ -141,14 +139,12 @@ describe("ClaudeCodeHandler", () => {
 		}
 
 		// Emit the mixed response and wait for processing
-		setTimeout(() => {
+		setImmediate(() => {
 			mockProcess.stdout.emit("data", JSON.stringify(mixedResponse) + "\n")
-		}, 10)
-
-		// Emit process close after data
-		setTimeout(() => {
-			mockProcess.emit("close", 0)
-		}, 50)
+			setImmediate(() => {
+				mockProcess.emit("close", 0)
+			})
+		})
 
 		// Get the first result (thinking)
 		const thinkingResult = await streamGenerator.next()
@@ -200,14 +196,12 @@ describe("ClaudeCodeHandler", () => {
 		}
 
 		// Emit the error response and wait for processing
-		setTimeout(() => {
+		setImmediate(() => {
 			mockProcess.stdout.emit("data", JSON.stringify(errorResponse) + "\n")
-		}, 10)
-
-		// Emit process close after data
-		setTimeout(() => {
-			mockProcess.emit("close", 0)
-		}, 50)
+			setImmediate(() => {
+				mockProcess.emit("close", 0)
+			})
+		})
 
 		// Should throw error with thinking content
 		await expect(streamGenerator.next()).rejects.toThrow("This is an error scenario")

--- a/src/api/providers/__tests__/claude-code.spec.ts
+++ b/src/api/providers/__tests__/claude-code.spec.ts
@@ -1,0 +1,215 @@
+import { describe, test, expect, vi, beforeEach } from "vitest"
+import { ClaudeCodeHandler } from "../claude-code"
+import { ApiHandlerOptions } from "../../../shared/api"
+
+// Mock the runClaudeCode function
+vi.mock("../../../integrations/claude-code/run", () => ({
+	runClaudeCode: vi.fn(),
+}))
+
+const { runClaudeCode } = await import("../../../integrations/claude-code/run")
+const mockRunClaudeCode = vi.mocked(runClaudeCode)
+
+// Mock the EventEmitter for the process
+class MockEventEmitter {
+	private handlers: { [event: string]: ((...args: any[]) => void)[] } = {}
+
+	on(event: string, handler: (...args: any[]) => void) {
+		if (!this.handlers[event]) {
+			this.handlers[event] = []
+		}
+		this.handlers[event].push(handler)
+	}
+
+	emit(event: string, ...args: any[]) {
+		if (this.handlers[event]) {
+			this.handlers[event].forEach((handler) => handler(...args))
+		}
+	}
+}
+
+describe("ClaudeCodeHandler", () => {
+	let handler: ClaudeCodeHandler
+	let mockProcess: any
+
+	beforeEach(() => {
+		const options: ApiHandlerOptions = {
+			claudeCodePath: "claude",
+			apiModelId: "claude-3-5-sonnet-20241022",
+		}
+		handler = new ClaudeCodeHandler(options)
+
+		const mainEmitter = new MockEventEmitter()
+		mockProcess = {
+			stdout: new MockEventEmitter(),
+			stderr: new MockEventEmitter(),
+			on: mainEmitter.on.bind(mainEmitter),
+			emit: mainEmitter.emit.bind(mainEmitter),
+		}
+
+		mockRunClaudeCode.mockReturnValue(mockProcess)
+	})
+
+	test("should handle thinking content properly", async () => {
+		const systemPrompt = "You are a helpful assistant"
+		const messages = [{ role: "user" as const, content: "Hello" }]
+
+		// Start the stream
+		const stream = handler.createMessage(systemPrompt, messages)
+		const streamGenerator = stream[Symbol.asyncIterator]()
+
+		// Simulate thinking content response
+		const thinkingResponse = {
+			type: "assistant",
+			message: {
+				id: "msg_123",
+				type: "message",
+				role: "assistant",
+				model: "claude-3-5-sonnet-20241022",
+				content: [
+					{
+						type: "thinking",
+						thinking: "I need to think about this carefully...",
+						signature: "abc123",
+					},
+				],
+				stop_reason: null,
+				stop_sequence: null,
+				usage: {
+					input_tokens: 10,
+					output_tokens: 20,
+					service_tier: "standard" as const,
+				},
+			},
+			session_id: "session_123",
+		}
+
+		// Emit the thinking response and wait for processing
+		setTimeout(() => {
+			mockProcess.stdout.emit("data", JSON.stringify(thinkingResponse) + "\n")
+		}, 10)
+
+		// Emit process close after data
+		setTimeout(() => {
+			mockProcess.emit("close", 0)
+		}, 50)
+
+		// Get the result
+		const result = await streamGenerator.next()
+
+		expect(result.done).toBe(false)
+		expect(result.value).toEqual({
+			type: "reasoning",
+			text: "I need to think about this carefully...",
+		})
+	})
+
+	test("should handle mixed content types", async () => {
+		const systemPrompt = "You are a helpful assistant"
+		const messages = [{ role: "user" as const, content: "Hello" }]
+
+		const stream = handler.createMessage(systemPrompt, messages)
+		const streamGenerator = stream[Symbol.asyncIterator]()
+
+		// Simulate mixed content response
+		const mixedResponse = {
+			type: "assistant",
+			message: {
+				id: "msg_123",
+				type: "message",
+				role: "assistant",
+				model: "claude-3-5-sonnet-20241022",
+				content: [
+					{
+						type: "thinking",
+						thinking: "Let me think about this...",
+					},
+					{
+						type: "text",
+						text: "Here's my response!",
+					},
+				],
+				stop_reason: null,
+				stop_sequence: null,
+				usage: {
+					input_tokens: 10,
+					output_tokens: 20,
+					service_tier: "standard" as const,
+				},
+			},
+			session_id: "session_123",
+		}
+
+		// Emit the mixed response and wait for processing
+		setTimeout(() => {
+			mockProcess.stdout.emit("data", JSON.stringify(mixedResponse) + "\n")
+		}, 10)
+
+		// Emit process close after data
+		setTimeout(() => {
+			mockProcess.emit("close", 0)
+		}, 50)
+
+		// Get the first result (thinking)
+		const thinkingResult = await streamGenerator.next()
+		expect(thinkingResult.done).toBe(false)
+		expect(thinkingResult.value).toEqual({
+			type: "reasoning",
+			text: "Let me think about this...",
+		})
+
+		// Get the second result (text)
+		const textResult = await streamGenerator.next()
+		expect(textResult.done).toBe(false)
+		expect(textResult.value).toEqual({
+			type: "text",
+			text: "Here's my response!",
+		})
+	})
+
+	test("should handle stop_reason with thinking content in error messages", async () => {
+		const systemPrompt = "You are a helpful assistant"
+		const messages = [{ role: "user" as const, content: "Hello" }]
+
+		const stream = handler.createMessage(systemPrompt, messages)
+		const streamGenerator = stream[Symbol.asyncIterator]()
+
+		// Simulate error response with thinking content
+		const errorResponse = {
+			type: "assistant",
+			message: {
+				id: "msg_123",
+				type: "message",
+				role: "assistant",
+				model: "claude-3-5-sonnet-20241022",
+				content: [
+					{
+						type: "thinking",
+						thinking: "This is an error scenario",
+					},
+				],
+				stop_reason: "max_tokens",
+				stop_sequence: null,
+				usage: {
+					input_tokens: 10,
+					output_tokens: 20,
+					service_tier: "standard" as const,
+				},
+			},
+			session_id: "session_123",
+		}
+
+		// Emit the error response and wait for processing
+		setTimeout(() => {
+			mockProcess.stdout.emit("data", JSON.stringify(errorResponse) + "\n")
+		}, 10)
+
+		// Emit process close after data
+		setTimeout(() => {
+			mockProcess.emit("close", 0)
+		}, 50)
+
+		// Should throw error with thinking content
+		await expect(streamGenerator.next()).rejects.toThrow("This is an error scenario")
+	})
+})

--- a/src/api/providers/claude-code.ts
+++ b/src/api/providers/claude-code.ts
@@ -55,7 +55,15 @@ export class ClaudeCodeHandler extends BaseProvider implements ApiHandler {
 			// Process any remaining data in buffer
 			const trimmedBuffer = buffer.trim()
 			if (trimmedBuffer) {
-				dataQueue.push(trimmedBuffer)
+				// Validate that the remaining buffer looks like valid JSON before processing
+				if (this.isLikelyValidJSON(trimmedBuffer)) {
+					dataQueue.push(trimmedBuffer)
+				} else {
+					console.warn(
+						"Discarding incomplete JSON data on process close:",
+						trimmedBuffer.substring(0, 100) + (trimmedBuffer.length > 100 ? "..." : ""),
+					)
+				}
 				buffer = ""
 			}
 		})
@@ -189,6 +197,30 @@ export class ClaudeCodeHandler extends BaseProvider implements ApiHandler {
 			default:
 				return undefined
 		}
+	}
+
+	private isLikelyValidJSON(data: string): boolean {
+		// Basic validation to check if the data looks like it could be valid JSON
+		const trimmed = data.trim()
+		if (!trimmed) return false
+
+		// Must start and end with appropriate JSON delimiters
+		const startsCorrectly = trimmed.startsWith("{") || trimmed.startsWith("[")
+		const endsCorrectly = trimmed.endsWith("}") || trimmed.endsWith("]")
+
+		if (!startsCorrectly || !endsCorrectly) return false
+
+		// Check for balanced braces/brackets (simple heuristic)
+		let braceCount = 0
+		let bracketCount = 0
+		for (const char of trimmed) {
+			if (char === "{") braceCount++
+			else if (char === "}") braceCount--
+			else if (char === "[") bracketCount++
+			else if (char === "]") bracketCount--
+		}
+
+		return braceCount === 0 && bracketCount === 0
 	}
 
 	// TODO: Validate instead of parsing

--- a/src/integrations/claude-code/types.ts
+++ b/src/integrations/claude-code/types.ts
@@ -6,10 +6,16 @@ type InitMessage = {
 	mcp_servers: string[]
 }
 
-type ClaudeCodeContent = {
-	type: "text"
-	text: string
-}
+type ClaudeCodeContent =
+	| {
+			type: "text"
+			text: string
+	  }
+	| {
+			type: "thinking"
+			thinking: string
+			signature?: string
+	  }
 
 type AssistantMessage = {
 	type: "assistant"


### PR DESCRIPTION
## Description

Fixes the Claude Code provider showing raw JSON output instead of properly parsed content. This PR addresses two key issues that were causing poor user experience with the Claude Code integration.

## Changes Made

- **JSON Buffering Fix**: Implemented proper line-based buffering in `src/api/providers/claude-code.ts` to handle incomplete data chunks that were causing JSON parsing failures
- **Reasoning Block Display**: Changed thinking content to yield as `"reasoning"` type instead of `"text"` type so it renders as collapsible reasoning blocks in the UI
- **Type System Enhancement**: Extended `ClaudeCodeContent` type in `src/integrations/claude-code/types.ts` to support both text and thinking content
- **Comprehensive Testing**: Added full test suite in `src/api/providers/__tests__/claude-code.spec.ts` covering thinking content, mixed content, and error scenarios

## Testing

- [x] All existing tests pass
- [x] Added comprehensive test coverage for Claude Code provider:
  - [x] Thinking content properly yields as "reasoning" type
  - [x] Mixed content types handled correctly
  - [x] Error scenarios with thinking content
- [x] Manual testing completed:
  - [x] JSON parsing no longer fails on incomplete chunks
  - [x] Thinking content displays as collapsible reasoning blocks
  - [x] No more raw JSON output in chat

## Technical Details

**JSON Buffering Implementation:**
```typescript
// Before: Direct JSON parsing caused failures on incomplete chunks
JSON.parse(data.toString())

// After: Line-based buffering handles incomplete data properly
lines.forEach(line => {
  if (line.trim()) {
    const parsed = JSON.parse(line)
    // Process parsed data...
  }
})
```

**Reasoning Block Fix:**
```typescript
// Before: Thinking content displayed as raw text
if (content.type === "thinking") {
  yield { type: "text", text: content.thinking }
}

// After: Thinking content displays as collapsible reasoning blocks
if (content.type === "thinking") {
  yield { type: "reasoning", text: content.thinking }
}
```

## Verification of Fix

- **UI Integration**: Confirmed `ChatRow.tsx` has proper `case "reasoning":` handling that renders `ReasoningBlock` components
- **Type Safety**: All TypeScript types properly support the new content structure
- **Backward Compatibility**: No breaking changes to existing functionality

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] All tests pass with comprehensive coverage
- [x] No breaking changes
- [x] ESLint warnings resolved
- [x] TypeScript checks pass
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix JSON parsing and reasoning block display in Claude Code provider by implementing line-based buffering and updating content types.
> 
>   - **JSON Parsing**:
>     - Implement line-based buffering in `claude-code.ts` to handle incomplete JSON data.
>     - Add `isLikelyValidJSON()` to validate JSON before processing.
>   - **Reasoning Block Display**:
>     - Change thinking content to yield as `"reasoning"` type in `claude-code.ts`.
>     - Update `ClaudeCodeContent` type in `types.ts` to support `thinking` content.
>   - **Testing**:
>     - Add tests in `claude-code.spec.ts` for thinking content, mixed content, and error scenarios.
>   - **Misc**:
>     - Add `getContentText()` in `claude-code.ts` to extract text from content objects.
>     - Improve error logging in `attemptParseChunk()` in `claude-code.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for dd9e1464b941fd10d411a8bb050754375aa7d861. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->