### PR TITLE
feat: register importSettings as VSCode command

### DIFF
--- a/packages/types/src/vscode.ts
+++ b/packages/types/src/vscode.ts
@@ -48,6 +48,7 @@ export const commandIds = [
 	"newTask",
 
 	"setCustomStoragePath",
+	"importSettings",
 
 	"focusInput",
 	"acceptInput",

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -13,7 +13,7 @@ import { focusPanel } from "../utils/focusPanel"
 import { registerHumanRelayCallback, unregisterHumanRelayCallback, handleHumanRelayResponse } from "./humanRelay"
 import { handleNewTask } from "./handleTask"
 import { CodeIndexManager } from "../services/code-index/manager"
-import { importSettings } from "../core/config/importExport"
+import { importSettingsWithFeedback } from "../core/config/importExport"
 import { t } from "../i18n"
 
 /**
@@ -179,19 +179,15 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 			return
 		}
 
-		const result = await importSettings({
-			providerSettingsManager: visibleProvider.providerSettingsManager,
-			contextProxy: visibleProvider.contextProxy,
-			customModesManager: visibleProvider.customModesManager,
-		}, filePath)
-
-		if (result.success) {
-			visibleProvider.settingsImportedAt = Date.now()
-			await visibleProvider.postStateToWebview()
-			await vscode.window.showInformationMessage(t("common:info.settings_imported"))
-		} else if (result.error) {
-			await vscode.window.showErrorMessage(t("common:errors.settings_import_failed", { error: result.error }))
-		}
+		await importSettingsWithFeedback(
+			{
+				providerSettingsManager: visibleProvider.providerSettingsManager,
+				contextProxy: visibleProvider.contextProxy,
+				customModesManager: visibleProvider.customModesManager,
+				provider: visibleProvider,
+			},
+			filePath,
+		)
 	},
 	focusInput: async () => {
 		try {

--- a/src/core/config/importExport.ts
+++ b/src/core/config/importExport.ts
@@ -23,13 +23,20 @@ type ExportOptions = {
 	contextProxy: ContextProxy
 }
 
-export const importSettings = async ({ providerSettingsManager, contextProxy, customModesManager }: ImportOptions) => {
-	const uris = await vscode.window.showOpenDialog({
-		filters: { JSON: ["json"] },
-		canSelectMany: false,
-	})
+export const importSettings = async ({ providerSettingsManager, contextProxy, customModesManager }: ImportOptions, filePath?: string) => {
+	let fileUri: vscode.Uri | undefined
 
-	if (!uris) {
+	if (filePath) {
+		fileUri = vscode.Uri.file(filePath)
+	} else {
+		const uris = await vscode.window.showOpenDialog({
+			filters: { JSON: ["json"] },
+			canSelectMany: false,
+		})
+		fileUri = uris?.[0]
+	}
+
+	if (!fileUri) {
 		return { success: false }
 	}
 
@@ -41,7 +48,7 @@ export const importSettings = async ({ providerSettingsManager, contextProxy, cu
 	try {
 		const previousProviderProfiles = await providerSettingsManager.export()
 
-		const data = JSON.parse(await fs.readFile(uris[0].fsPath, "utf-8"))
+		const data = JSON.parse(await fs.readFile(fileUri.fsPath, "utf-8"))
 		const { providerProfiles: newProviderProfiles, globalSettings = {} } = schema.parse(data)
 
 		const providerProfiles = {

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -27,7 +27,7 @@ import { fileExistsAtPath } from "../../utils/fs"
 import { playTts, setTtsEnabled, setTtsSpeed, stopTts } from "../../utils/tts"
 import { singleCompletionHandler } from "../../utils/single-completion-handler"
 import { searchCommits } from "../../utils/git"
-import { exportSettings, importSettings } from "../config/importExport"
+import { exportSettings, importSettingsWithFeedback } from "../config/importExport"
 import { getOpenAiModels } from "../../api/providers/openai"
 import { getVsCodeLmModels } from "../../api/providers/vscode-lm"
 import { openMention } from "../mentions"
@@ -316,19 +316,12 @@ export const webviewMessageHandler = async (
 			provider.exportTaskWithId(message.text!)
 			break
 		case "importSettings": {
-			const result = await importSettings({
+			await importSettingsWithFeedback({
 				providerSettingsManager: provider.providerSettingsManager,
 				contextProxy: provider.contextProxy,
 				customModesManager: provider.customModesManager,
+				provider: provider,
 			})
-
-			if (result.success) {
-				provider.settingsImportedAt = Date.now()
-				await provider.postStateToWebview()
-				await vscode.window.showInformationMessage(t("common:info.settings_imported"))
-			} else if (result.error) {
-				await vscode.window.showErrorMessage(t("common:errors.settings_import_failed", { error: result.error }))
-			}
 
 			break
 		}

--- a/src/package.json
+++ b/src/package.json
@@ -162,6 +162,11 @@
 				"category": "%configuration.title%"
 			},
 			{
+				"command": "roo-cline.importSettings",
+				"title": "%command.importSettings.title%",
+				"category": "%configuration.title%"
+			},
+			{
 				"command": "roo-cline.focusInput",
 				"title": "%command.focusInput.title%",
 				"category": "%configuration.title%"

--- a/src/package.nls.ca.json
+++ b/src/package.nls.ca.json
@@ -9,6 +9,7 @@
 	"command.openInNewTab.title": "Obrir en una Nova Pestanya",
 	"command.focusInput.title": "Enfocar Camp d'Entrada",
 	"command.setCustomStoragePath.title": "Establir Ruta d'Emmagatzematge Personalitzada",
+	"command.importSettings.title": "Importar Configuració",
 	"command.terminal.addToContext.title": "Afegir Contingut del Terminal al Context",
 	"command.terminal.fixCommand.title": "Corregir Aquesta Ordre",
 	"command.terminal.explainCommand.title": "Explicar Aquesta Ordre",

--- a/src/package.nls.de.json
+++ b/src/package.nls.de.json
@@ -9,6 +9,7 @@
 	"command.openInNewTab.title": "In Neuem Tab Öffnen",
 	"command.focusInput.title": "Eingabefeld Fokussieren",
 	"command.setCustomStoragePath.title": "Benutzerdefinierten Speicherpfad Festlegen",
+	"command.importSettings.title": "Einstellungen Importieren",
 	"command.terminal.addToContext.title": "Terminal-Inhalt zum Kontext Hinzufügen",
 	"command.terminal.fixCommand.title": "Diesen Befehl Reparieren",
 	"command.terminal.explainCommand.title": "Diesen Befehl Erklären",

--- a/src/package.nls.es.json
+++ b/src/package.nls.es.json
@@ -9,6 +9,7 @@
 	"command.openInNewTab.title": "Abrir en Nueva Pestaña",
 	"command.focusInput.title": "Enfocar Campo de Entrada",
 	"command.setCustomStoragePath.title": "Establecer Ruta de Almacenamiento Personalizada",
+	"command.importSettings.title": "Importar Configuración",
 	"command.terminal.addToContext.title": "Añadir Contenido de Terminal al Contexto",
 	"command.terminal.fixCommand.title": "Corregir Este Comando",
 	"command.terminal.explainCommand.title": "Explicar Este Comando",

--- a/src/package.nls.fr.json
+++ b/src/package.nls.fr.json
@@ -9,6 +9,7 @@
 	"command.openInNewTab.title": "Ouvrir dans un Nouvel Onglet",
 	"command.focusInput.title": "Focus sur le Champ de Saisie",
 	"command.setCustomStoragePath.title": "Définir le Chemin de Stockage Personnalisé",
+	"command.importSettings.title": "Importer les Paramètres",
 	"command.terminal.addToContext.title": "Ajouter le Contenu du Terminal au Contexte",
 	"command.terminal.fixCommand.title": "Corriger cette Commande",
 	"command.terminal.explainCommand.title": "Expliquer cette Commande",

--- a/src/package.nls.hi.json
+++ b/src/package.nls.hi.json
@@ -9,6 +9,7 @@
 	"command.openInNewTab.title": "नए टैब में खोलें",
 	"command.focusInput.title": "इनपुट फ़ील्ड पर फोकस करें",
 	"command.setCustomStoragePath.title": "कस्टम स्टोरेज पाथ सेट करें",
+	"command.importSettings.title": "सेटिंग्स इम्पोर्ट करें",
 	"command.terminal.addToContext.title": "टर्मिनल सामग्री को संदर्भ में जोड़ें",
 	"command.terminal.fixCommand.title": "यह कमांड ठीक करें",
 	"command.terminal.explainCommand.title": "यह कमांड समझाएं",

--- a/src/package.nls.id.json
+++ b/src/package.nls.id.json
@@ -20,6 +20,7 @@
 	"command.addToContext.title": "Tambahkan ke Konteks",
 	"command.focusInput.title": "Fokus ke Field Input",
 	"command.setCustomStoragePath.title": "Atur Path Penyimpanan Kustom",
+	"command.importSettings.title": "Impor Pengaturan",
 	"command.terminal.addToContext.title": "Tambahkan Konten Terminal ke Konteks",
 	"command.terminal.fixCommand.title": "Perbaiki Perintah Ini",
 	"command.terminal.explainCommand.title": "Jelaskan Perintah Ini",

--- a/src/package.nls.it.json
+++ b/src/package.nls.it.json
@@ -9,6 +9,7 @@
 	"command.openInNewTab.title": "Apri in Nuova Scheda",
 	"command.focusInput.title": "Focalizza Campo di Input",
 	"command.setCustomStoragePath.title": "Imposta Percorso di Archiviazione Personalizzato",
+	"command.importSettings.title": "Importa Impostazioni",
 	"command.terminal.addToContext.title": "Aggiungi Contenuto del Terminale al Contesto",
 	"command.terminal.fixCommand.title": "Correggi Questo Comando",
 	"command.terminal.explainCommand.title": "Spiega Questo Comando",

--- a/src/package.nls.ja.json
+++ b/src/package.nls.ja.json
@@ -20,6 +20,7 @@
 	"command.addToContext.title": "コンテキストに追加",
 	"command.focusInput.title": "入力フィールドにフォーカス",
 	"command.setCustomStoragePath.title": "カスタムストレージパスの設定",
+	"command.importSettings.title": "設定をインポート",
 	"command.terminal.addToContext.title": "ターミナルの内容をコンテキストに追加",
 	"command.terminal.fixCommand.title": "このコマンドを修正",
 	"command.terminal.explainCommand.title": "このコマンドを説明",

--- a/src/package.nls.json
+++ b/src/package.nls.json
@@ -20,6 +20,7 @@
 	"command.addToContext.title": "Add To Context",
 	"command.focusInput.title": "Focus Input Field",
 	"command.setCustomStoragePath.title": "Set Custom Storage Path",
+	"command.importSettings.title": "Import Settings",
 	"command.terminal.addToContext.title": "Add Terminal Content to Context",
 	"command.terminal.fixCommand.title": "Fix This Command",
 	"command.terminal.explainCommand.title": "Explain This Command",

--- a/src/package.nls.ko.json
+++ b/src/package.nls.ko.json
@@ -9,6 +9,7 @@
 	"command.openInNewTab.title": "새 탭에서 열기",
 	"command.focusInput.title": "입력 필드 포커스",
 	"command.setCustomStoragePath.title": "사용자 지정 저장소 경로 설정",
+	"command.importSettings.title": "설정 가져오기",
 	"command.terminal.addToContext.title": "터미널 내용을 컨텍스트에 추가",
 	"command.terminal.fixCommand.title": "이 명령어 수정",
 	"command.terminal.explainCommand.title": "이 명령어 설명",

--- a/src/package.nls.nl.json
+++ b/src/package.nls.nl.json
@@ -20,6 +20,7 @@
 	"command.addToContext.title": "Toevoegen aan Context",
 	"command.focusInput.title": "Focus op Invoerveld",
 	"command.setCustomStoragePath.title": "Aangepast Opslagpad Instellen",
+	"command.importSettings.title": "Instellingen Importeren",
 	"command.terminal.addToContext.title": "Terminalinhoud aan Context Toevoegen",
 	"command.terminal.fixCommand.title": "Repareer Dit Commando",
 	"command.terminal.explainCommand.title": "Leg Dit Commando Uit",

--- a/src/package.nls.pl.json
+++ b/src/package.nls.pl.json
@@ -9,6 +9,7 @@
 	"command.openInNewTab.title": "Otwórz w Nowej Karcie",
 	"command.focusInput.title": "Fokus na Pole Wprowadzania",
 	"command.setCustomStoragePath.title": "Ustaw Niestandardową Ścieżkę Przechowywania",
+	"command.importSettings.title": "Importuj Ustawienia",
 	"command.terminal.addToContext.title": "Dodaj Zawartość Terminala do Kontekstu",
 	"command.terminal.fixCommand.title": "Napraw tę Komendę",
 	"command.terminal.explainCommand.title": "Wyjaśnij tę Komendę",

--- a/src/package.nls.pt-BR.json
+++ b/src/package.nls.pt-BR.json
@@ -9,6 +9,7 @@
 	"command.openInNewTab.title": "Abrir em Nova Aba",
 	"command.focusInput.title": "Focar Campo de Entrada",
 	"command.setCustomStoragePath.title": "Definir Caminho de Armazenamento Personalizado",
+	"command.importSettings.title": "Importar Configurações",
 	"command.terminal.addToContext.title": "Adicionar Conteúdo do Terminal ao Contexto",
 	"command.terminal.fixCommand.title": "Corrigir Este Comando",
 	"command.terminal.explainCommand.title": "Explicar Este Comando",

--- a/src/package.nls.ru.json
+++ b/src/package.nls.ru.json
@@ -20,6 +20,7 @@
 	"command.addToContext.title": "Добавить в контекст",
 	"command.focusInput.title": "Фокус на поле ввода",
 	"command.setCustomStoragePath.title": "Указать путь хранения",
+	"command.importSettings.title": "Импортировать настройки",
 	"command.terminal.addToContext.title": "Добавить содержимое терминала в контекст",
 	"command.terminal.fixCommand.title": "Исправить эту команду",
 	"command.terminal.explainCommand.title": "Объяснить эту команду",

--- a/src/package.nls.tr.json
+++ b/src/package.nls.tr.json
@@ -9,6 +9,7 @@
 	"command.openInNewTab.title": "Yeni Sekmede Aç",
 	"command.focusInput.title": "Giriş Alanına Odaklan",
 	"command.setCustomStoragePath.title": "Özel Depolama Yolunu Ayarla",
+	"command.importSettings.title": "Ayarları İçe Aktar",
 	"command.terminal.addToContext.title": "Terminal İçeriğini Bağlama Ekle",
 	"command.terminal.fixCommand.title": "Bu Komutu Düzelt",
 	"command.terminal.explainCommand.title": "Bu Komutu Açıkla",

--- a/src/package.nls.vi.json
+++ b/src/package.nls.vi.json
@@ -9,6 +9,7 @@
 	"command.openInNewTab.title": "Mở trong Tab Mới",
 	"command.focusInput.title": "Tập Trung vào Trường Nhập",
 	"command.setCustomStoragePath.title": "Đặt Đường Dẫn Lưu Trữ Tùy Chỉnh",
+	"command.importSettings.title": "Nhập Cài Đặt",
 	"command.terminal.addToContext.title": "Thêm Nội Dung Terminal vào Ngữ Cảnh",
 	"command.terminal.fixCommand.title": "Sửa Lệnh Này",
 	"command.terminal.explainCommand.title": "Giải Thích Lệnh Này",

--- a/src/package.nls.zh-CN.json
+++ b/src/package.nls.zh-CN.json
@@ -9,6 +9,7 @@
 	"command.openInNewTab.title": "在新标签页中打开",
 	"command.focusInput.title": "聚焦输入框",
 	"command.setCustomStoragePath.title": "设置自定义存储路径",
+	"command.importSettings.title": "导入设置",
 	"command.terminal.addToContext.title": "将终端内容添加到上下文",
 	"command.terminal.fixCommand.title": "修复此命令",
 	"command.terminal.explainCommand.title": "解释此命令",

--- a/src/package.nls.zh-TW.json
+++ b/src/package.nls.zh-TW.json
@@ -9,6 +9,7 @@
 	"command.openInNewTab.title": "在新分頁中開啟",
 	"command.focusInput.title": "聚焦輸入框",
 	"command.setCustomStoragePath.title": "設定自訂儲存路徑",
+	"command.importSettings.title": "匯入設定",
 	"command.terminal.addToContext.title": "將終端內容新增到上下文",
 	"command.terminal.fixCommand.title": "修復此命令",
 	"command.terminal.explainCommand.title": "解釋此命令",

--- a/src/utils/__tests__/autoImportSettings.spec.ts
+++ b/src/utils/__tests__/autoImportSettings.spec.ts
@@ -9,6 +9,9 @@ vi.mock("vscode", () => ({
 		showInformationMessage: vi.fn(),
 		showWarningMessage: vi.fn(),
 	},
+	Uri: {
+		file: vi.fn((path: string) => ({ fsPath: path })),
+	},
 }))
 
 vi.mock("fs/promises", () => ({

--- a/src/utils/__tests__/autoImportSettings.spec.ts
+++ b/src/utils/__tests__/autoImportSettings.spec.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+
+// Mock dependencies
+vi.mock("vscode", () => ({
+	workspace: {
+		getConfiguration: vi.fn(),
+	},
+	window: {
+		showInformationMessage: vi.fn(),
+		showWarningMessage: vi.fn(),
+	},
+}))
+
+vi.mock("fs/promises", () => ({
+	__esModule: true,
+	default: {
+		readFile: vi.fn(),
+	},
+	readFile: vi.fn(),
+}))
+
+vi.mock("path", () => ({
+	join: vi.fn((...args: string[]) => args.join("/")),
+	isAbsolute: vi.fn((p: string) => p.startsWith("/")),
+	basename: vi.fn((p: string) => p.split("/").pop() || ""),
+}))
+
+vi.mock("os", () => ({
+	homedir: vi.fn(() => "/home/user"),
+}))
+
+vi.mock("../fs", () => ({
+	fileExistsAtPath: vi.fn(),
+}))
+
+vi.mock("../../core/config/ProviderSettingsManager", async (importOriginal) => {
+	const originalModule = await importOriginal()
+	return {
+		__esModule: true,
+		// We need to mock the class constructor and its methods,
+		// but keep other exports (like schemas) as their original values.
+		...(originalModule || {}), // Spread original exports
+		ProviderSettingsManager: vi.fn().mockImplementation(() => ({
+			// Mock the class
+			export: vi.fn().mockResolvedValue({
+				apiConfigs: {},
+				modeApiConfigs: {},
+				currentApiConfigName: "default",
+			}),
+			import: vi.fn().mockResolvedValue({ success: true }),
+			listConfig: vi.fn().mockResolvedValue([]),
+		})),
+	}
+})
+vi.mock("../../core/config/ContextProxy")
+vi.mock("../../core/config/CustomModesManager")
+
+import { autoImportSettings } from "../autoImportSettings"
+import * as vscode from "vscode"
+import fsPromises from "fs/promises"
+import { fileExistsAtPath } from "../fs"
+
+describe("autoImportSettings", () => {
+	let mockProviderSettingsManager: any
+	let mockContextProxy: any
+	let mockCustomModesManager: any
+	let mockOutputChannel: any
+	let mockProvider: any
+
+	beforeEach(() => {
+		// Reset all mocks
+		vi.clearAllMocks()
+
+		// Mock output channel
+		mockOutputChannel = {
+			appendLine: vi.fn(),
+		}
+
+		// Mock provider settings manager
+		mockProviderSettingsManager = {
+			export: vi.fn().mockResolvedValue({
+				apiConfigs: {},
+				modeApiConfigs: {},
+				currentApiConfigName: "default",
+			}),
+			import: vi.fn().mockResolvedValue({ success: true }),
+			listConfig: vi.fn().mockResolvedValue([]),
+		}
+
+		// Mock context proxy
+		mockContextProxy = {
+			setValues: vi.fn().mockResolvedValue(undefined),
+			setValue: vi.fn().mockResolvedValue(undefined),
+			setProviderSettings: vi.fn().mockResolvedValue(undefined),
+		}
+
+		// Mock custom modes manager
+		mockCustomModesManager = {
+			updateCustomMode: vi.fn().mockResolvedValue(undefined),
+		}
+
+		// mockProvider must be initialized AFTER its dependencies
+		mockProvider = {
+			providerSettingsManager: mockProviderSettingsManager,
+			contextProxy: mockContextProxy,
+			upsertProviderProfile: vi.fn().mockResolvedValue({ success: true }),
+			postStateToWebview: vi.fn().mockResolvedValue({ success: true }),
+		}
+
+		// Reset fs mock
+		vi.mocked(fsPromises.readFile).mockReset()
+		vi.mocked(fileExistsAtPath).mockReset()
+		vi.mocked(vscode.workspace.getConfiguration).mockReset()
+		vi.mocked(vscode.window.showInformationMessage).mockReset()
+		vi.mocked(vscode.window.showWarningMessage).mockReset()
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it("should skip auto-import when no settings path is specified", async () => {
+		vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+			get: vi.fn().mockReturnValue(""),
+		} as any)
+
+		await autoImportSettings(mockOutputChannel, {
+			providerSettingsManager: mockProviderSettingsManager,
+			contextProxy: mockContextProxy,
+			customModesManager: mockCustomModesManager,
+		})
+
+		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
+			"[AutoImport] No auto-import settings path specified, skipping auto-import",
+		)
+		expect(mockProviderSettingsManager.import).not.toHaveBeenCalled()
+	})
+
+	it("should skip auto-import when settings file does not exist", async () => {
+		const settingsPath = "~/Documents/roo-config.json"
+		vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+			get: vi.fn().mockReturnValue(settingsPath),
+		} as any)
+
+		// Mock fileExistsAtPath to return false
+		vi.mocked(fileExistsAtPath).mockResolvedValue(false)
+
+		await autoImportSettings(mockOutputChannel, {
+			providerSettingsManager: mockProviderSettingsManager,
+			contextProxy: mockContextProxy,
+			customModesManager: mockCustomModesManager,
+		})
+
+		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
+			"[AutoImport] Checking for settings file at: /home/user/Documents/roo-config.json",
+		)
+		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
+			"[AutoImport] Settings file not found at /home/user/Documents/roo-config.json, skipping auto-import",
+		)
+		expect(mockProviderSettingsManager.import).not.toHaveBeenCalled()
+	})
+
+	it("should successfully import settings when file exists and is valid", async () => {
+		const settingsPath = "/absolute/path/to/config.json"
+		vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+			get: vi.fn().mockReturnValue(settingsPath),
+		} as any)
+
+		// Mock fileExistsAtPath to return true
+		vi.mocked(fileExistsAtPath).mockResolvedValue(true)
+
+		// Mock fs.readFile to return valid config
+		const mockSettings = {
+			providerProfiles: {
+				currentApiConfigName: "test-config",
+				apiConfigs: {
+					"test-config": {
+						apiProvider: "anthropic",
+						anthropicApiKey: "test-key",
+					},
+				},
+			},
+			globalSettings: {
+				customInstructions: "Test instructions",
+			},
+		}
+
+		vi.mocked(fsPromises.readFile).mockResolvedValue(JSON.stringify(mockSettings) as any)
+
+		await autoImportSettings(mockOutputChannel, {
+			providerSettingsManager: mockProviderSettingsManager,
+			contextProxy: mockContextProxy,
+			customModesManager: mockCustomModesManager,
+		})
+
+		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
+			"[AutoImport] Checking for settings file at: /absolute/path/to/config.json",
+		)
+		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
+			"[AutoImport] Successfully imported settings from /absolute/path/to/config.json",
+		)
+		expect(vscode.window.showInformationMessage).toHaveBeenCalledWith("info.auto_import_success")
+		expect(mockProviderSettingsManager.import).toHaveBeenCalled()
+		expect(mockContextProxy.setValues).toHaveBeenCalled()
+	})
+
+	it("should handle invalid JSON gracefully", async () => {
+		const settingsPath = "~/config.json"
+		vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+			get: vi.fn().mockReturnValue(settingsPath),
+		} as any)
+
+		// Mock fileExistsAtPath to return true
+		vi.mocked(fileExistsAtPath).mockResolvedValue(true)
+
+		// Mock fs.readFile to return invalid JSON
+		vi.mocked(fsPromises.readFile).mockResolvedValue("invalid json" as any)
+
+		await autoImportSettings(mockOutputChannel, {
+			providerSettingsManager: mockProviderSettingsManager,
+			contextProxy: mockContextProxy,
+			customModesManager: mockCustomModesManager,
+		})
+
+		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
+			expect.stringContaining("[AutoImport] Failed to import settings:"),
+		)
+		expect(vscode.window.showWarningMessage).toHaveBeenCalledWith("warnings.auto_import_failed")
+		expect(mockProviderSettingsManager.import).not.toHaveBeenCalled()
+	})
+
+	it("should resolve home directory paths correctly", async () => {
+		const settingsPath = "~/Documents/config.json"
+		vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+			get: vi.fn().mockReturnValue(settingsPath),
+		} as any)
+
+		// Mock fileExistsAtPath to return false (so we can check the resolved path)
+		vi.mocked(fileExistsAtPath).mockResolvedValue(false)
+
+		await autoImportSettings(mockOutputChannel, {
+			providerSettingsManager: mockProviderSettingsManager,
+			contextProxy: mockContextProxy,
+			customModesManager: mockCustomModesManager,
+		})
+
+		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
+			"[AutoImport] Checking for settings file at: /home/user/Documents/config.json",
+		)
+	})
+
+	it("should handle relative paths by resolving them to home directory", async () => {
+		const settingsPath = "Documents/config.json"
+		vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+			get: vi.fn().mockReturnValue(settingsPath),
+		} as any)
+
+		// Mock fileExistsAtPath to return false (so we can check the resolved path)
+		vi.mocked(fileExistsAtPath).mockResolvedValue(false)
+
+		await autoImportSettings(mockOutputChannel, {
+			providerSettingsManager: mockProviderSettingsManager,
+			contextProxy: mockContextProxy,
+			customModesManager: mockCustomModesManager,
+		})
+
+		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
+			"[AutoImport] Checking for settings file at: /home/user/Documents/config.json",
+		)
+	})
+
+	it("should handle file system errors gracefully", async () => {
+		const settingsPath = "~/config.json"
+		vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+			get: vi.fn().mockReturnValue(settingsPath),
+		} as any)
+
+		// Mock fileExistsAtPath to throw an error
+		vi.mocked(fileExistsAtPath).mockRejectedValue(new Error("File system error"))
+
+		await autoImportSettings(mockOutputChannel, {
+			providerSettingsManager: mockProviderSettingsManager,
+			contextProxy: mockContextProxy,
+			customModesManager: mockCustomModesManager,
+		})
+
+		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
+			expect.stringContaining("[AutoImport] Unexpected error during auto-import:"),
+		)
+		expect(mockProviderSettingsManager.import).not.toHaveBeenCalled()
+	})
+})

--- a/src/utils/autoImportSettings.ts
+++ b/src/utils/autoImportSettings.ts
@@ -1,0 +1,84 @@
+import * as vscode from "vscode"
+import * as path from "path"
+import * as os from "os"
+
+import { Package } from "../shared/package"
+import { fileExistsAtPath } from "./fs"
+import { t } from "../i18n"
+
+import { importSettingsFromPath, ImportOptions } from "../core/config/importExport"
+
+/**
+ * Automatically imports RooCode settings from a specified path if it exists.
+ * This function is called during extension activation to allow users to pre-configure
+ * their settings by placing a settings file at a predefined location.
+ */
+export async function autoImportSettings(
+	outputChannel: vscode.OutputChannel,
+	{ providerSettingsManager, contextProxy, customModesManager }: ImportOptions,
+): Promise<void> {
+	try {
+		// Get the auto-import settings path from VSCode settings
+		const settingsPath = vscode.workspace.getConfiguration(Package.name).get<string>("autoImportSettingsPath")
+
+		if (!settingsPath || settingsPath.trim() === "") {
+			outputChannel.appendLine("[AutoImport] No auto-import settings path specified, skipping auto-import")
+			return
+		}
+
+		// Resolve the path (handle ~ for home directory and relative paths)
+		const resolvedPath = resolvePath(settingsPath.trim())
+		outputChannel.appendLine(`[AutoImport] Checking for settings file at: ${resolvedPath}`)
+
+		// Check if the file exists
+		if (!(await fileExistsAtPath(resolvedPath))) {
+			outputChannel.appendLine(`[AutoImport] Settings file not found at ${resolvedPath}, skipping auto-import`)
+			return
+		}
+
+		// Attempt to import the configuration
+		const result = await importSettingsFromPath(resolvedPath, {
+			providerSettingsManager,
+			contextProxy,
+			customModesManager,
+		})
+
+		if (result.success) {
+			outputChannel.appendLine(`[AutoImport] Successfully imported settings from ${resolvedPath}`)
+
+			// Show a notification to the user
+			vscode.window.showInformationMessage(
+				t("common:info.auto_import_success", { filename: path.basename(resolvedPath) }),
+			)
+		} else {
+			outputChannel.appendLine(`[AutoImport] Failed to import settings: ${result.error}`)
+
+			// Show a warning but don't fail the extension activation
+			vscode.window.showWarningMessage(t("common:warnings.auto_import_failed", { error: result.error }))
+		}
+	} catch (error) {
+		const errorMessage = error instanceof Error ? error.message : String(error)
+		outputChannel.appendLine(`[AutoImport] Unexpected error during auto-import: ${errorMessage}`)
+
+		// Log error but don't fail extension activation
+		console.warn("Auto-import settings error:", error)
+	}
+}
+
+/**
+ * Resolves a file path, handling home directory expansion and relative paths
+ */
+function resolvePath(settingsPath: string): string {
+	// Handle home directory expansion
+	if (settingsPath.startsWith("~/")) {
+		return path.join(os.homedir(), settingsPath.slice(2))
+	}
+
+	// Handle absolute paths
+	if (path.isAbsolute(settingsPath)) {
+		return settingsPath
+	}
+
+	// Handle relative paths (relative to home directory for safety)
+	return path.join(os.homedir(), settingsPath)
+}

--- a/src/utils/autoImportSettings.ts
+++ b/src/utils/autoImportSettings.ts
@@ -6,7 +6,16 @@ import { Package } from "../shared/package"
 import { fileExistsAtPath } from "./fs"
 import { t } from "../i18n"
 
-import { importSettingsFromPath, ImportOptions } from "../core/config/importExport"
+import { importSettingsFromFile } from "../core/config/importExport"
+import { ProviderSettingsManager } from "../core/config/ProviderSettingsManager"
+import { ContextProxy } from "../core/config/ContextProxy"
+import { CustomModesManager } from "../core/config/CustomModesManager"
+
+type ImportOptions = {
+	providerSettingsManager: ProviderSettingsManager
+	contextProxy: ContextProxy
+	customModesManager: CustomModesManager
+}
 
 /**
  * Automatically imports RooCode settings from a specified path if it exists.
@@ -37,11 +46,15 @@ export async function autoImportSettings(
 		}
 
 		// Attempt to import the configuration
-		const result = await importSettingsFromPath(resolvedPath, {
-			providerSettingsManager,
-			contextProxy,
-			customModesManager,
-		})
+		const fileUri = vscode.Uri.file(resolvedPath)
+		const result = await importSettingsFromFile(
+			{
+				providerSettingsManager,
+				contextProxy,
+				customModesManager,
+			},
+			fileUri,
+		)
 
 		if (result.success) {
 			outputChannel.appendLine(`[AutoImport] Successfully imported settings from ${resolvedPath}`)


### PR DESCRIPTION
- Add importSettings to commandIds in types package
- Modify importSettings function to accept optional filePath parameter
- Register command in registerCommands.ts with proper error handling
- Add command to package.json contributions
- Add translation for command title
- Add unit test for file path parameter functionality

This enables automated settings import via:
- Command palette: "Roo: Import Settings"
- API: vscode.commands.executeCommand('roo.importSettings', filePath)


🤖 Generated with [Claude Code](https://claude.ai/code)

<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes:#3706

### Description

<!--
Briefly summarize the changes in this PR and how they address the linked issue.
The issue should cover the "what" and "why"; this section should focus on:
- The "how": key implementation details, design choices, or trade-offs made.
- Anything specific reviewers should pay attention to in this PR.
-->

### Test Procedure

<!--
Detail the steps to test your changes. This helps reviewers verify your work.
- How did you test this specific implementation? (e.g., unit tests, manual testing steps)
- How can reviewers reproduce your tests or verify the fix/feature?
- Include relevant testing environment details if applicable.
-->

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [X ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [ X] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [X] **Self-Review**: I have performed a thorough self-review of my code.
- [X ] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [X ] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [X ] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->

### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `importSettings` command to VSCode extension for importing settings with optional file path support and unit tests.
> 
>   - **Behavior**:
>     - Register `importSettings` command in `registerCommands.ts` with error handling.
>     - Modify `importSettings` function in `importExport.ts` to accept optional `filePath` parameter.
>     - Add command to `package.json` contributions and translations in `package.nls.json`.
>   - **Testing**:
>     - Add unit test in `importExport.spec.ts` for importing settings from a provided file path.
>   - **Misc**:
>     - Add `importSettings` to `commandIds` in `vscode.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 75ac1bc758675576ef0f19f6efdaaa5e7363c631. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->