### PR TITLE
fix(i18n): correct gemini cli error translation paths

### DIFF
--- a/src/i18n/locales/ca/common.json
+++ b/src/i18n/locales/ca/common.json
@@ -73,6 +73,16 @@
 			"processExitedWithError": "El procés Claude Code ha sortit amb codi {{exitCode}}. Sortida d'error: {{output}}",
 			"stoppedWithReason": "Claude Code s'ha aturat per la raó: {{reason}}",
 			"apiKeyModelPlanMismatch": "Les claus API i els plans de subscripció permeten models diferents. Assegura't que el model seleccionat estigui inclòs al teu pla."
+		},
+		"geminiCli": {
+			"oauthLoadFailed": "No s'han pogut carregar les credencials OAuth. Si us plau, autentica't primer: {{error}}",
+			"tokenRefreshFailed": "No s'ha pogut actualitzar el token OAuth: {{error}}",
+			"onboardingTimeout": "L'operació d'onboarding ha esgotat el temps després de 60 segons. Si us plau, torna-ho a provar més tard.",
+			"projectDiscoveryFailed": "No s'ha pogut descobrir l'ID del projecte. Assegura't d'estar autenticat amb 'gemini auth'.",
+			"rateLimitExceeded": "S'ha superat el límit de velocitat. S'han assolit els límits del nivell gratuït.",
+			"badRequest": "Sol·licitud incorrecta: {{details}}",
+			"apiError": "Error de l'API Gemini CLI: {{error}}",
+			"completionError": "Error de compleció de Gemini CLI: {{error}}"
 		}
 	},
 	"warnings": {
@@ -139,16 +149,6 @@
 			"cloud_auth_required": "La teva organització requereix autenticació de Roo Code Cloud. Si us plau, inicia sessió per continuar.",
 			"organization_mismatch": "Has d'estar autenticat amb el compte de Roo Code Cloud de la teva organització.",
 			"verification_failed": "No s'ha pogut verificar l'autenticació de l'organització."
-		},
-		"geminiCli": {
-			"oauthLoadFailed": "No s'han pogut carregar les credencials OAuth. Si us plau, autentica't primer: {{error}}",
-			"tokenRefreshFailed": "No s'ha pogut actualitzar el token OAuth: {{error}}",
-			"onboardingTimeout": "L'operació d'onboarding ha esgotat el temps després de 60 segons. Si us plau, torna-ho a provar més tard.",
-			"projectDiscoveryFailed": "No s'ha pogut descobrir l'ID del projecte. Assegura't d'estar autenticat amb 'gemini auth'.",
-			"rateLimitExceeded": "S'ha superat el límit de velocitat. S'han assolit els límits del nivell gratuït.",
-			"badRequest": "Sol·licitud incorrecta: {{details}}",
-			"apiError": "Error de l'API Gemini CLI: {{error}}",
-			"completionError": "Error de compleció de Gemini CLI: {{error}}"
 		}
 	}
 }

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -69,6 +69,16 @@
 			"processExitedWithError": "Claude Code Prozess wurde mit Code {{exitCode}} beendet. Fehlerausgabe: {{output}}",
 			"stoppedWithReason": "Claude Code wurde mit Grund gestoppt: {{reason}}",
 			"apiKeyModelPlanMismatch": "API-Schlüssel und Abonnement-Pläne erlauben verschiedene Modelle. Stelle sicher, dass das ausgewählte Modell in deinem Plan enthalten ist."
+		},
+		"geminiCli": {
+			"oauthLoadFailed": "Fehler beim Laden der OAuth-Anmeldedaten. Bitte authentifiziere dich zuerst: {{error}}",
+			"tokenRefreshFailed": "Fehler beim Aktualisieren des OAuth-Tokens: {{error}}",
+			"onboardingTimeout": "Onboarding-Vorgang nach 60 Sekunden abgebrochen. Bitte versuche es später erneut.",
+			"projectDiscoveryFailed": "Projekt-ID konnte nicht ermittelt werden. Stelle sicher, dass du mit 'gemini auth' authentifiziert bist.",
+			"rateLimitExceeded": "Anfragenlimit überschritten. Die Limits des kostenlosen Tarifs wurden erreicht.",
+			"badRequest": "Ungültige Anfrage: {{details}}",
+			"apiError": "Gemini CLI API-Fehler: {{error}}",
+			"completionError": "Gemini CLI Vervollständigungsfehler: {{error}}"
 		}
 	},
 	"warnings": {
@@ -139,16 +149,6 @@
 			"cloud_auth_required": "Deine Organisation erfordert eine Roo Code Cloud-Authentifizierung. Bitte melde dich an, um fortzufahren.",
 			"organization_mismatch": "Du musst mit dem Roo Code Cloud-Konto deiner Organisation authentifiziert sein.",
 			"verification_failed": "Die Organisationsauthentifizierung konnte nicht verifiziert werden."
-		},
-		"geminiCli": {
-			"oauthLoadFailed": "Fehler beim Laden der OAuth-Anmeldedaten. Bitte authentifiziere dich zuerst: {{error}}",
-			"tokenRefreshFailed": "Fehler beim Aktualisieren des OAuth-Tokens: {{error}}",
-			"onboardingTimeout": "Onboarding-Vorgang nach 60 Sekunden abgebrochen. Bitte versuche es später erneut.",
-			"projectDiscoveryFailed": "Projekt-ID konnte nicht ermittelt werden. Stelle sicher, dass du mit 'gemini auth' authentifiziert bist.",
-			"rateLimitExceeded": "Anfragenlimit überschritten. Die Limits des kostenlosen Tarifs wurden erreicht.",
-			"badRequest": "Ungültige Anfrage: {{details}}",
-			"apiError": "Gemini CLI API-Fehler: {{error}}",
-			"completionError": "Gemini CLI Vervollständigungsfehler: {{error}}"
 		}
 	}
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -69,6 +69,16 @@
 			"processExitedWithError": "Claude Code process exited with code {{exitCode}}. Error output: {{output}}",
 			"stoppedWithReason": "Claude Code stopped with reason: {{reason}}",
 			"apiKeyModelPlanMismatch": "API keys and subscription plans allow different models. Make sure the selected model is included in your plan."
