### PR TITLE
Use upstream_inference_cost for OpenRouter BYOK cost calculation and show cached token count

### DIFF
--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -48,12 +48,10 @@ interface CompletionUsage {
 	}
 	total_tokens?: number
 	cost?: number
-	is_byok?: boolean
+	cost_details?: {
+		upstream_inference_cost?: number
+	}
 }
-
-// with bring your own key, OpenRouter charges 5% of what it normally would: https://openrouter.ai/docs/use-cases/byok
-// so we multiply the cost reported by OpenRouter to get an estimate of what the request actually cost
-const BYOK_COST_MULTIPLIER = 20
 
 export class OpenRouterHandler extends BaseProvider implements SingleCompletionHandler {
 	protected options: ApiHandlerOptions
@@ -168,11 +166,9 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 				type: "usage",
 				inputTokens: lastUsage.prompt_tokens || 0,
 				outputTokens: lastUsage.completion_tokens || 0,
-				// Waiting on OpenRouter to figure out what this represents in the Gemini case
-				// and how to best support it.
-				// cacheReadTokens: lastUsage.prompt_tokens_details?.cached_tokens,
+				cacheReadTokens: lastUsage.prompt_tokens_details?.cached_tokens,
 				reasoningTokens: lastUsage.completion_tokens_details?.reasoning_tokens,
-				totalCost: (lastUsage.is_byok ? BYOK_COST_MULTIPLIER : 1) * (lastUsage.cost || 0),
+				totalCost: (lastUsage.cost_details?.upstream_inference_cost || 0) + (lastUsage.cost || 0),
 			}
 		}
 	}

