### PR TITLE
chore: add changeset for v3.22.1 patch release

### DIFF
--- a/.changeset/v3.22.1.md
+++ b/.changeset/v3.22.1.md
@@ -2,9 +2,8 @@
 "roo-cline": patch
 ---
 
+- Add Gemini CLI provider for free access to Gemini models (thanks Cline!)
 - Fix undefined mcp command (thanks @qdaxb!)
-- Fix: standardize tooltip delays to 300ms (thanks @hannesrudolph!)
 - Use upstream_inference_cost for OpenRouter BYOK cost calculation and show cached token count (thanks @chrarnoldus!)
-- Add Gemini CLI provider for free access to Gemini models (thanks @hannesrudolph!)
 - Update maxTokens value for qwen/qwen3-32b model on Groq (thanks @KanTakahiro!)
-- Track mode selector opened in telemetry (thanks @mrubens!)
+- Standardize tooltip delays to 300ms

--- a/.changeset/v3.22.1.md
+++ b/.changeset/v3.22.1.md
@@ -1,0 +1,10 @@
+---
+"roo-cline": patch
+---
+
+- Fix undefined mcp command (thanks @qdaxb!)
+- Fix: standardize tooltip delays to 300ms (thanks @hannesrudolph!)
+- Use upstream_inference_cost for OpenRouter BYOK cost calculation and show cached token count (thanks @chrarnoldus!)
+- Add Gemini CLI provider for free access to Gemini models (thanks @hannesrudolph!)
+- Update maxTokens value for qwen/qwen3-32b model on Groq (thanks @KanTakahiro!)
+- Track mode selector opened in telemetry (thanks @mrubens!)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add changeset for v3.22.1 patch release with bug fixes, improvements, and new features.
> 
>   - **Bug Fixes**:
>     - Fix undefined `mcp` command.
>     - Standardize tooltip delays to 300ms.
>   - **Improvements**:
>     - Use `upstream_inference_cost` for OpenRouter BYOK cost calculation and show cached token count.
>     - Update `maxTokens` value for `qwen/qwen3-32b` model on Groq.
>   - **Features**:
>     - Add Gemini CLI provider for free access to Gemini models.
>     - Track mode selector opened in telemetry.
>   - **Misc**:
>     - New changeset file `.changeset/v3.22.1.md` added for patch release documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 278cefaa08da51f64c40ab91b4c9ad248364bdaa. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->