+		},
+		"geminiCli": {
+			"oauthLoadFailed": "Failed to load OAuth credentials. Please authenticate first: {{error}}",
+			"tokenRefreshFailed": "Failed to refresh OAuth token: {{error}}",
+			"onboardingTimeout": "Onboarding operation timed out after 60 seconds. Please try again later.",
+			"projectDiscoveryFailed": "Could not discover project ID. Make sure you're authenticated with 'gemini auth'.",
+			"rateLimitExceeded": "Rate limit exceeded. Free tier limits have been reached.",
+			"badRequest": "Bad request: {{details}}",
+			"apiError": "Gemini CLI API error: {{error}}",
+			"completionError": "Gemini CLI completion error: {{error}}"
 		}
 	},
 	"warnings": {
@@ -128,16 +138,6 @@
 			"cloud_auth_required": "Your organization requires Roo Code Cloud authentication. Please sign in to continue.",
 			"organization_mismatch": "You must be authenticated with your organization's Roo Code Cloud account.",
 			"verification_failed": "Unable to verify organization authentication."
-		},
-		"geminiCli": {
-			"oauthLoadFailed": "Failed to load OAuth credentials. Please authenticate first: {{error}}",
-			"tokenRefreshFailed": "Failed to refresh OAuth token: {{error}}",
-			"onboardingTimeout": "Onboarding operation timed out after 60 seconds. Please try again later.",
-			"projectDiscoveryFailed": "Could not discover project ID. Make sure you're authenticated with 'gemini auth'.",
-			"rateLimitExceeded": "Rate limit exceeded. Free tier limits have been reached.",
-			"badRequest": "Bad request: {{details}}",
-			"apiError": "Gemini CLI API error: {{error}}",
-			"completionError": "Gemini CLI completion error: {{error}}"
 		}
 	}
 }

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -69,6 +69,16 @@
 			"processExitedWithError": "El proceso de Claude Code terminó con código {{exitCode}}. Salida de error: {{output}}",
 			"stoppedWithReason": "Claude Code se detuvo por la razón: {{reason}}",
 			"apiKeyModelPlanMismatch": "Las claves API y los planes de suscripción permiten diferentes modelos. Asegúrate de que el modelo seleccionado esté incluido en tu plan."
+		},
+		"geminiCli": {
+			"oauthLoadFailed": "Error al cargar credenciales OAuth. Por favor autentícate primero: {{error}}",
+			"tokenRefreshFailed": "Error al actualizar token OAuth: {{error}}",
+			"onboardingTimeout": "La operación de incorporación expiró después de 60 segundos. Inténtalo de nuevo más tarde.",
+			"projectDiscoveryFailed": "No se pudo descubrir el ID del proyecto. Asegúrate de estar autenticado con 'gemini auth'.",
+			"rateLimitExceeded": "Límite de velocidad excedido. Se han alcanzado los límites del nivel gratuito.",
+			"badRequest": "Solicitud incorrecta: {{details}}",
+			"apiError": "Error de API de Gemini CLI: {{error}}",
+			"completionError": "Error de completado de Gemini CLI: {{error}}"
 		}
 	},
 	"warnings": {
@@ -139,16 +149,6 @@
 			"cloud_auth_required": "Tu organización requiere autenticación de Roo Code Cloud. Por favor, inicia sesión para continuar.",
 			"organization_mismatch": "Debes estar autenticado con la cuenta de Roo Code Cloud de tu organización.",
 			"verification_failed": "No se pudo verificar la autenticación de la organización."
-		},
-		"geminiCli": {
-			"oauthLoadFailed": "Error al cargar credenciales OAuth. Por favor autentícate primero: {{error}}",
-			"tokenRefreshFailed": "Error al actualizar token OAuth: {{error}}",
-			"onboardingTimeout": "La operación de incorporación expiró después de 60 segundos. Inténtalo de nuevo más tarde.",
-			"projectDiscoveryFailed": "No se pudo descubrir el ID del proyecto. Asegúrate de estar autenticado con 'gemini auth'.",
-			"rateLimitExceeded": "Límite de velocidad excedido. Se han alcanzado los límites del nivel gratuito.",
-			"badRequest": "Solicitud incorrecta: {{details}}",
-			"apiError": "Error de API de Gemini CLI: {{error}}",
-			"completionError": "Error de completado de Gemini CLI: {{error}}"
 		}
 	}
 }

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -69,6 +69,16 @@
 			"processExitedWithError": "Le processus Claude Code s'est terminé avec le code {{exitCode}}. Sortie d'erreur : {{output}}",
 			"stoppedWithReason": "Claude Code s'est arrêté pour la raison : {{reason}}",
 			"apiKeyModelPlanMismatch": "Les clés API et les plans d'abonnement permettent différents modèles. Assurez-vous que le modèle sélectionné est inclus dans votre plan."
+		},
+		"geminiCli": {
+			"oauthLoadFailed": "Échec du chargement des identifiants OAuth. Veuillez vous authentifier d'abord : {{error}}",
+			"tokenRefreshFailed": "Échec du renouvellement du token OAuth : {{error}}",
+			"onboardingTimeout": "L'opération d'intégration a expiré après 60 secondes. Veuillez réessayer plus tard.",
+			"projectDiscoveryFailed": "Impossible de découvrir l'ID du projet. Assurez-vous d'être authentifié avec 'gemini auth'.",
+			"rateLimitExceeded": "Limite de débit dépassée. Les limites du niveau gratuit ont été atteintes.",
+			"badRequest": "Requête incorrecte : {{details}}",
+			"apiError": "Erreur API Gemini CLI : {{error}}",
+			"completionError": "Erreur de complétion Gemini CLI : {{error}}"
 		}
 	},
 	"warnings": {
@@ -139,16 +149,6 @@
 			"cloud_auth_required": "Votre organisation nécessite une authentification Roo Code Cloud. Veuillez vous connecter pour continuer.",
 			"organization_mismatch": "Vous devez être authentifié avec le compte Roo Code Cloud de votre organisation.",
 			"verification_failed": "Impossible de vérifier l'authentification de l'organisation."
-		},
-		"geminiCli": {
-			"oauthLoadFailed": "Échec du chargement des identifiants OAuth. Veuillez vous authentifier d'abord : {{error}}",
-			"tokenRefreshFailed": "Échec du renouvellement du token OAuth : {{error}}",
-			"onboardingTimeout": "L'opération d'intégration a expiré après 60 secondes. Veuillez réessayer plus tard.",
-			"projectDiscoveryFailed": "Impossible de découvrir l'ID du projet. Assurez-vous d'être authentifié avec 'gemini auth'.",
-			"rateLimitExceeded": "Limite de débit dépassée. Les limites du niveau gratuit ont été atteintes.",
-			"badRequest": "Requête incorrecte : {{details}}",
-			"apiError": "Erreur API Gemini CLI : {{error}}",
-			"completionError": "Erreur de complétion Gemini CLI : {{error}}"
 		}
 	}
 }

