### PR TITLE
Track mode selector opened in telemetry

### DIFF
--- a/packages/types/src/telemetry.ts
+++ b/packages/types/src/telemetry.ts
@@ -25,6 +25,7 @@ export enum TelemetryEventName {
 	TASK_CONVERSATION_MESSAGE = "Conversation Message",
 	LLM_COMPLETION = "LLM Completion",
 	MODE_SWITCH = "Mode Switched",
+	MODE_SELECTOR_OPENED = "Mode Selector Opened",
 	TOOL_USED = "Tool Used",
 
 	CHECKPOINT_CREATED = "Checkpoint Created",
@@ -126,6 +127,7 @@ export const rooCodeTelemetryEventSchema = z.discriminatedUnion("type", [
 			TelemetryEventName.TASK_COMPLETED,
 			TelemetryEventName.TASK_CONVERSATION_MESSAGE,
 			TelemetryEventName.MODE_SWITCH,
+			TelemetryEventName.MODE_SELECTOR_OPENED,
 			TelemetryEventName.TOOL_USED,
 			TelemetryEventName.CHECKPOINT_CREATED,
 			TelemetryEventName.CHECKPOINT_RESTORED,

--- a/webview-ui/src/components/chat/ModeSelector.tsx
+++ b/webview-ui/src/components/chat/ModeSelector.tsx
@@ -9,6 +9,8 @@ import { useExtensionState } from "@/context/ExtensionStateContext"
 import { useAppTranslation } from "@/i18n/TranslationContext"
 import { Mode, getAllModes } from "@roo/modes"
 import { ModeConfig, CustomModePrompts } from "@roo-code/types"
+import { telemetryClient } from "@/utils/TelemetryClient"
+import { TelemetryEventName } from "@roo-code/types"
 
 interface ModeSelectorProps {
 	value: Mode
@@ -37,6 +39,10 @@ export const ModeSelector = ({
 	const { t } = useAppTranslation()
 
 	const trackModeSelectorOpened = () => {
+		// Track telemetry every time the mode selector is opened
+		telemetryClient.capture(TelemetryEventName.MODE_SELECTOR_OPENED)
+
+		// Track first-time usage for UI purposes
 		if (!hasOpenedModeSelector) {
 			setHasOpenedModeSelector(true)
 			vscode.postMessage({ type: "hasOpenedModeSelector", bool: true })


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add telemetry tracking for mode selector opening in `ModeSelector.tsx` by introducing `MODE_SELECTOR_OPENED` event.
> 
>   - **Telemetry**:
>     - Add `MODE_SELECTOR_OPENED` to `TelemetryEventName` in `telemetry.ts`.
>     - Update `rooCodeTelemetryEventSchema` in `telemetry.ts` to include `MODE_SELECTOR_OPENED`.
>   - **ModeSelector Component**:
>     - In `ModeSelector.tsx`, add `trackModeSelectorOpened()` to capture `TelemetryEventName.MODE_SELECTOR_OPENED` when the mode selector is opened.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 639070f42c0ca357744fdb4fd4283a6304261550. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->