### PR TITLE
fix: eliminate XSS vulnerability in CodeBlock component

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -958,6 +958,9 @@ importers:
       fzf:
         specifier: ^0.5.2
         version: 0.5.2
+      hast-util-to-jsx-runtime:
+        specifier: ^2.3.6
+        version: 2.3.6
       i18next:
         specifier: ^25.0.0
         version: 25.2.1(typescript@5.8.3)

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -42,6 +42,7 @@
 		"debounce": "^2.1.1",
 		"fast-deep-equal": "^3.1.3",
 		"fzf": "^0.5.2",
+		"hast-util-to-jsx-runtime": "^2.3.6",
 		"i18next": "^25.0.0",
 		"i18next-http-backend": "^3.0.2",
 		"katex": "^0.16.11",


### PR DESCRIPTION
This PR addresses a cross-site scripting (XSS) vulnerability in the CodeBlock component identified by CodeQL.

## Context

The CodeBlock component was using `dangerouslySetInnerHTML` to render syntax-highlighted code from Shiki, which posed a security risk.

## Implementation

The fix replaces `dangerouslySetInnerHTML` with a safer approach using `codeToHast` and direct React element rendering:

1. Added `hast-util-to-jsx-runtime` dependency
2. Modified the syntax highlighting logic to use `codeToHast` instead of `codeToHtml`
3. Updated the `MemoizedCodeContent` component to render React elements directly
4. Changed the state type from `string` to `React.ReactNode`

## Security Considerations

- Eliminates potential for HTML injection attacks
- Maintains all syntax highlighting capabilities
- Preserves exact visual output

## Performance Considerations

- Direct React element creation is more efficient than HTML parsing
- No browser HTML parsing overhead
- Memoization pattern preserved for optimal rendering

## How to Test

1. Open any code sample in the chat
2. Verify syntax highlighting works correctly
3. Test word wrap and collapse functionality
4. Ensure copy code functionality works

This issue was discovered as part of security review #3785.

Fixes #5156