### PR TITLE
fix: resolve E2BIG error by passing large prompts via stdin to Claude CLI

### DIFF
--- a/src/integrations/claude-code/__tests__/run.spec.ts
+++ b/src/integrations/claude-code/__tests__/run.spec.ts
@@ -13,9 +13,80 @@ vi.mock("vscode", () => ({
 	},
 }))
 
+// Mock execa to test stdin behavior
+const mockExeca = vi.fn()
+const mockStdin = {
+	write: vi.fn(),
+	end: vi.fn(),
+}
+
+// Mock process that simulates successful execution
+const createMockProcess = () => {
+	let resolveProcess: (value: { exitCode: number }) => void
+	const processPromise = new Promise<{ exitCode: number }>((resolve) => {
+		resolveProcess = resolve
+	})
+
+	const mockProcess = {
+		stdin: mockStdin,
+		stdout: {
+			on: vi.fn(),
+		},
+		stderr: {
+			on: vi.fn((event, callback) => {
+				// Don't emit any stderr data in tests
+			}),
+		},
+		on: vi.fn((event, callback) => {
+			if (event === "close") {
+				// Simulate successful process completion after a short delay
+				setTimeout(() => {
+					callback(0)
+					resolveProcess({ exitCode: 0 })
+				}, 10)
+			}
+			if (event === "error") {
+				// Don't emit any errors in tests
+			}
+		}),
+		killed: false,
+		kill: vi.fn(),
+		then: processPromise.then.bind(processPromise),
+		catch: processPromise.catch.bind(processPromise),
+		finally: processPromise.finally.bind(processPromise),
+	}
+	return mockProcess
+}
+
+vi.mock("execa", () => ({
+	execa: mockExeca,
+}))
+
+// Mock readline with proper interface simulation
+let mockReadlineInterface: any = null
+
+vi.mock("readline", () => ({
+	default: {
+		createInterface: vi.fn(() => {
+			mockReadlineInterface = {
+				async *[Symbol.asyncIterator]() {
+					// Simulate Claude CLI JSON output
+					yield '{"type":"text","text":"Hello"}'
+					yield '{"type":"text","text":" world"}'
+					// Simulate end of stream - must return to terminate the iterator
+					return
+				},
+				close: vi.fn(),
+			}
+			return mockReadlineInterface
+		}),
+	},
+}))
+
 describe("runClaudeCode", () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
+		mockExeca.mockReturnValue(createMockProcess())
 	})
 
 	test("should export runClaudeCode function", async () => {
@@ -33,5 +104,100 @@ describe("runClaudeCode", () => {
 		const result = runClaudeCode(options)
 		expect(Symbol.asyncIterator in result).toBe(true)
 		expect(typeof result[Symbol.asyncIterator]).toBe("function")
+	})
+
+	test("should use stdin instead of command line arguments for messages", async () => {
+		const { runClaudeCode } = await import("../run")
+		const messages = [{ role: "user" as const, content: "Hello world!" }]
+		const options = {
+			systemPrompt: "You are a helpful assistant",
+			messages,
+		}
+
+		const generator = runClaudeCode(options)
+
+		// Consume the generator to completion
+		const results = []
+		for await (const chunk of generator) {
+			results.push(chunk)
+		}
+
+		// Verify execa was called with correct arguments (no JSON.stringify(messages) in args)
+		expect(mockExeca).toHaveBeenCalledWith(
+			"claude",
+			expect.arrayContaining([
+				"-p",
+				"--input-format",
+				"text",
+				"--system-prompt",
+				"You are a helpful assistant",
+				"--verbose",
+				"--output-format",
+				"stream-json",
+				"--disallowedTools",
+				expect.any(String),
+				"--max-turns",
+				"1",
+			]),
+			expect.objectContaining({
+				stdin: "pipe",
+				stdout: "pipe",
+				stderr: "pipe",
+			}),
+		)
+
+		// Verify the arguments do NOT contain the stringified messages
+		const [, args] = mockExeca.mock.calls[0]
+		expect(args).not.toContain(JSON.stringify(messages))
+
+		// Verify messages were written to stdin
+		expect(mockStdin.write).toHaveBeenCalledWith(JSON.stringify(messages), "utf8")
+		expect(mockStdin.end).toHaveBeenCalled()
+
+		// Verify we got the expected mock output
+		expect(results).toHaveLength(2)
+		expect(results[0]).toEqual({ type: "text", text: "Hello" })
+		expect(results[1]).toEqual({ type: "text", text: " world" })
+	})
+
+	test("should include model parameter when provided", async () => {
+		const { runClaudeCode } = await import("../run")
+		const options = {
+			systemPrompt: "You are a helpful assistant",
+			messages: [{ role: "user" as const, content: "Hello" }],
+			modelId: "claude-3-5-sonnet-20241022",
+		}
+
+		const generator = runClaudeCode(options)
+
+		// Consume at least one item to trigger process spawn
+		await generator.next()
+
+		// Clean up the generator
+		await generator.return(undefined)
+
+		const [, args] = mockExeca.mock.calls[0]
+		expect(args).toContain("--model")
+		expect(args).toContain("claude-3-5-sonnet-20241022")
+	})
+
+	test("should use custom claude path when provided", async () => {
+		const { runClaudeCode } = await import("../run")
+		const options = {
+			systemPrompt: "You are a helpful assistant",
+			messages: [{ role: "user" as const, content: "Hello" }],
+			path: "/custom/path/to/claude",
+		}
+
+		const generator = runClaudeCode(options)
+
+		// Consume at least one item to trigger process spawn
+		await generator.next()
+
+		// Clean up the generator
+		await generator.return(undefined)
+
+		const [claudePath] = mockExeca.mock.calls[0]
+		expect(claudePath).toBe("/custom/path/to/claude")
 	})
 })


