### PR TITLE
Revert fix: resolve LM Studio context length detection (#5075)

### DIFF
--- a/src/api/providers/__tests__/lmstudio.spec.ts
+++ b/src/api/providers/__tests__/lmstudio.spec.ts
@@ -58,37 +58,14 @@ vi.mock("openai", () => {
 	}
 })
 
-// Mock LM Studio fetcher
-vi.mock("../fetchers/lmstudio", () => ({
-	getLMStudioModels: vi.fn(),
-}))
-
 import type { Anthropic } from "@anthropic-ai/sdk"
-import type { ModelInfo } from "@roo-code/types"
 
 import { LmStudioHandler } from "../lm-studio"
 import type { ApiHandlerOptions } from "../../../shared/api"
-import { getLMStudioModels } from "../fetchers/lmstudio"
-
-// Get the mocked function
-const mockGetLMStudioModels = vi.mocked(getLMStudioModels)
 
 describe("LmStudioHandler", () => {
 	let handler: LmStudioHandler
 	let mockOptions: ApiHandlerOptions
-
-	const mockModelInfo: ModelInfo = {
-		maxTokens: 8192,
-		contextWindow: 32768,
-		supportsImages: false,
-		supportsComputerUse: false,
-		supportsPromptCache: true,
-		inputPrice: 0,
-		outputPrice: 0,
-		cacheWritesPrice: 0,
-		cacheReadsPrice: 0,
-		description: "Test Model - local-model",
-	}
 
 	beforeEach(() => {
 		mockOptions = {
@@ -98,7 +75,6 @@ describe("LmStudioHandler", () => {
 		}
 		handler = new LmStudioHandler(mockOptions)
 		mockCreate.mockClear()
-		mockGetLMStudioModels.mockClear()
 	})
 
 	describe("constructor", () => {
@@ -180,71 +156,12 @@ describe("LmStudioHandler", () => {
 	})
 
 	describe("getModel", () => {
-		it("should return default model info when no models fetched", () => {
+		it("should return model info", () => {
 			const modelInfo = handler.getModel()
 			expect(modelInfo.id).toBe(mockOptions.lmStudioModelId)
 			expect(modelInfo.info).toBeDefined()
 			expect(modelInfo.info.maxTokens).toBe(-1)
 			expect(modelInfo.info.contextWindow).toBe(128_000)
-		})
-
-		it("should return fetched model info when available", async () => {
-			// Mock the fetched models
-			mockGetLMStudioModels.mockResolvedValueOnce({
-				"local-model": mockModelInfo,
-			})
-
-			await handler.fetchModel()
-			const modelInfo = handler.getModel()
-
-			expect(modelInfo.id).toBe(mockOptions.lmStudioModelId)
-			expect(modelInfo.info).toEqual(mockModelInfo)
-			expect(modelInfo.info.contextWindow).toBe(32768)
-		})
-
-		it("should fallback to default when model not found in fetched models", async () => {
-			// Mock fetched models without our target model
-			mockGetLMStudioModels.mockResolvedValueOnce({
-				"other-model": mockModelInfo,
-			})
-
-			await handler.fetchModel()
-			const modelInfo = handler.getModel()
-
-			expect(modelInfo.id).toBe(mockOptions.lmStudioModelId)
-			expect(modelInfo.info.maxTokens).toBe(-1)
-			expect(modelInfo.info.contextWindow).toBe(128_000)
-		})
-	})
-
-	describe("fetchModel", () => {
-		it("should fetch models successfully", async () => {
-			mockGetLMStudioModels.mockResolvedValueOnce({
-				"local-model": mockModelInfo,
-			})
-
-			const result = await handler.fetchModel()
-
-			expect(mockGetLMStudioModels).toHaveBeenCalledWith(mockOptions.lmStudioBaseUrl)
-			expect(result.id).toBe(mockOptions.lmStudioModelId)
-			expect(result.info).toEqual(mockModelInfo)
-		})
-
-		it("should handle fetch errors gracefully", async () => {
-			const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
-			mockGetLMStudioModels.mockRejectedValueOnce(new Error("Connection failed"))
-
-			const result = await handler.fetchModel()
-
-			expect(consoleSpy).toHaveBeenCalledWith(
-				"Failed to fetch LM Studio models, using defaults:",
-				expect.any(Error),
-			)
-			expect(result.id).toBe(mockOptions.lmStudioModelId)
-			expect(result.info.maxTokens).toBe(-1)
-			expect(result.info.contextWindow).toBe(128_000)
-
-			consoleSpy.mockRestore()
 		})
 	})
 })

--- a/src/api/providers/lm-studio.ts
+++ b/src/api/providers/lm-studio.ts
@@ -13,12 +13,10 @@ import { ApiStream } from "../transform/stream"
 
 import { BaseProvider } from "./base-provider"
 import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
-import { getLMStudioModels } from "./fetchers/lmstudio"
 
 export class LmStudioHandler extends BaseProvider implements SingleCompletionHandler {
 	protected options: ApiHandlerOptions
 	private client: OpenAI
-	private models: Record<string, ModelInfo> = {}
 
 	constructor(options: ApiHandlerOptions) {
 		super()
@@ -132,25 +130,10 @@ export class LmStudioHandler extends BaseProvider implements SingleCompletionHan
 		}
 	}
 
-	public async fetchModel() {
-		try {
-			this.models = await getLMStudioModels(this.options.lmStudioBaseUrl)
-		} catch (error) {
-			console.warn("Failed to fetch LM Studio models, using defaults:", error)
-			this.models = {}
-		}
-		return this.getModel()
-	}
-
 	override getModel(): { id: string; info: ModelInfo } {
-		const id = this.options.lmStudioModelId || ""
-
-		// Try to get the actual model info from fetched models
-		const info = this.models[id] || openAiModelInfoSaneDefaults
-
 		return {
-			id,
-			info,
+			id: this.options.lmStudioModelId || "",
+			info: openAiModelInfoSaneDefaults,
 		}
 	}
 


### PR DESCRIPTION
This reverts commit ac85aa681642a95c0dba03077f8f0fa63031c87e from PR #5076.

## Changes Reverted

- Removed `fetchModel()` method from `LmStudioHandler`
- Removed `models` property and dynamic model fetching functionality
- Reverted `getModel()` method to return static defaults
- Removed tests for `fetchModel()` functionality
- Removed import of `getLMStudioModels`

## Files Changed

- `src/api/providers/lm-studio.ts` - Reverted to original implementation
- `src/api/providers/__tests__/lmstudio.spec.ts` - Removed new tests and mocks

## Testing

- ✅ All existing tests pass (8 tests passed)
- ✅ Type checking passes
- ✅ Linting passes

This revert restores the LM Studio handler to its previous stable state.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts dynamic model fetching in `LmStudioHandler`, restoring static defaults and removing related tests.
> 
>   - **Behavior**:
>     - Reverts `LmStudioHandler` to use static model defaults in `getModel()`.
>     - Removes `fetchModel()` method and dynamic model fetching.
>     - Deletes tests related to `fetchModel()` in `lmstudio.spec.ts`.
>   - **Files**:
>     - `lm-studio.ts`: Removes `fetchModel()` and related imports.
>     - `lmstudio.spec.ts`: Removes tests and mocks for `fetchModel()`.
>   - **Testing**:
>     - All existing tests pass.
>     - Type checking and linting pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d965a24350eace9c46baa5d67e0a3a6044994c71. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->