### PR TITLE
fix typescript compiler watch path inconsistency

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -348,7 +348,7 @@
 		"vsix": "mkdirp ../bin && vsce package --no-dependencies --out ../bin",
 		"publish:marketplace": "vsce publish --no-dependencies && ovsx publish --no-dependencies",
 		"watch:bundle": "pnpm bundle --watch",
-		"watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
+		"watch:tsc": "cd .. && tsc --noEmit --watch --project src/tsconfig.json",
 		"clean": "rimraf README.md CHANGELOG.md LICENSE dist mock .turbo"
 	},
 	"dependencies": {

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -13,7 +13,6 @@
 		"noImplicitReturns": true,
 		"noUnusedLocals": false,
 		"resolveJsonModule": true,
-		"rootDir": ".",
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,


### PR DESCRIPTION
### Related GitHub Issue

Closes: #5133 

### Description

Fixes TypeScript compiler watch mode reporting incorrect file paths without the `src/` prefix, which prevented VS Code from properly navigating to error locations.

**Before:**
- Error paths: `core/webview/webviewMessageHandler.ts:439:7`
- VS Code navigation: ❌ Broken

**After:**  
- Error paths: `src/core/webview/webviewMessageHandler.ts:439:7`
- VS Code navigation: ✅ Working

## Changes Made

- **Removed `rootDir: "."` from `src/tsconfig.json`**
  - The watch script already runs from project root (`cd .. && tsc --noEmit --watch --project src/tsconfig.json`)
  - Removing explicit `rootDir` allows TypeScript to use default behavior and include `src/` in error paths

### Test Procedure

- Manually produced a forced compile error before and after the change
- All lint checks and automatic tests pass successfully

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [ ] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [x] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->

### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->
Discord username is `gooner4ever`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes TypeScript compiler watch mode path inconsistency by removing `rootDir` from `tsconfig.json`, enabling correct VS Code navigation.
> 
>   - **Behavior**:
>     - Fixes TypeScript compiler watch mode path inconsistency by removing `rootDir: "."` from `src/tsconfig.json`.
>     - Error paths now include `src/` prefix, enabling correct VS Code navigation.
>   - **Scripts**:
>     - Updates `watch:tsc` script in `package.json` to run from project root (`cd .. && tsc --noEmit --watch --project src/tsconfig.json`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 994c206686d091b594c179c2805b207081d6c245. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->