### PR TITLE
Fix: Remove temperature parameter for Azure OpenAI reasoning models

### DIFF
--- a/src/api/providers/__tests__/openai.spec.ts
+++ b/src/api/providers/__tests__/openai.spec.ts
@@ -599,7 +599,7 @@ describe("OpenAiHandler", () => {
 					stream: true,
 					stream_options: { include_usage: true },
 					reasoning_effort: "medium",
-					temperature: 0.5,
+					temperature: undefined,
 					// O3 models do not support deprecated max_tokens but do support max_completion_tokens
 					max_completion_tokens: 32000,
 				}),
@@ -640,7 +640,7 @@ describe("OpenAiHandler", () => {
 					stream: true,
 					stream_options: { include_usage: true },
 					reasoning_effort: "medium",
-					temperature: 0.7,
+					temperature: undefined,
 				}),
 				{},
 			)
@@ -682,7 +682,7 @@ describe("OpenAiHandler", () => {
 						{ role: "user", content: "Hello!" },
 					],
 					reasoning_effort: "medium",
-					temperature: 0.3,
+					temperature: undefined,
 					// O3 models do not support deprecated max_tokens but do support max_completion_tokens
 					max_completion_tokens: 65536, // Using default maxTokens from o3Options
 				}),
@@ -712,7 +712,7 @@ describe("OpenAiHandler", () => {
 
 			expect(mockCreate).toHaveBeenCalledWith(
 				expect.objectContaining({
-					temperature: 0, // Default temperature
+					temperature: undefined, // Temperature is not supported for O3 models
 				}),
 				{},
 			)

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -86,7 +86,7 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 		const deepseekReasoner = modelId.includes("deepseek-reasoner") || enabledR1Format
 		const ark = modelUrl.includes(".volces.com")
 
-		if (modelId.startsWith("o3-mini")) {
+		if (modelId.includes("o1") || modelId.includes("o3") || modelId.includes("o4")) {
 			yield* this.handleO3FamilyMessage(modelId, systemPrompt, messages)
 			return
 		}
@@ -306,7 +306,7 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 				stream: true,
 				...(isGrokXAI ? {} : { stream_options: { include_usage: true } }),
 				reasoning_effort: modelInfo.reasoningEffort,
-				temperature: this.options.modelTemperature ?? 0,
+				temperature: undefined,
 			}
 
 			// O3 family models do not support the deprecated max_tokens parameter
@@ -331,7 +331,7 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 					...convertToOpenAiMessages(messages),
 				],
 				reasoning_effort: modelInfo.reasoningEffort,
-				temperature: this.options.modelTemperature ?? 0,
+				temperature: undefined,
 			}
 
 			// O3 family models do not support the deprecated max_tokens parameter


### PR DESCRIPTION
Fixes #1400

Modifies o3 family handler to add o1 and o4 families. All of these reasoning models in Azure AI OpenAI API service do not support the `temperature` parameter. Some of them reportedly have worked in some cases when setting the temperature to exactly 1.0. However Microsoft does *not* support them at all and they are not supposed to be included.

In my case with using o3-mini the API requests were completely rejected with the response that temperature was an unsupported parameter.

This fix follows a similar model as Cline's fix for the same issue.

Setting temperature to null causes it to be completely excluded from the API call, which is exactly what Microsoft requires, and it works perfectly in my testing.

Screenshots showing working API provider configuration with this fix in place.
![working_azureai_o3_model_config_1_of_2](https://github.com/user-attachments/assets/daca1c19-d905-4b9c-9f86-9feb26a340c1)

![working_azureai_o3_model_config_2_of_2](https://github.com/user-attachments/assets/84013589-66bc-4695-83c8-e798792a1bc8)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Removes unsupported `temperature` parameter for Azure OpenAI `o1`, `o3`, and `o4` models in `openai.ts`.
> 
>   - **Behavior**:
>     - Removes `temperature` parameter for Azure OpenAI models in `OpenAiHandler`.
>     - Specifically affects `o1`, `o3`, and `o4` model families.
>     - Sets `temperature` to `undefined` in `createMessage()` and `handleO3FamilyMessage()`.
>   - **Logic**:
>     - Modifies condition in `createMessage()` to check for `o1`, `o3`, and `o4` models.
>     - Ensures `temperature` is excluded from API calls for these models.
>   - **Misc**:
>     - Fixes issue #1400 by aligning with Microsoft's API requirements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d5546e5a80394a75985c15836f6a6bcce10d3777. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->