### PR TITLE
Code Index (Qdrant) recreate services when change configurations

### DIFF
--- a/src/services/code-index/__tests__/manager.spec.ts
+++ b/src/services/code-index/__tests__/manager.spec.ts
@@ -89,7 +89,7 @@ describe("CodeIndexManager - handleExternalSettingsChange regression", () => {
 			expect(manager.isInitialized).toBe(true)
 
 			// Mock the methods that would be called during restart
-			const stopWatcherSpy = vitest.spyOn(manager, "stopWatcher").mockImplementation(() => {})
+			const recreateServicesSpy = vitest.spyOn(manager as any, "_recreateServices").mockImplementation(() => {})
 			const startIndexingSpy = vitest.spyOn(manager, "startIndexing").mockResolvedValue()
 
 			// Mock the feature state
@@ -100,7 +100,7 @@ describe("CodeIndexManager - handleExternalSettingsChange regression", () => {
 
 			// Verify that the restart sequence was called
 			expect(mockConfigManager.loadConfiguration).toHaveBeenCalled()
-			expect(stopWatcherSpy).toHaveBeenCalled()
+			expect(recreateServicesSpy).toHaveBeenCalled()
 			expect(startIndexingSpy).toHaveBeenCalled()
 		})
 


### PR DESCRIPTION
### Related GitHub Issue

Resolve: [#814](https://github.com/Kilo-Org/kilocode/issues/814)

### Description

The code index manager it's not refreshing the configuration automatically causing frustration to the user don't know why it's not connecting correctly 

This PR ensures that CodeIndex services are automatically recreated whenever relevant configurations change, improving connection reliability.

- Extracted service recreation logic into a private helper _recreateServices
- Replaced inline recreation in both initialization and external settings change handlers with the new helper

### Test Procedure

- Configure the Code Index Qdrant with a wrong url
- Save
- This should be show an connection error msg
- Update the config with a valid url
- Save
- Now should connect correctly

### Pre-Submission Checklist

- [X] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [X] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [X] **Self-Review**: I have performed a thorough self-review of my code.
- [X] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [X] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [X] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

![image](https://github.com/user-attachments/assets/a15e3fe7-373e-4337-b528-f96b6dfcc579)

### Documentation Updates

Does this PR necessitate updates to user-facing documentation?
- [X] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs 

### Additional Notes

-

### Get in Touch

Discord: catrielmuller

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces `_recreateServices()` in `manager.ts` to handle service recreation on configuration changes, updating `initialize()` and `handleExternalSettingsChange()` methods, and modifies tests accordingly.
> 
>   - **Behavior**:
>     - Introduces `_recreateServices()` in `manager.ts` to handle service recreation on configuration changes.
>     - Replaces inline service recreation logic in `initialize()` and `handleExternalSettingsChange()` with `_recreateServices()`.
>   - **Tests**:
>     - Updates `manager.spec.ts` to mock `_recreateServices()` and verify its invocation during configuration changes.
>     - Ensures `handleExternalSettingsChange()` does not throw errors when manager is uninitialized or config manager is unset.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 48043aa1e09c5c8e493d3cbb4a50e5a4ff03a8da. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->