--- a/src/i18n/locales/hi/common.json
+++ b/src/i18n/locales/hi/common.json
@@ -69,6 +69,16 @@
 			"processExitedWithError": "Claude Code प्रक्रिया कोड {{exitCode}} के साथ समाप्त हुई। त्रुटि आउटपुट: {{output}}",
 			"stoppedWithReason": "Claude Code इस कारण से रुका: {{reason}}",
 			"apiKeyModelPlanMismatch": "API कुंजी और सब्सक्रिप्शन प्लान अलग-अलग मॉडल की अनुमति देते हैं। सुनिश्चित करें कि चयनित मॉडल आपकी योजना में शामिल है।"
+		},
+		"geminiCli": {
+			"oauthLoadFailed": "OAuth क्रेडेंशियल लोड करने में विफल। कृपया पहले प्रमाणीकरण करें: {{error}}",
+			"tokenRefreshFailed": "OAuth टोकन रीफ्रेश करने में विफल: {{error}}",
+			"onboardingTimeout": "ऑनबोर्डिंग ऑपरेशन 60 सेकंड बाद टाइमआउट हो गया। कृपया बाद में पुनः प्रयास करें।",
+			"projectDiscoveryFailed": "प्रोजेक्ट ID खोजने में असमर्थ। सुनिश्चित करें कि आप 'gemini auth' के साथ प्रमाणित हैं।",
+			"rateLimitExceeded": "दर सीमा पार हो गई। मुफ्त टियर की सीमा पहुंच गई है।",
+			"badRequest": "गलत अनुरोध: {{details}}",
+			"apiError": "Gemini CLI API त्रुटि: {{error}}",
+			"completionError": "Gemini CLI पूर्णता त्रुटि: {{error}}"
 		}
 	},
 	"warnings": {
@@ -139,16 +149,6 @@
 			"cloud_auth_required": "आपके संगठन को Roo Code Cloud प्रमाणीकरण की आवश्यकता है। कृपया जारी रखने के लिए साइन इन करें।",
 			"organization_mismatch": "आपको अपने संगठन के Roo Code Cloud खाते से प्रमाणित होना होगा।",
 			"verification_failed": "संगठन प्रमाणीकरण सत्यापित करने में असमर्थ।"
-		},
-		"geminiCli": {
-			"oauthLoadFailed": "OAuth क्रेडेंशियल लोड करने में विफल। कृपया पहले प्रमाणीकरण करें: {{error}}",
-			"tokenRefreshFailed": "OAuth टोकन रीफ्रेश करने में विफल: {{error}}",
-			"onboardingTimeout": "ऑनबोर्डिंग ऑपरेशन 60 सेकंड बाद टाइमआउट हो गया। कृपया बाद में पुनः प्रयास करें।",
-			"projectDiscoveryFailed": "प्रोजेक्ट ID खोजने में असमर्थ। सुनिश्चित करें कि आप 'gemini auth' के साथ प्रमाणित हैं।",
-			"rateLimitExceeded": "दर सीमा पार हो गई। मुफ्त टियर की सीमा पहुंच गई है।",
-			"badRequest": "गलत अनुरोध: {{details}}",
-			"apiError": "Gemini CLI API त्रुटि: {{error}}",
-			"completionError": "Gemini CLI पूर्णता त्रुटि: {{error}}"
 		}
 	}
 }

--- a/src/i18n/locales/id/common.json
+++ b/src/i18n/locales/id/common.json
@@ -69,6 +69,16 @@
 			"processExitedWithError": "Proses Claude Code keluar dengan kode {{exitCode}}. Output error: {{output}}",
 			"stoppedWithReason": "Claude Code berhenti karena alasan: {{reason}}",
 			"apiKeyModelPlanMismatch": "Kunci API dan paket berlangganan memungkinkan model yang berbeda. Pastikan model yang dipilih termasuk dalam paket Anda."
