### PR TITLE
Improve translation workflow to avoid unnecessary file reads

### DIFF
--- a/.roo/rules-translate/001-general-rules.md
+++ b/.roo/rules-translate/001-general-rules.md
@@ -64,8 +64,10 @@
     1. Identify where the string appears in the UI/codebase
     2. Understand the context and purpose of the string
     3. Update English translation first
-    4. Create appropriate translations for all other supported languages
-    5. Validate your changes with the missing translations script
+    4. Use the `<search_files>` tool to find JSON keys that are near new keys in English translations but do not yet exist in the other language files for `<apply_diff>` SEARCH context
+    5. Create appropriate translations for all other supported languages utilizing the `search_files` result using `<apply_diff>` without reading every file.
+    6. Do not show me the translated text, just modify the files.
+    7. Validate your changes with the missing translations script
 - Flag or comment if an English source string is incomplete ("please see this...") to avoid truncated or unclear translations
 - For UI elements, distinguish between:
     - Button labels: Use short imperative commands ("Save", "Cancel")

--- a/.roo/rules-translate/001-general-rules.md
+++ b/.roo/rules-translate/001-general-rules.md
@@ -66,7 +66,7 @@
     3. Update English translation first
     4. Use the `<search_files>` tool to find JSON keys that are near new keys in English translations but do not yet exist in the other language files for `<apply_diff>` SEARCH context
     5. Create appropriate translations for all other supported languages utilizing the `search_files` result using `<apply_diff>` without reading every file.
-    6. Do not show me the translated text, just modify the files.
+    6. Do not output the translated text into the chat, just modify the files.
     7. Validate your changes with the missing translations script
 - Flag or comment if an English source string is incomplete ("please see this...") to avoid truncated or unclear translations
 - For UI elements, distinguish between:


### PR DESCRIPTION
## Context

This PR updates the translation workflow guidelines to use a more efficient approach that reduces unnecessary file reads and context token usage.

## Implementation

The improved workflow:
- Uses `search_files` to find JSON keys that are near new keys in English translations
- Creates proper context for `apply_diff` without reading every file
- Only reads specific files when their structure differs from the expected pattern
- Validates changes with the missing translations script as the final step

This approach has been successfully tested with the errorBoundary translations and significantly reduces the number of file reads required.

## How to Test

1. Follow the updated workflow in the translation rules when adding new translations
2. Verify that you can successfully add translations without reading every file individually
3. Run the missing translations script to confirm all translations are complete

## Get in Touch

Discord: KJ7LNW

Fixes #5125