### PR TITLE
Fetch settings only when ready

### DIFF
--- a/packages/cloud/src/SettingsService.ts
+++ b/packages/cloud/src/SettingsService.ts
@@ -42,10 +42,6 @@ export class SettingsService {
 			this.removeSettings()
 		}
 
-		this.authService.on("attempting-session", () => {
-			this.timer.start()
-		})
-
 		this.authService.on("active-session", () => {
 			this.timer.start()
 		})
@@ -55,7 +51,7 @@ export class SettingsService {
 			this.removeSettings()
 		})
 
-		if (this.authService.hasOrIsAcquiringActiveSession()) {
+		if (this.authService.hasActiveSession()) {
 			this.timer.start()
 		}
 	}

--- a/packages/cloud/src/SettingsService.ts
+++ b/packages/cloud/src/SettingsService.ts
@@ -25,8 +25,7 @@ export class SettingsService {
 
 		this.timer = new RefreshTimer({
 			callback: async () => {
-				await this.fetchSettings(callback)
-				return true
+				return await this.fetchSettings(callback)
 			},
 			successInterval: 30000,
 			initialBackoffMs: 1000,
@@ -56,11 +55,11 @@ export class SettingsService {
 		}
 	}
 
-	private async fetchSettings(callback: () => void): Promise<void> {
+	private async fetchSettings(callback: () => void): Promise<boolean> {
 		const token = this.authService.getSessionToken()
 
 		if (!token) {
-			return
+			return false
 		}
 
 		try {
@@ -72,7 +71,7 @@ export class SettingsService {
 
 			if (!response.ok) {
 				console.error(`Failed to fetch organization settings: ${response.status} ${response.statusText}`)
-				return
+				return false
 			}
 
 			const data = await response.json()
@@ -80,7 +79,7 @@ export class SettingsService {
 
 			if (!result.success) {
 				console.error("Invalid organization settings format:", result.error)
-				return
+				return false
 			}
 
 			const newSettings = result.data
@@ -90,8 +89,11 @@ export class SettingsService {
 				await this.cacheSettings()
 				callback()
 			}
+
+			return true
 		} catch (error) {
 			console.error("Error fetching organization settings:", error)
+			return false
 		}
 	}
 


### PR DESCRIPTION
2 problems working together:
1. Trying to fetch org settings at `attempting-session` instead of `active-session`.
2. Not bubbling up org settings fetch failures properly to `RefreshTimer`, so we wait 30s instead of 1s (with backoff) to fetch after a failure.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes timing and error handling for fetching organization settings in `SettingsService.ts`.
> 
>   - **Behavior**:
>     - Change event listener in `SettingsService` to start `RefreshTimer` on `active-session` instead of `attempting-session`.
>     - Modify `fetchSettings()` to return a boolean indicating success or failure, affecting backoff logic in `RefreshTimer`.
>   - **Error Handling**:
>     - Ensure `fetchSettings()` returns `false` on failure to fetch or parse settings, improving retry logic.
>   - **Misc**:
>     - Remove unused `attempting-session` event listener in `SettingsService`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c7dafc6adf059f3dfca705f8e26594984f134178. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->