### PR TITLE
feat: enhance MCP tool response handling to support image responses

### DIFF
--- a/src/core/prompts/responses.ts
+++ b/src/core/prompts/responses.ts
@@ -77,10 +77,16 @@ Otherwise, if you have not completed the task and do not need additional informa
 		images?: string[],
 	): string | Array<Anthropic.TextBlockParam | Anthropic.ImageBlockParam> => {
 		if (images && images.length > 0) {
-			const textBlock: Anthropic.TextBlockParam = { type: "text", text }
 			const imageBlocks: Anthropic.ImageBlockParam[] = formatImagesIntoBlocks(images)
-			// Placing images after text leads to better results
-			return [textBlock, ...imageBlocks]
+
+			if (text.trim()) {
+				const textBlock: Anthropic.TextBlockParam = { type: "text", text }
+				// Placing images after text leads to better results
+				return [textBlock, ...imageBlocks]
+			} else {
+				// For image-only responses, return only image blocks
+				return imageBlocks
+			}
 		} else {
 			return text
 		}

--- a/src/shared/__tests__/combineCommandSequences.spec.ts
+++ b/src/shared/__tests__/combineCommandSequences.spec.ts
@@ -89,6 +89,48 @@ describe("combineCommandSequences", () => {
 			})
 		})
 