+		},
+		"geminiCli": {
+			"oauthLoadFailed": "Gagal memuat kredensial OAuth. Silakan autentikasi terlebih dahulu: {{error}}",
+			"tokenRefreshFailed": "Gagal memperbarui token OAuth: {{error}}",
+			"onboardingTimeout": "Operasi onboarding habis waktu setelah 60 detik. Silakan coba lagi nanti.",
+			"projectDiscoveryFailed": "Tidak dapat menemukan ID proyek. Pastikan Anda terautentikasi dengan 'gemini auth'.",
+			"rateLimitExceeded": "Batas kecepatan terlampaui. Batas tingkat gratis telah tercapai.",
+			"badRequest": "Permintaan tidak valid: {{details}}",
+			"apiError": "Kesalahan API Gemini CLI: {{error}}",
+			"completionError": "Kesalahan penyelesaian Gemini CLI: {{error}}"
 		}
 	},
 	"warnings": {
@@ -139,16 +149,6 @@
 			"cloud_auth_required": "Organisasi kamu memerlukan autentikasi Roo Code Cloud. Silakan masuk untuk melanjutkan.",
 			"organization_mismatch": "Kamu harus diautentikasi dengan akun Roo Code Cloud organisasi kamu.",
 			"verification_failed": "Tidak dapat memverifikasi autentikasi organisasi."
-		},
-		"geminiCli": {
-			"oauthLoadFailed": "Gagal memuat kredensial OAuth. Silakan autentikasi terlebih dahulu: {{error}}",
-			"tokenRefreshFailed": "Gagal memperbarui token OAuth: {{error}}",
-			"onboardingTimeout": "Operasi onboarding timeout setelah 60 detik. Silakan coba lagi nanti.",
-			"projectDiscoveryFailed": "Tidak dapat menemukan ID proyek. Pastikan Anda sudah terautentikasi dengan 'gemini auth'.",
-			"rateLimitExceeded": "Batas kecepatan terlampaui. Batas tier gratis telah tercapai.",
-			"badRequest": "Permintaan tidak valid: {{details}}",
-			"apiError": "Error API Gemini CLI: {{error}}",
-			"completionError": "Error penyelesaian Gemini CLI: {{error}}"
 		}
 	}
 }

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -69,6 +69,16 @@
 			"processExitedWithError": "Il processo Claude Code è terminato con codice {{exitCode}}. Output di errore: {{output}}",
 			"stoppedWithReason": "Claude Code si è fermato per il motivo: {{reason}}",
 			"apiKeyModelPlanMismatch": "Le chiavi API e i piani di abbonamento consentono modelli diversi. Assicurati che il modello selezionato sia incluso nel tuo piano."
+		},
+		"geminiCli": {
+			"oauthLoadFailed": "Impossibile caricare le credenziali OAuth. Autenticati prima: {{error}}",
+			"tokenRefreshFailed": "Impossibile aggiornare il token OAuth: {{error}}",
+			"onboardingTimeout": "L'operazione di onboarding è scaduta dopo 60 secondi. Riprova più tardi.",
+			"projectDiscoveryFailed": "Impossibile scoprire l'ID del progetto. Assicurati di essere autenticato con 'gemini auth'.",
+			"rateLimitExceeded": "Limite di velocità superato. I limiti del livello gratuito sono stati raggiunti.",
+			"badRequest": "Richiesta non valida: {{details}}",
+			"apiError": "Errore API Gemini CLI: {{error}}",
+			"completionError": "Errore di completamento Gemini CLI: {{error}}"
 		}
 	},
 	"warnings": {
@@ -139,16 +149,6 @@
 			"cloud_auth_required": "La tua organizzazione richiede l'autenticazione Roo Code Cloud. Accedi per continuare.",
 			"organization_mismatch": "Devi essere autenticato con l'account Roo Code Cloud della tua organizzazione.",
 			"verification_failed": "Impossibile verificare l'autenticazione dell'organizzazione."
-		},
-		"geminiCli": {
-			"oauthLoadFailed": "Impossibile caricare le credenziali OAuth. Autenticati prima: {{error}}",
-			"tokenRefreshFailed": "Impossibile aggiornare il token OAuth: {{error}}",
-			"onboardingTimeout": "L'operazione di onboarding è scaduta dopo 60 secondi. Riprova più tardi.",
-			"projectDiscoveryFailed": "Impossibile scoprire l'ID del progetto. Assicurati di essere autenticato con 'gemini auth'.",
-			"rateLimitExceeded": "Limite di velocità superato. I limiti del livello gratuito sono stati raggiunti.",
-			"badRequest": "Richiesta non valida: {{details}}",
-			"apiError": "Errore API Gemini CLI: {{error}}",
-			"completionError": "Errore di completamento Gemini CLI: {{error}}"
 		}
 	}
 }

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -69,6 +69,16 @@
 			"processExitedWithError": "Claude Code プロセスがコード {{exitCode}} で終了しました。エラー出力：{{output}}",
 			"stoppedWithReason": "Claude Code が理由により停止しました：{{reason}}",
 			"apiKeyModelPlanMismatch": "API キーとサブスクリプションプランでは異なるモデルが利用可能です。選択したモデルがプランに含まれていることを確認してください。"
+		},
+		"geminiCli": {
+			"oauthLoadFailed": "OAuth認証情報の読み込みに失敗しました。まず認証してください: {{error}}",
+			"tokenRefreshFailed": "OAuthトークンの更新に失敗しました: {{error}}",
+			"onboardingTimeout": "オンボーディング操作が60秒でタイムアウトしました。後でもう一度お試しください。",
+			"projectDiscoveryFailed": "プロジェクトIDを発見できませんでした。'gemini auth'で認証されていることを確認してください。",
+			"rateLimitExceeded": "レート制限を超過しました。無料プランの制限に達しています。",
+			"badRequest": "不正なリクエスト: {{details}}",
+			"apiError": "Gemini CLI APIエラー: {{error}}",
+			"completionError": "Gemini CLI補完エラー: {{error}}"
 		}
 	},
 	"warnings": {
@@ -139,16 +149,6 @@
 			"cloud_auth_required": "あなたの組織では Roo Code Cloud 認証が必要です。続行するにはサインインしてください。",
 			"organization_mismatch": "組織の Roo Code Cloud アカウントで認証する必要があります。",
 			"verification_failed": "組織認証の確認ができませんでした。"
-		},
-		"geminiCli": {
-			"oauthLoadFailed": "OAuth認証情報の読み込みに失敗しました。まず認証してください: {{error}}",
-			"tokenRefreshFailed": "OAuthトークンの更新に失敗しました: {{error}}",
-			"onboardingTimeout": "オンボーディング操作が60秒でタイムアウトしました。後でもう一度お試しください。",
-			"projectDiscoveryFailed": "プロジェクトIDを発見できませんでした。'gemini auth'で認証されていることを確認してください。",
-			"rateLimitExceeded": "レート制限を超過しました。無料プランの制限に達しています。",
-			"badRequest": "不正なリクエスト: {{details}}",
-			"apiError": "Gemini CLI APIエラー: {{error}}",
-			"completionError": "Gemini CLI補完エラー: {{error}}"
 		}
 	}
 }

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -69,6 +69,16 @@
 			"processExitedWithError": "Claude Code 프로세스가 코드 {{exitCode}}로 종료되었습니다. 오류 출력: {{output}}",
 			"stoppedWithReason": "Claude Code가 다음 이유로 중지되었습니다: {{reason}}",
 			"apiKeyModelPlanMismatch": "API 키와 구독 플랜에서 다른 모델을 허용합니다. 선택한 모델이 플랜에 포함되어 있는지 확인하세요."
