### PR TITLE
Add default project name field to gemini-cli settings

### DIFF
--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -161,6 +161,7 @@ const geminiSchema = apiModelIdProviderModelSchema.extend({
 
 const geminiCliSchema = apiModelIdProviderModelSchema.extend({
 	geminiCliOAuthPath: z.string().optional(),
+	geminiCliDefaultProject: z.string().optional(),
 	geminiCliProjectId: z.string().optional(),
 })
 

--- a/src/api/providers/gemini-cli.ts
+++ b/src/api/providers/gemini-cli.ts
@@ -140,7 +140,7 @@ export class GeminiCliHandler extends BaseProvider implements SingleCompletionHa
 		}
 
 		// Start with a default project ID (can be anything for personal OAuth)
-		const initialProjectId = this.options.geminiCliDefaultProject
+		const initialProjectId = this.options.geminiCliDefaultProject || "default"
 
 		// Prepare client metadata
 		const clientMetadata = {

--- a/src/api/providers/gemini-cli.ts
+++ b/src/api/providers/gemini-cli.ts
@@ -140,7 +140,7 @@ export class GeminiCliHandler extends BaseProvider implements SingleCompletionHa
 		}
 
 		// Start with a default project ID (can be anything for personal OAuth)
-		const initialProjectId = "default"
+		const initialProjectId = this.options.geminiCliDefaultProject
 
 		// Prepare client metadata
 		const clientMetadata = {

--- a/webview-ui/src/components/settings/providers/GeminiCli.tsx
+++ b/webview-ui/src/components/settings/providers/GeminiCli.tsx
@@ -40,6 +40,18 @@ export const GeminiCli = ({ apiConfiguration, setApiConfigurationField }: Gemini
 				{t("settings:providers.geminiCli.oauthPathDescription")}
 			</div>
 
+			<VSCodeTextField
+				value={apiConfiguration?.geminiCliDefaultProject || ""}
+				onInput={handleInputChange("geminiCliDefaultProject")}
+				placeholder="default"
+				className="w-full">
+				<label className="block font-medium mb-1">{t("settings:providers.geminiCli.defaultProject")}</label>
+			</VSCodeTextField>
+
+			<div className="text-sm text-vscode-descriptionForeground -mt-2">
+				{t("settings:providers.geminiCli.defaultProjectDescription")}
+			</div>
+
 			<div className="text-sm text-vscode-descriptionForeground mt-3">
 				{t("settings:providers.geminiCli.description")}
 			</div>

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -311,6 +311,8 @@
 		},
 		"geminiCli": {
 			"description": "This provider uses OAuth authentication from the Gemini CLI tool and does not require API keys.",
+			"defaultProject": "Default Project (optional)",
+			"defaultProjectDescription": "Default Google Cloud Project Name (For paid Gemini Code Assist tiers, see https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/authentication.md)",
 			"oauthPath": "OAuth Credentials Path (optional)",
 			"oauthPathDescription": "Path to the OAuth credentials file. Leave empty to use the default location (~/.gemini/oauth_creds.json).",
 			"instructions": "If you haven't authenticated yet, please run",


### PR DESCRIPTION
### Related GitHub Issue

Closes: #5177 

### Description

This adds the default project name as a user-customizable field in settings. If this is set by the user the user will be able to use paid tiers of Gemini Code Assist,.

### Test Procedure

I have a 'Standard' tier gemini code assist plan on a personal account. Without this set I am unable to make any requests from the account like how an unlicensed account can, every request gives a 403 and says it is not using a valid project. Once I set a project name that has a Google Gemini Code Assist Standard license applied in the field it then works.

### Pre-Submission Checklist


- [X] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [X] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [X] **Self-Review**: I have performed a thorough self-review of my code.
- [X] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [X] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [X] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

![image](https://github.com/user-attachments/assets/dc1b77b7-203f-491e-ab5c-bff4ef32b59f)


### Documentation Updates

- [X] No documentation updates are required.

### Additional Notes


### Get in Touch

netham45

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `geminiCliDefaultProject` field to Gemini CLI settings for user-customizable default project name.
> 
>   - **Behavior**:
>     - Adds `geminiCliDefaultProject` field to `geminiCliSchema` in `provider-settings.ts` for user-customizable default project name.
>     - Updates `GeminiCliHandler` in `gemini-cli.ts` to use `geminiCliDefaultProject` as initial project ID.
>   - **UI**:
>     - Adds input field for `geminiCliDefaultProject` in `GeminiCli.tsx`.
>   - **i18n**:
>     - Adds `defaultProject` and `defaultProjectDescription` translations in `settings.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 34a4e2e3d4dfe330dc7d428571d03e2fa53b94fb. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->