+		it("should preserve images from mcp_server_response messages", () => {
+			const messages: ClineMessage[] = [
+				{
+					type: "ask",
+					ask: "use_mcp_server",
+					text: JSON.stringify({
+						serverName: "test-server",
+						toolName: "test-tool",
+						arguments: { param: "value" },
+					}),
+					ts: 1625097600000,
+				},
+				{
+					type: "say",
+					say: "mcp_server_response",
+					text: "Generated 1 image",
+					images: [
+						"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChAI9jU",
+					],
+					ts: 1625097601000,
+				},
+			]
+
+			const result = combineCommandSequences(messages)
+
+			expect(result).toHaveLength(1)
+			expect(result[0]).toEqual({
+				type: "ask",
+				ask: "use_mcp_server",
+				text: JSON.stringify({
+					serverName: "test-server",
+					toolName: "test-tool",
+					arguments: { param: "value" },
+					response: "Generated 1 image",
+				}),
+				images: [
+					"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChAI9jU",
+				],
+				ts: 1625097600000,
+			})
+		})
+
 		it("should handle multiple MCP server requests", () => {
 			const messages: ClineMessage[] = [
 				{

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1176,6 +1176,7 @@ export const ChatRowContent = ({
 										server={server}
 										useMcpServer={useMcpServer}
 										alwaysAllowMcp={alwaysAllowMcp}
+										images={message.images}
 									/>
 								)}
 							</div>

--- a/webview-ui/src/components/chat/McpExecution.tsx
+++ b/webview-ui/src/components/chat/McpExecution.tsx
@@ -10,6 +10,7 @@ import { cn } from "@src/lib/utils"
 import { Button } from "@src/components/ui"
 import CodeBlock from "../common/CodeBlock"
 import McpToolRow from "../mcp/McpToolRow"
+import Thumbnails from "../common/Thumbnails"
 import { Markdown } from "./Markdown"
 
 interface McpExecutionProps {
@@ -28,6 +29,7 @@ interface McpExecutionProps {
 	}
 	useMcpServer?: ClineAskUseMcpServer
 	alwaysAllowMcp?: boolean
+	images?: string[]
 }
 
 export const McpExecution = ({
@@ -39,6 +41,7 @@ export const McpExecution = ({
 	server,
 	useMcpServer,
 	alwaysAllowMcp = false,
+	images,
 }: McpExecutionProps) => {
 	const { t } = useTranslation("mcp")
 
@@ -212,15 +215,23 @@ export const McpExecution = ({
 								)}
 							</div>
 						)}
-						{responseText && responseText.length > 0 && (
-							<Button variant="ghost" size="icon" onClick={onToggleResponseExpand}>
-								<ChevronDown
-									className={cn("size-4 transition-transform duration-300", {
-										"rotate-180": isResponseExpanded,
-									})}
-								/>
-							</Button>
-						)}
+						{(responseText && responseText.length > 0) || (images && images.length > 0) ? (
+							<div className="flex items-center gap-1">
+								{images && images.length > 0 && (
+									<div className="flex items-center gap-1 text-xs text-vscode-descriptionForeground">
+										<span className="codicon codicon-file-media" />
+										<span>{images.length}</span>
+									</div>
+								)}
+								<Button variant="ghost" size="icon" onClick={onToggleResponseExpand}>
+									<ChevronDown
+										className={cn("size-4 transition-transform duration-300", {
+											"rotate-180": isResponseExpanded,
+										})}
+									/>
+								</Button>
+							</div>
+						) : null}
 					</div>
 				</div>
 			</div>
@@ -280,6 +291,7 @@ export const McpExecution = ({
 					isJson={responseIsJson}
 					hasArguments={!!(isArguments || useMcpServer?.arguments || argumentsText)}
 					isPartial={status ? status.status !== "completed" : false}
+					images={images}
 				/>
 			</div>
 		</>
@@ -294,15 +306,17 @@ const ResponseContainerInternal = ({
 	isJson,
 	hasArguments,
 	isPartial = false,
+	images,
 }: {
 	isExpanded: boolean
 	response: string
 	isJson: boolean
 	hasArguments?: boolean
 	isPartial?: boolean
+	images?: string[]
 }) => {
 	// Only render content when expanded to prevent performance issues with large responses
-	if (!isExpanded || response.length === 0) {
+	if (!isExpanded || (response.length === 0 && (!images || images.length === 0))) {
 		return (
 			<div
 				className={cn("overflow-hidden", {
@@ -312,17 +326,25 @@ const ResponseContainerInternal = ({
 		)
 	}
 
+	const shouldShowText = response.trim()
+
 	return (
 		<div
 			className={cn("overflow-hidden", {
 				"max-h-96 overflow-y-auto mt-1 pt-1 border-t border-border/25": hasArguments,
 				"max-h-96 overflow-y-auto mt-1 pt-1": !hasArguments,
 			})}>
-			{isJson ? (
-				<CodeBlock source={response} language="json" />
-			) : (
-				<Markdown markdown={response} partial={isPartial} />
+			{images && images.length > 0 && (
+				<div className="mb-2">
+					<Thumbnails images={images} />
+				</div>
 			)}
+			{shouldShowText &&
+				(isJson ? (
+					<CodeBlock source={response} language="json" />
+				) : (
+					<Markdown markdown={response} partial={isPartial} />
+				))}
 		</div>
 	)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->
I couldn't find an approved issue related to this. 

### Description

This PR enhances MCP (Model Context Protocol) tool response handling to support images alongside text content. The implementation allows MCP servers to return images in their tool responses, which are then properly displayed in the Roo Code UI.

**Key implementation details:**
- Modified [`processToolContent()`](src/core/tools/useMcpToolTool.ts) to extract and return both text and images from MCP tool results
- Updated [`executeToolAndProcessResult()`](src/core/tools/useMcpToolTool.ts) to handle image data and pass it through the response pipeline
- Enhanced [`combineCommandSequences()`](src/shared/combineCommandSequences.ts) to preserve images from MCP server responses during command sequence processing
- Updated UI components ([`McpExecution.tsx`](webview-ui/src/components/chat/McpExecution.tsx) and [`ChatRow.tsx`](webview-ui/src/components/chat/ChatRow.tsx)) to render images alongside text responses

**Design choices:**
- Images are handled as part of the tool result structure, maintaining backward compatibility with text-only responses
- The implementation supports both text-only, image-only, and combined text+image responses from MCP tools

### Test Procedure

**Unit Tests Added:**
- Added comprehensive tests in [`useMcpToolTool.spec.ts`](src/core/tools/__tests__/useMcpToolTool.spec.ts) to verify:
  - Correct extraction of both text and images from tool results
  - Proper handling of image-only responses
  - Backward compatibility with text-only responses
- Updated tests in [`combineCommandSequences.spec.ts`](src/shared/__tests__/combineCommandSequences.spec.ts) to ensure images are preserved during command sequence processing

**Manual Testing:**
1. Connect to an MCP server that supports image responses (e.g., browser MCP server with screenshot capability)
2. Execute a tool that returns images (e.g., take a screenshot)
3. Verify that both text and images are displayed correctly in the chat interface
4. Test with various MCP tools to ensure backward compatibility with text-only responses

**Reviewers can test by:**
1. Running the test suite: `npm test -- useMcpToolTool.spec.ts`
2. Setting up an MCP server with image capabilities and testing the integration manually

### Pre-Submission Checklist

- [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [ ] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->

**Before:** MCP tool responses only displayed text content, images were not supported.
![Screenshot 2025-06-27 at 2 32 26 PM](https://github.com/user-attachments/assets/993a6a32-3ddb-4b10-8d77-1df7fe99fbea)


**After:** MCP tool responses now display both text and images seamlessly in the chat interface.
`codicon-file-media` indicates if images are present in mcp response and the number of images.
![Screenshot 2025-06-27 at 2 18 30 PM](https://github.com/user-attachments/assets/da4c2063-1c91-4c4b-97d8-e54d7bb501d4)
Images are presented using the `Thumbnail` component inside `mcp-server-response` block.
![Screenshot 2025-06-27 at 2 19 29 PM](https://github.com/user-attachments/assets/8db7a8a5-9edf-41a2-8eb7-45ea4f0a75cd)

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

- [ ] No documentation updates are required.
- [x] Yes, documentation updates are required. The MCP integration documentation should be updated to mention image support capabilities for tool responses.

### Additional Notes

- This enhancement maintains full backward compatibility with existing MCP servers that only return text
- The implementation follows the existing patterns for handling MCP tool responses
- Images are processed and displayed using the same infrastructure as other image content in Roo Code

### Improvements
Old chat loaded from memory show tool call argument inside the response.
![Screenshot 2025-06-27 at 2 19 44 PM](https://github.com/user-attachments/assets/63f1de24-73cd-4737-9b41-25c6cc47b22b)