+		},
+		"geminiCli": {
+			"oauthLoadFailed": "OAuth 자격 증명을 로드하지 못했습니다. 먼저 인증하세요: {{error}}",
+			"tokenRefreshFailed": "OAuth 토큰을 새로 고치지 못했습니다: {{error}}",
+			"onboardingTimeout": "온보딩 작업이 60초 후 시간 초과되었습니다. 나중에 다시 시도하세요.",
+			"projectDiscoveryFailed": "프로젝트 ID를 찾을 수 없습니다. 'gemini auth'로 인증되었는지 확인하세요.",
+			"rateLimitExceeded": "속도 제한을 초과했습니다. 무료 등급 제한에 도달했습니다.",
+			"badRequest": "잘못된 요청: {{details}}",
+			"apiError": "Gemini CLI API 오류: {{error}}",
+			"completionError": "Gemini CLI 완성 오류: {{error}}"
 		}
 	},
 	"warnings": {
@@ -139,16 +149,6 @@
 			"cloud_auth_required": "조직에서 Roo Code Cloud 인증이 필요합니다. 계속하려면 로그인하세요.",
 			"organization_mismatch": "조직의 Roo Code Cloud 계정으로 인증해야 합니다.",
 			"verification_failed": "조직 인증을 확인할 수 없습니다."
-		},
-		"geminiCli": {
-			"oauthLoadFailed": "OAuth 자격 증명을 로드하지 못했습니다. 먼저 인증하세요: {{error}}",
-			"tokenRefreshFailed": "OAuth 토큰 새로 고침에 실패했습니다: {{error}}",
-			"onboardingTimeout": "온보딩 작업이 60초 후 시간 초과되었습니다. 나중에 다시 시도하세요.",
-			"projectDiscoveryFailed": "프로젝트 ID를 발견할 수 없습니다. 'gemini auth'로 인증되었는지 확인하세요.",
-			"rateLimitExceeded": "속도 제한을 초과했습니다. 무료 계층 제한에 도달했습니다.",
-			"badRequest": "잘못된 요청: {{details}}",
-			"apiError": "Gemini CLI API 오류: {{error}}",
-			"completionError": "Gemini CLI 완성 오류: {{error}}"
 		}
 	}
 }

--- a/src/i18n/locales/nl/common.json
+++ b/src/i18n/locales/nl/common.json
@@ -69,6 +69,16 @@
 			"processExitedWithError": "Claude Code proces beëindigd met code {{exitCode}}. Foutuitvoer: {{output}}",
 			"stoppedWithReason": "Claude Code gestopt om reden: {{reason}}",
 			"apiKeyModelPlanMismatch": "API-sleutels en abonnementsplannen staan verschillende modellen toe. Zorg ervoor dat het geselecteerde model is opgenomen in je plan."
+		},
+		"geminiCli": {
+			"oauthLoadFailed": "Kan OAuth-referenties niet laden. Authenticeer eerst: {{error}}",
+			"tokenRefreshFailed": "Kan OAuth-token niet vernieuwen: {{error}}",
+			"onboardingTimeout": "Onboarding-operatie is na 60 seconden verlopen. Probeer het later opnieuw.",
+			"projectDiscoveryFailed": "Kan project-ID niet ontdekken. Zorg ervoor dat je geauthenticeerd bent met 'gemini auth'.",
+			"rateLimitExceeded": "Snelheidslimiet overschreden. Gratis tier limieten zijn bereikt.",
+			"badRequest": "Ongeldig verzoek: {{details}}",
+			"apiError": "Gemini CLI API-fout: {{error}}",
+			"completionError": "Gemini CLI voltooiingsfout: {{error}}"
 		}
 	},
 	"warnings": {
@@ -139,16 +149,6 @@
 			"cloud_auth_required": "Je organisatie vereist Roo Code Cloud-authenticatie. Log in om door te gaan.",
 			"organization_mismatch": "Je moet geauthenticeerd zijn met het Roo Code Cloud-account van je organisatie.",
 			"verification_failed": "Kan organisatie-authenticatie niet verifiëren."
-		},
-		"geminiCli": {
-			"oauthLoadFailed": "Kan OAuth-referenties niet laden. Authenticeer eerst: {{error}}",
-			"tokenRefreshFailed": "Kan OAuth-token niet vernieuwen: {{error}}",
-			"onboardingTimeout": "Onboarding-operatie is na 60 seconden verlopen. Probeer het later opnieuw.",
-			"projectDiscoveryFailed": "Kan project-ID niet ontdekken. Zorg ervoor dat je geauthenticeerd bent met 'gemini auth'.",
-			"rateLimitExceeded": "Snelheidslimiet overschreden. Gratis tier limieten zijn bereikt.",
-			"badRequest": "Ongeldig verzoek: {{details}}",
-			"apiError": "Gemini CLI API-fout: {{error}}",
-			"completionError": "Gemini CLI voltooiingsfout: {{error}}"
 		}
 	}
 }

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -69,6 +69,16 @@
 			"processExitedWithError": "Proces Claude Code zakończył się kodem {{exitCode}}. Wyjście błędu: {{output}}",
 			"stoppedWithReason": "Claude Code zatrzymał się z powodu: {{reason}}",
 			"apiKeyModelPlanMismatch": "Klucze API i plany subskrypcji pozwalają na różne modele. Upewnij się, że wybrany model jest zawarty w twoim planie."
