### PR TITLE
fix: cap API retry exponential backoff at 10 minutes

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1792,7 +1792,7 @@ export class Task extends EventEmitter<ClineEvents> {
 				}
 
 				const baseDelay = requestDelaySeconds || 5
-				let exponentialDelay = Math.ceil(baseDelay * Math.pow(2, retryAttempt))
+				let exponentialDelay = Math.min(Math.ceil(baseDelay * Math.pow(2, retryAttempt)), 600) // Cap at 10 minutes
 
 				// If the error is a 429, and the error details contain a retry delay, use that delay instead of exponential backoff
 				if (error.status === 429) {

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -86,6 +86,9 @@ import { ApiMessage } from "../task-persistence/apiMessages"
 import { getMessagesSinceLastSummary, summarizeConversation } from "../condense"
 import { maybeRemoveImageBlocks } from "../../api/transform/image-cleaning"
 
+// Constants
+const MAX_EXPONENTIAL_BACKOFF_SECONDS = 600 // 10 minutes
+
 export type ClineEvents = {
 	message: [{ action: "created" | "updated"; message: ClineMessage }]
 	taskStarted: []
@@ -1792,7 +1795,10 @@ export class Task extends EventEmitter<ClineEvents> {
 				}
 
 				const baseDelay = requestDelaySeconds || 5
-				let exponentialDelay = Math.min(Math.ceil(baseDelay * Math.pow(2, retryAttempt)), 600) // Cap at 10 minutes
+				let exponentialDelay = Math.min(
+					Math.ceil(baseDelay * Math.pow(2, retryAttempt)),
+					MAX_EXPONENTIAL_BACKOFF_SECONDS,
+				)
 
 				// If the error is a 429, and the error details contain a retry delay, use that delay instead of exponential backoff
 				if (error.status === 429) {


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #2724 

### Description

fix: cap API retry exponential backoff at 10 minutes maximum

Files affected:
- src/core/task/Task.ts

Issue:
Auto-retry feature with exponential backoff was causing excessive delays
that could reach multiple hours (e.g., 7168 seconds ≈ 2 hours) when API
requests repeatedly failed. This particularly affected users working with
frequently overloaded models like Gemini 2.0 Thinking that return 503
"model overloaded" errors.

Root cause:
The retry logic used unbounded exponential backoff with formula:
`baseDelay * 2^retryAttempt`. With a 7-second base delay, this resulted
in delays growing as: 7s → 14s → 28s → 56s → ... → 7168s after 11 failures.

Solution:
Added Math.min() cap of 600 seconds (10 minutes) to the exponential delay
calculation. This preserves the benefits of exponential backoff for
transient errors while preventing excessive delays that could abandon
long-running tasks.

Impact:
- Maintains exponential backoff benefits for short-term outages
- Prevents "all night prompts" from getting stuck for hours
- Only affects auto-retry with alwaysApproveResubmit enabled
- Does not impact 429 rate-limit handling or manual retry flows

### Test Procedure

- Set a AI profile config with an invalid URL (can be something random like "aisdaujdshfjgsd.com")
- Set auto-approve retry
- Check if the retry time goes to at most 10 minutes. The logic that was implemented before doubled the time after every retry, I set a hard cap to at most 10 minutes.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [X] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [X] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [X] **Self-Review**: I have performed a thorough self-review of my code.
- [X] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [X] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [X] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [X] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

### Additional Notes

Should I set a configuration for the max delay time? Or change the limit for something other than 10 minutes?

### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Caps API retry exponential backoff at 10 minutes in `Task.ts` to prevent excessive delays.
> 
>   - **Behavior**:
>     - Caps exponential backoff for API retries at 600 seconds (10 minutes) in `Task.ts`.
>     - Affects auto-retry logic with `alwaysApproveResubmit` enabled.
>   - **Logic**:
>     - Uses `Math.min()` to limit delay calculation in `attemptApiRequest()`.
>     - Does not affect 429 rate-limit handling or manual retries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3c1a46f0db7b97c5a2db4d1f8af4213c94df28cf. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->