### PR DESCRIPTION
# fix: resolve E2BIG error by passing large prompts via stdin to Claude CLI

- Pass messages via stdin instead of command line arguments to avoid Linux argument length limits
- Add --input-format text flag to claude CLI command
- Update execa configuration to use stdin pipe
- Fix corresponding unit tests with proper async iterator mocking
- Resolves spawn E2BIG errors when using very large conversation histories

<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #5064  <!-- Replace with the issue number, e.g., Closes: #123 -->
<!-- Note: This PR addresses user-reported E2BIG errors when using Claude CLI with large prompts. A GitHub issue should be created to track this bug report. -->

### Description

This PR fixes the `spawn E2BIG` error that occurs when users interact with Claude CLI through Roo Code with large conversation histories or extensive context. The error happens because Linux imposes a per-argument limit (~128 KiB) on command-line arguments passed to `execve()` system calls.

**Key implementation details:**
- **Modified `src/integrations/claude-code/run.ts`**: Replaced command-line argument passing with stdin streaming for large message payloads
- **Enhanced test coverage in `src/integrations/claude-code/__tests__/run.spec.ts`**: Fixed async iterator mocking to properly test stdin functionality
- **Backward compatibility**: Maintains all existing functionality

**Technical approach:**
- Removed `JSON.stringify(messages)` from args array to avoid argument length limits
- Added `--input-format text` flag to enable stdin message reading
- Configured `execa` with `stdin: "pipe"` and stream messages as JSON
- Ensured proper stdin termination with `child.stdin.end()`

### Test Procedure

**Unit Testing:**
1. Run tests from the `src/` directory: `cd src && npm test src/integrations/claude-code/__tests__/run.spec.ts`
2. Verify all 5 tests pass, including the new stdin functionality test
3. Confirm no regressions in existing Claude CLI integration behavior

**Manual Testing (if accessible):**
1. Use Roo Code with a very large conversation history (>100KB of messages)
2. Attempt to interact with Claude CLI 
3. Verify no `spawn E2BIG` errors occur
4. Confirm normal Claude CLI responses are received

**Environment Requirements:**
- Linux environment (where E2BIG errors are most common)

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Documentation Updates

- [x] No documentation updates are required.

This is an internal bug fix that doesn't change user-facing APIs or require documentation updates. The fix is transparent to end users.

### Additional Notes

- **Performance**: Stdin streaming may have slightly better memory characteristics for very large prompts compared to command-line arguments
- **Compatibility**: The change is backward compatible and doesn't affect any existing functionality

### Get in Touch

@fovty
<!-- Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR -->