+		},
+		"geminiCli": {
+			"oauthLoadFailed": "Nie udało się załadować danych uwierzytelniających OAuth. Najpierw się uwierzytelnij: {{error}}",
+			"tokenRefreshFailed": "Nie udało się odświeżyć tokenu OAuth: {{error}}",
+			"onboardingTimeout": "Operacja wdrażania przekroczyła limit czasu po 60 sekundach. Spróbuj ponownie później.",
+			"projectDiscoveryFailed": "Nie można odkryć ID projektu. Upewnij się, że jesteś uwierzytelniony za pomocą 'gemini auth'.",
+			"rateLimitExceeded": "Przekroczono limit szybkości. Osiągnięto limity darmowego poziomu.",
+			"badRequest": "Nieprawidłowe żądanie: {{details}}",
+			"apiError": "Błąd API Gemini CLI: {{error}}",
+			"completionError": "Błąd uzupełniania Gemini CLI: {{error}}"
 		}
 	},
 	"warnings": {
@@ -139,16 +149,6 @@
 			"cloud_auth_required": "Twoja organizacja wymaga uwierzytelnienia Roo Code Cloud. Zaloguj się, aby kontynuować.",
 			"organization_mismatch": "Musisz być uwierzytelniony kontem Roo Code Cloud swojej organizacji.",
 			"verification_failed": "Nie można zweryfikować uwierzytelnienia organizacji."
-		},
-		"geminiCli": {
-			"oauthLoadFailed": "Nie udało się załadować danych uwierzytelniających OAuth. Najpierw się uwierzytelnij: {{error}}",
-			"tokenRefreshFailed": "Nie udało się odświeżyć tokenu OAuth: {{error}}",
-			"onboardingTimeout": "Operacja wdrażania przekroczyła limit czasu po 60 sekundach. Spróbuj ponownie później.",
-			"projectDiscoveryFailed": "Nie można odkryć ID projektu. Upewnij się, że jesteś uwierzytelniony za pomocą 'gemini auth'.",
-			"rateLimitExceeded": "Przekroczono limit szybkości. Osiągnięto limity darmowego poziomu.",
-			"badRequest": "Nieprawidłowe żądanie: {{details}}",
-			"apiError": "Błąd API Gemini CLI: {{error}}",
-			"completionError": "Błąd uzupełniania Gemini CLI: {{error}}"
 		}
 	}
 }

--- a/src/i18n/locales/pt-BR/common.json
+++ b/src/i18n/locales/pt-BR/common.json
@@ -73,6 +73,16 @@
 			"processExitedWithError": "O processo Claude Code saiu com código {{exitCode}}. Saída de erro: {{output}}",
 			"stoppedWithReason": "Claude Code parou pela razão: {{reason}}",
 			"apiKeyModelPlanMismatch": "Chaves de API e planos de assinatura permitem modelos diferentes. Certifique-se de que o modelo selecionado esteja incluído no seu plano."
+		},
+		"geminiCli": {
+			"oauthLoadFailed": "Falha ao carregar credenciais OAuth. Por favor, autentique-se primeiro: {{error}}",
+			"tokenRefreshFailed": "Falha ao atualizar token OAuth: {{error}}",
+			"onboardingTimeout": "A operação de integração expirou após 60 segundos. Por favor, tente novamente mais tarde.",
+			"projectDiscoveryFailed": "Não foi possível descobrir o ID do projeto. Certifique-se de estar autenticado com 'gemini auth'.",
+			"rateLimitExceeded": "Limite de taxa excedido. Os limites do nível gratuito foram atingidos.",
+			"badRequest": "Solicitação inválida: {{details}}",
+			"apiError": "Erro da API Gemini CLI: {{error}}",
+			"completionError": "Erro de conclusão do Gemini CLI: {{error}}"
 		}
 	},
 	"warnings": {
@@ -139,16 +149,6 @@
 			"cloud_auth_required": "Sua organização requer autenticação do Roo Code Cloud. Faça login para continuar.",
 			"organization_mismatch": "Você deve estar autenticado com a conta Roo Code Cloud da sua organização.",
 			"verification_failed": "Não foi possível verificar a autenticação da organização."
-		},
-		"geminiCli": {
-			"oauthLoadFailed": "Falha ao carregar credenciais OAuth. Por favor, autentique-se primeiro: {{error}}",
-			"tokenRefreshFailed": "Falha ao atualizar token OAuth: {{error}}",
-			"onboardingTimeout": "A operação de integração expirou após 60 segundos. Tente novamente mais tarde.",
-			"projectDiscoveryFailed": "Não foi possível descobrir o ID do projeto. Certifique-se de estar autenticado com 'gemini auth'.",
-			"rateLimitExceeded": "Limite de taxa excedido. Os limites do nível gratuito foram atingidos.",
-			"badRequest": "Solicitação inválida: {{details}}",
-			"apiError": "Erro da API Gemini CLI: {{error}}",
-			"completionError": "Erro de conclusão do Gemini CLI: {{error}}"
 		}
 	}
 }

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -69,6 +69,16 @@
 			"processExitedWithError": "Процесс Claude Code завершился с кодом {{exitCode}}. Вывод ошибки: {{output}}",
 			"stoppedWithReason": "Claude Code остановился по причине: {{reason}}",
 			"apiKeyModelPlanMismatch": "API-ключи и планы подписки позволяют использовать разные модели. Убедитесь, что выбранная модель включена в ваш план."