--- a/webview-ui/src/__tests__/ContextWindowProgress.spec.tsx
+++ b/webview-ui/src/__tests__/ContextWindowProgress.spec.tsx
@@ -51,7 +51,6 @@ describe("ContextWindowProgress", () => {
 			task: { ts: Date.now(), type: "say" as const, say: "text" as const, text: "Test task" },
 			tokensIn: 100,
 			tokensOut: 50,
-			doesModelSupportPromptCache: true,
 			totalCost: 0.001,
 			contextTokens: 1000,
 			onClose: vi.fn(),

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -1371,7 +1371,6 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 						task={task}
 						tokensIn={apiMetrics.totalTokensIn}
 						tokensOut={apiMetrics.totalTokensOut}
-						doesModelSupportPromptCache={model?.supportsPromptCache ?? false}
 						cacheWrites={apiMetrics.totalCacheWrites}
 						cacheReads={apiMetrics.totalCacheReads}
 						totalCost={apiMetrics.totalCost}

--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -25,7 +25,6 @@ export interface TaskHeaderProps {
 	task: ClineMessage
 	tokensIn: number
 	tokensOut: number
-	doesModelSupportPromptCache: boolean
 	cacheWrites?: number
 	cacheReads?: number
 	totalCost: number
@@ -39,7 +38,6 @@ const TaskHeader = ({
 	task,
 	tokensIn,
 	tokensOut,
-	doesModelSupportPromptCache,
 	cacheWrites,
 	cacheReads,
 	totalCost,
@@ -186,25 +184,24 @@ const TaskHeader = ({
 								{!totalCost && <TaskActions item={currentTaskItem} buttonsDisabled={buttonsDisabled} />}
 							</div>
 
-							{doesModelSupportPromptCache &&
-								((typeof cacheReads === "number" && cacheReads > 0) ||
-									(typeof cacheWrites === "number" && cacheWrites > 0)) && (
-									<div className="flex items-center gap-1 flex-wrap h-[20px]">
-										<span className="font-bold">{t("chat:task.cache")}</span>
-										{typeof cacheWrites === "number" && cacheWrites > 0 && (
-											<span className="flex items-center gap-0.5">
-												<CloudUpload size={16} />
-												{formatLargeNumber(cacheWrites)}
-											</span>
-										)}
-										{typeof cacheReads === "number" && cacheReads > 0 && (
-											<span className="flex items-center gap-0.5">
-												<CloudDownload size={16} />
-												{formatLargeNumber(cacheReads)}
-											</span>
-										)}
-									</div>
-								)}
+							{((typeof cacheReads === "number" && cacheReads > 0) ||
+								(typeof cacheWrites === "number" && cacheWrites > 0)) && (
+								<div className="flex items-center gap-1 flex-wrap h-[20px]">
+									<span className="font-bold">{t("chat:task.cache")}</span>
+									{typeof cacheWrites === "number" && cacheWrites > 0 && (
+										<span className="flex items-center gap-0.5">
+											<CloudUpload size={16} />
+											{formatLargeNumber(cacheWrites)}
+										</span>
+									)}
+									{typeof cacheReads === "number" && cacheReads > 0 && (
+										<span className="flex items-center gap-0.5">
+											<CloudDownload size={16} />
+											{formatLargeNumber(cacheReads)}
+										</span>
+									)}
+								</div>
+							)}
 
 							{!!totalCost && (
 								<div className="flex justify-between items-center h-[20px]">

--- a/webview-ui/src/components/chat/__tests__/TaskHeader.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/TaskHeader.spec.tsx
@@ -49,7 +49,6 @@ describe("TaskHeader", () => {
 		task: { type: "say", ts: Date.now(), text: "Test task", images: [] },
 		tokensIn: 100,
 		tokensOut: 50,
-		doesModelSupportPromptCache: true,
 		totalCost: 0.05,
 		contextTokens: 200,
 		buttonsDisabled: false,


### PR DESCRIPTION
### Related GitHub Issue

Closes: #5144

### Description

Replace 20x multiplier by adding OpenRouter cost and upstream cost.

### Test Procedure

I've included two examples below that I think show the new calculation is correct. The calculations are AI generated, but I think they make sense.

<details>

<summary>GPT4.1 request using BYOK</summary>

<img width="581" alt="GPT41_BYOK" src="https://github.com/user-attachments/assets/3b92cb63-3788-4b97-9d5c-d2469c163697" />

> Use pricing information from: https://openai.com/api/pricing/
> How much does a GPT4.1 request cost given 40.6k input tokens, 1.9k output tokens and 12.4k cache reads? Subtract cache reads from input tokens and add a 5% OpenRouter tax.

From the search results, GPT-4.1 pricing is:
- **Input tokens**: $2.00 per million
- **Output tokens**: $8.00 per million
- **Cached input tokens**: $0.50 per million tokens

Now let me calculate your request cost:

**Given:**
- Total input tokens: 40,600
- Output tokens: 1,900
- Cache reads: 12,400
- OpenRouter tax: 5%

**Step 1: Calculate effective input tokens**
- Effective input tokens = Total input tokens - Cache reads
- Effective input tokens = 40,600 - 12,400 = 28,200 tokens

**Step 2: Calculate cache read tokens**
- Cache read tokens = 12,400 tokens

**Step 3: Calculate costs**
- Regular input cost = 28,200 × ($2.00 / 1,000,000) = $0.0564
- Cache read cost = 12,400 × ($0.50 / 1,000,000) = $0.0062
- Output cost = 1,900 × ($8.00 / 1,000,000) = $0.0152

**Step 4: Calculate subtotal**
- Subtotal = $0.0564 + $0.0062 + $0.0152 = $0.0778

**Step 5: Add 5% OpenRouter tax**
- Tax = $0.0778 × 0.05 = $0.00389
- Total = $0.0778 + $0.00389 = $0.08169

**The total cost for your GPT-4.1 request is approximately $0.082 (or 8.2 cents).**

</details>

<details>

<summary>Gemini 2.5 Pro request NOT using BYOK</summary>

<img width="582" alt="Gemini25Pro_NoBYOK" src="https://github.com/user-attachments/assets/6625c632-3a84-465b-9208-fb1a4879826a" />

> Use pricing information from: https://ai.google.dev/gemini-api/docs/pricing
> How much does a Gemini 2.5 Pro request cost given 68.3k input tokens, 3.0k output tokens and 10.2k cache reads? Subtract cache reads from input tokens.

For Gemini 2.5 Pro (paid tier):
- **Input pricing**: $1.25 per 1M tokens for prompts ≤ 200k tokens
- **Output pricing**: $10.00 per 1M tokens for prompts ≤ 200k tokens
- **Context caching pricing**: $0.31 per 1M tokens for prompts ≤ 200k tokens

Your request details:
- Input tokens: 68.3k - 10.2k (cache reads) = 58.1k tokens
- Output tokens: 3.0k tokens
- Cache reads: 10.2k tokens

Cost calculation:
1. **Input cost**: 58.1k tokens = 0.0581M tokens × $1.25 = $0.072625
2. **Output cost**: 3.0k tokens = 0.003M tokens × $10.00 = $0.03
3. **Cache read cost**: 10.2k tokens = 0.0102M tokens × $0.31 = $0.003162

**Total cost**: $0.072625 + $0.03 + $0.003162 = **$0.105787**

The total cost for your Gemini 2.5 Pro request would be approximately **$0.106** (rounded to 3 decimal places).

</details>

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

See Test Procedure

### Get in Touch

Discord username is the same as GitHub username.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update OpenRouter BYOK cost calculation to use upstream inference cost and display cache token counts in UI.
> 
>   - **Cost Calculation**:
>     - Replaces 20x multiplier with `upstream_inference_cost` in `OpenRouterHandler` in `openrouter.ts`.
>     - Updates `totalCost` calculation to sum `upstream_inference_cost` and `cost`.
>   - **UI Changes**:
>     - Removes `doesModelSupportPromptCache` prop from `TaskHeader`, `ChatView`, and related tests.
>     - Displays cache read and write token counts in `TaskHeader`.
>   - **Tests**:
>     - Updates `TaskHeader.spec.tsx` to test cost display logic and condense context button behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 58dfad9531fda29eeb8f11aaf90de336f8b856d5. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->