### PR TITLE
Update lastShownAnnouncementId in EVALS_SETTINGS

### DIFF
--- a/packages/types/src/global-settings.ts
+++ b/packages/types/src/global-settings.ts
@@ -171,7 +171,7 @@ export const EVALS_SETTINGS: RooCodeSettings = {
 	apiProvider: "openrouter",
 	openRouterUseMiddleOutTransform: false,
 
-	lastShownAnnouncementId: "may-29-2025-3-19",
+	lastShownAnnouncementId: "jun-17-2025-3-21",
 
 	pinnedApiConfigs: {},
 


### PR DESCRIPTION
### Description

Prevents the modal from popping up when running roomote locally. We should figure out a better long-term solution though.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `lastShownAnnouncementId` in `EVALS_SETTINGS` to prevent modal pop-up when running roomote locally.
> 
>   - **Behavior**:
>     - Update `lastShownAnnouncementId` in `EVALS_SETTINGS` in `global-settings.ts` from "may-29-2025-3-19" to "jun-17-2025-3-21".
>     - Prevents modal pop-up when running roomote locally.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d2002bcb8346eb755f39536fe8eafadc74c7a908. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->