+		},
+		"geminiCli": {
+			"oauthLoadFailed": "Не удалось загрузить учетные данные OAuth. Сначала выполните аутентификацию: {{error}}",
+			"tokenRefreshFailed": "Не удалось обновить токен OAuth: {{error}}",
+			"onboardingTimeout": "Операция подключения истекла через 60 секунд. Пожалуйста, попробуйте позже.",
+			"projectDiscoveryFailed": "Не удалось обнаружить идентификатор проекта. Убедитесь, что вы аутентифицированы с помощью 'gemini auth'.",
+			"rateLimitExceeded": "Превышен лимит скорости. Достигнуты лимиты бесплатного уровня.",
+			"badRequest": "Неверный запрос: {{details}}",
+			"apiError": "Ошибка API Gemini CLI: {{error}}",
+			"completionError": "Ошибка завершения Gemini CLI: {{error}}"
 		}
 	},
 	"warnings": {
@@ -139,16 +149,6 @@
 			"cloud_auth_required": "Ваша организация требует аутентификации Roo Code Cloud. Войдите в систему, чтобы продолжить.",
 			"organization_mismatch": "Вы должны быть аутентифицированы с учетной записью Roo Code Cloud вашей организации.",
 			"verification_failed": "Не удается проверить аутентификацию организации."
-		},
-		"geminiCli": {
-			"oauthLoadFailed": "Не удалось загрузить учетные данные OAuth. Сначала выполните аутентификацию: {{error}}",
-			"tokenRefreshFailed": "Не удалось обновить токен OAuth: {{error}}",
-			"onboardingTimeout": "Операция адаптации истекла через 60 секунд. Попробуйте позже.",
-			"projectDiscoveryFailed": "Не удалось обнаружить ID проекта. Убедитесь, что вы аутентифицированы с помощью 'gemini auth'.",
-			"rateLimitExceeded": "Превышен лимит скорости. Достигнуты ограничения бесплатного уровня.",
-			"badRequest": "Неверный запрос: {{details}}",
-			"apiError": "Ошибка API Gemini CLI: {{error}}",
-			"completionError": "Ошибка завершения Gemini CLI: {{error}}"
 		}
 	}
 }

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -69,6 +69,16 @@
 			"processExitedWithError": "Claude Code işlemi {{exitCode}} koduyla çıktı. Hata çıktısı: {{output}}",
 			"stoppedWithReason": "Claude Code şu nedenle durdu: {{reason}}",
 			"apiKeyModelPlanMismatch": "API anahtarları ve abonelik planları farklı modellere izin verir. Seçilen modelin planınıza dahil olduğundan emin olun."
+		},
+		"geminiCli": {
+			"oauthLoadFailed": "OAuth kimlik bilgileri yüklenemedi. Lütfen önce kimlik doğrulaması yapın: {{error}}",
+			"tokenRefreshFailed": "OAuth token yenilenemedi: {{error}}",
+			"onboardingTimeout": "Onboarding işlemi 60 saniye sonra zaman aşımına uğradı. Lütfen daha sonra tekrar deneyin.",
+			"projectDiscoveryFailed": "Proje ID'si keşfedilemedi. 'gemini auth' ile kimlik doğrulaması yaptığınızdan emin olun.",
+			"rateLimitExceeded": "Hız sınırı aşıldı. Ücretsiz seviye sınırlarına ulaşıldı.",
+			"badRequest": "Geçersiz istek: {{details}}",
+			"apiError": "Gemini CLI API hatası: {{error}}",
+			"completionError": "Gemini CLI tamamlama hatası: {{error}}"
 		}
 	},
 	"warnings": {
@@ -139,16 +149,6 @@
 			"cloud_auth_required": "Kuruluşunuz Roo Code Cloud kimlik doğrulaması gerektiriyor. Devam etmek için giriş yapın.",
 			"organization_mismatch": "Kuruluşunuzun Roo Code Cloud hesabıyla kimlik doğrulaması yapmalısınız.",
 			"verification_failed": "Kuruluş kimlik doğrulaması doğrulanamıyor."
-		},
-		"geminiCli": {
-			"oauthLoadFailed": "OAuth kimlik bilgileri yüklenemedi. Lütfen önce kimlik doğrulaması yapın: {{error}}",
-			"tokenRefreshFailed": "OAuth token yenilenemedi: {{error}}",
-			"onboardingTimeout": "Onboarding işlemi 60 saniye sonra zaman aşımına uğradı. Lütfen daha sonra tekrar deneyin.",
-			"projectDiscoveryFailed": "Proje ID'si keşfedilemedi. 'gemini auth' ile kimlik doğrulaması yaptığınızdan emin olun.",
-			"rateLimitExceeded": "Hız sınırı aşıldı. Ücretsiz seviye sınırlarına ulaşıldı.",
-			"badRequest": "Geçersiz istek: {{details}}",
-			"apiError": "Gemini CLI API hatası: {{error}}",
-			"completionError": "Gemini CLI tamamlama hatası: {{error}}"
 		}
 	}
 }

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -69,6 +69,16 @@
 			"processExitedWithError": "Tiến trình Claude Code thoát với mã {{exitCode}}. Đầu ra lỗi: {{output}}",
 			"stoppedWithReason": "Claude Code dừng lại vì lý do: {{reason}}",
 			"apiKeyModelPlanMismatch": "Khóa API và gói đăng ký cho phép các mô hình khác nhau. Đảm bảo rằng mô hình đã chọn được bao gồm trong gói của bạn."
+		},
+		"geminiCli": {
+			"oauthLoadFailed": "Không thể tải thông tin xác thực OAuth. Vui lòng xác thực trước: {{error}}",
+			"tokenRefreshFailed": "Không thể làm mới token OAuth: {{error}}",
+			"onboardingTimeout": "Thao tác onboarding đã hết thời gian chờ sau 60 giây. Vui lòng thử lại sau.",
+			"projectDiscoveryFailed": "Không thể khám phá ID dự án. Đảm bảo bạn đã xác thực bằng 'gemini auth'.",
+			"rateLimitExceeded": "Đã vượt quá giới hạn tốc độ. Đã đạt đến giới hạn của gói miễn phí.",
+			"badRequest": "Yêu cầu không hợp lệ: {{details}}",
+			"apiError": "Lỗi API Gemini CLI: {{error}}",
+			"completionError": "Lỗi hoàn thành Gemini CLI: {{error}}"
 		}
 	},
 	"warnings": {
@@ -139,16 +149,6 @@
 			"cloud_auth_required": "Tổ chức của bạn yêu cầu xác thực Roo Code Cloud. Vui lòng đăng nhập để tiếp tục.",
 			"organization_mismatch": "Bạn phải được xác thực bằng tài khoản Roo Code Cloud của tổ chức.",
 			"verification_failed": "Không thể xác minh xác thực tổ chức."
-		},
-		"geminiCli": {
-			"oauthLoadFailed": "Không thể tải thông tin xác thực OAuth. Vui lòng xác thực trước: {{error}}",
-			"tokenRefreshFailed": "Không thể làm mới token OAuth: {{error}}",
-			"onboardingTimeout": "Thao tác onboarding đã hết thời gian chờ sau 60 giây. Vui lòng thử lại sau.",
-			"projectDiscoveryFailed": "Không thể khám phá ID dự án. Đảm bảo bạn đã xác thực bằng 'gemini auth'.",
-			"rateLimitExceeded": "Đã vượt quá giới hạn tốc độ. Đã đạt đến giới hạn của gói miễn phí.",
-			"badRequest": "Yêu cầu không hợp lệ: {{details}}",
-			"apiError": "Lỗi API Gemini CLI: {{error}}",
-			"completionError": "Lỗi hoàn thành Gemini CLI: {{error}}"
 		}
 	}
 }

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -74,6 +74,16 @@
 			"processExitedWithError": "Claude Code 进程退出，退出码：{{exitCode}}。错误输出：{{output}}",
 			"stoppedWithReason": "Claude Code 停止，原因：{{reason}}",
 			"apiKeyModelPlanMismatch": "API 密钥和订阅计划支持不同的模型。请确保所选模型包含在您的计划中。"
+		},
+		"geminiCli": {
+			"oauthLoadFailed": "加载 OAuth 凭据失败。请先进行身份验证：{{error}}",
+			"tokenRefreshFailed": "刷新 OAuth Token 失败：{{error}}",
+			"onboardingTimeout": "入门操作在 60 秒后超时。请稍后重试。",
+			"projectDiscoveryFailed": "无法发现项目 ID。请确保已使用 'gemini auth' 进行身份验证。",
+			"rateLimitExceeded": "API 请求频率限制已超出。免费层级限制已达到。",
+			"badRequest": "请求错误：{{details}}",
+			"apiError": "Gemini CLI API 错误：{{error}}",
+			"completionError": "Gemini CLI 补全错误：{{error}}"
 		}
 	},
 	"warnings": {
@@ -144,16 +154,6 @@
 			"cloud_auth_required": "您的组织需要 Roo Code Cloud 身份验证。请登录以继续。",
 			"organization_mismatch": "您必须使用组织的 Roo Code Cloud 账户进行身份验证。",
 			"verification_failed": "无法验证组织身份验证。"
-		},
-		"geminiCli": {
-			"oauthLoadFailed": "加载 OAuth 凭据失败。请先进行身份验证：{{error}}",
-			"tokenRefreshFailed": "刷新 OAuth Token 失败：{{error}}",
-			"onboardingTimeout": "入门操作在 60 秒后超时。请稍后重试。",
-			"projectDiscoveryFailed": "无法发现项目 ID。请确保已使用 'gemini auth' 进行身份验证。",
-			"rateLimitExceeded": "API 请求频率限制已超出。免费层级限制已达到。",
-			"badRequest": "请求错误：{{details}}",
-			"apiError": "Gemini CLI API 错误：{{error}}",
-			"completionError": "Gemini CLI 补全错误：{{error}}"
 		}
 	}
 }

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -69,6 +69,16 @@
 			"processExitedWithError": "Claude Code 程序退出，退出碼：{{exitCode}}。錯誤輸出：{{output}}",
 			"stoppedWithReason": "Claude Code 停止，原因：{{reason}}",
 			"apiKeyModelPlanMismatch": "API 金鑰和訂閱方案允許不同的模型。請確保所選模型包含在您的方案中。"
+		},
+		"geminiCli": {
+			"oauthLoadFailed": "無法載入 OAuth 憑證。請先進行驗證：{{error}}",
+			"tokenRefreshFailed": "無法重新整理 OAuth 權杖：{{error}}",
+			"onboardingTimeout": "新手導引操作在 60 秒後逾時。請稍後再試。",
+			"projectDiscoveryFailed": "無法發現專案 ID。請確保您已使用 'gemini auth' 進行驗證。",
+			"rateLimitExceeded": "超過速率限制。已達到免費層級限制。",
+			"badRequest": "錯誤的請求：{{details}}",
+			"apiError": "Gemini CLI API 錯誤：{{error}}",
+			"completionError": "Gemini CLI 完成錯誤：{{error}}"
 		}
 	},
 	"warnings": {
@@ -139,16 +149,6 @@
 			"cloud_auth_required": "您的組織需要 Roo Code Cloud 身份驗證。請登入以繼續。",
 			"organization_mismatch": "您必須使用組織的 Roo Code Cloud 帳戶進行身份驗證。",
 			"verification_failed": "無法驗證組織身份驗證。"
-		},
-		"geminiCli": {
-			"oauthLoadFailed": "載入 OAuth 憑證失敗。請先進行身份驗證：{{error}}",
-			"tokenRefreshFailed": "重新整理 OAuth Token 失敗：{{error}}",
-			"onboardingTimeout": "入門操作在 60 秒後逾時。請稍後重試。",
-			"projectDiscoveryFailed": "無法發現專案 ID。請確保已使用 'gemini auth' 進行身份驗證。",
-			"rateLimitExceeded": "速率限制已超出。免費層級限制已達到。",
-			"badRequest": "請求錯誤：{{details}}",
-			"apiError": "Gemini CLI API 錯誤：{{error}}",
-			"completionError": "Gemini CLI 完成錯誤：{{error}}"
 		}
 	}
 }


### PR DESCRIPTION
Moved geminiCli error translations from mdm.geminiCli to errors.geminiCli in all locale files to match the correct usage in the codebase.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrected translation paths for Gemini CLI errors in `common.json` files across multiple locales to ensure proper error message display.
> 
>   - **Translation Path Correction**:
>     - Moved `geminiCli` error translations from `mdm.geminiCli` to `errors.geminiCli` in `common.json` files for multiple locales including `ca`, `de`, `en`, `es`, `fr`, `hi`, `id`, `it`, `ja`, `ko`, `nl`, `pl`, `pt-BR`, `ru`, `tr`, `vi`, `zh-CN`, and `zh-TW`.
>   - **Locales Affected**:
>     - Affected files include `common.json` for each locale, ensuring consistent error message translation paths across all supported languages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d6763e9dde483af55936b5cbe729b8e4a178ee9b. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->