### PR TITLE
Add optional mode suggestions to follow-up questions

### DIFF
--- a/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/architect-mode-prompt.snap
+++ b/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/architect-mode-prompt.snap
@@ -277,12 +277,17 @@ Parameters:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
   3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
+  4. Optionally include a mode attribute to switch to a specific mode when the suggestion is selected: <suggest mode="mode-slug">suggestion text</suggest>
+     - When using the mode attribute, focus the suggestion text on the action to be taken rather than mentioning the mode switch, as the mode change is handled automatically and indicated by a visual badge
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
 <follow_up>
 <suggest>
 Your suggested answer here
+</suggest>
+<suggest mode="code">
+Implement the solution
 </suggest>
 </follow_up>
 </ask_followup_question>
@@ -294,6 +299,16 @@ Example: Requesting to ask the user for the path to the frontend-config.json fil
 <suggest>./src/frontend-config.json</suggest>
 <suggest>./config/frontend-config.json</suggest>
 <suggest>./frontend-config.json</suggest>
+</follow_up>
+</ask_followup_question>
+
+Example: Asking a question with mode switching options
+<ask_followup_question>
+<question>How would you like to proceed with this task?</question>
+<follow_up>
+<suggest mode="code">Start implementing the solution</suggest>
+<suggest mode="architect">Plan the architecture first</suggest>
+<suggest>Continue with more details</suggest>
 </follow_up>
 </ask_followup_question>
 

--- a/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/ask-mode-prompt.snap
+++ b/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/ask-mode-prompt.snap
@@ -174,12 +174,17 @@ Parameters:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
   3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
+  4. Optionally include a mode attribute to switch to a specific mode when the suggestion is selected: <suggest mode="mode-slug">suggestion text</suggest>
+     - When using the mode attribute, focus the suggestion text on the action to be taken rather than mentioning the mode switch, as the mode change is handled automatically and indicated by a visual badge
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
 <follow_up>
 <suggest>
 Your suggested answer here
+</suggest>
+<suggest mode="code">
+Implement the solution
 </suggest>
 </follow_up>
 </ask_followup_question>
@@ -191,6 +196,16 @@ Example: Requesting to ask the user for the path to the frontend-config.json fil
 <suggest>./src/frontend-config.json</suggest>
 <suggest>./config/frontend-config.json</suggest>
 <suggest>./frontend-config.json</suggest>
+</follow_up>
+</ask_followup_question>
+
+Example: Asking a question with mode switching options
+<ask_followup_question>
+<question>How would you like to proceed with this task?</question>
+<follow_up>
+<suggest mode="code">Start implementing the solution</suggest>
+<suggest mode="architect">Plan the architecture first</suggest>
+<suggest>Continue with more details</suggest>
 </follow_up>
 </ask_followup_question>
 

--- a/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/mcp-server-creation-disabled.snap
+++ b/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/mcp-server-creation-disabled.snap
@@ -348,12 +348,17 @@ Parameters:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
   3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
+  4. Optionally include a mode attribute to switch to a specific mode when the suggestion is selected: <suggest mode="mode-slug">suggestion text</suggest>
+     - When using the mode attribute, focus the suggestion text on the action to be taken rather than mentioning the mode switch, as the mode change is handled automatically and indicated by a visual badge
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
 <follow_up>
 <suggest>
 Your suggested answer here
+</suggest>
+<suggest mode="code">
+Implement the solution
 </suggest>
 </follow_up>
 </ask_followup_question>
@@ -365,6 +370,16 @@ Example: Requesting to ask the user for the path to the frontend-config.json fil
 <suggest>./src/frontend-config.json</suggest>
 <suggest>./config/frontend-config.json</suggest>
 <suggest>./frontend-config.json</suggest>
+</follow_up>
+</ask_followup_question>
+
+Example: Asking a question with mode switching options
+<ask_followup_question>
+<question>How would you like to proceed with this task?</question>
+<follow_up>
+<suggest mode="code">Start implementing the solution</suggest>
+<suggest mode="architect">Plan the architecture first</suggest>
+<suggest>Continue with more details</suggest>
 </follow_up>
 </ask_followup_question>
 

--- a/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/mcp-server-creation-enabled.snap
+++ b/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/mcp-server-creation-enabled.snap
@@ -348,12 +348,17 @@ Parameters:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
   3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
+  4. Optionally include a mode attribute to switch to a specific mode when the suggestion is selected: <suggest mode="mode-slug">suggestion text</suggest>
+     - When using the mode attribute, focus the suggestion text on the action to be taken rather than mentioning the mode switch, as the mode change is handled automatically and indicated by a visual badge
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
 <follow_up>
 <suggest>
 Your suggested answer here
+</suggest>
+<suggest mode="code">
+Implement the solution
 </suggest>
 </follow_up>
 </ask_followup_question>
@@ -365,6 +370,16 @@ Example: Requesting to ask the user for the path to the frontend-config.json fil
 <suggest>./src/frontend-config.json</suggest>
 <suggest>./config/frontend-config.json</suggest>
 <suggest>./frontend-config.json</suggest>
+</follow_up>
+</ask_followup_question>
+
+Example: Asking a question with mode switching options
+<ask_followup_question>
+<question>How would you like to proceed with this task?</question>
+<follow_up>
+<suggest mode="code">Start implementing the solution</suggest>
+<suggest mode="architect">Plan the architecture first</suggest>
+<suggest>Continue with more details</suggest>
 </follow_up>
 </ask_followup_question>
 

--- a/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/partial-reads-enabled.snap
+++ b/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/partial-reads-enabled.snap
@@ -304,12 +304,17 @@ Parameters:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
   3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
+  4. Optionally include a mode attribute to switch to a specific mode when the suggestion is selected: <suggest mode="mode-slug">suggestion text</suggest>
+     - When using the mode attribute, focus the suggestion text on the action to be taken rather than mentioning the mode switch, as the mode change is handled automatically and indicated by a visual badge
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
 <follow_up>
 <suggest>
 Your suggested answer here
+</suggest>
+<suggest mode="code">
+Implement the solution
 </suggest>
 </follow_up>
 </ask_followup_question>
@@ -321,6 +326,16 @@ Example: Requesting to ask the user for the path to the frontend-config.json fil
 <suggest>./src/frontend-config.json</suggest>
 <suggest>./config/frontend-config.json</suggest>
 <suggest>./frontend-config.json</suggest>
+</follow_up>
+</ask_followup_question>
+
+Example: Asking a question with mode switching options
+<ask_followup_question>
+<question>How would you like to proceed with this task?</question>
+<follow_up>
+<suggest mode="code">Start implementing the solution</suggest>
+<suggest mode="architect">Plan the architecture first</suggest>
+<suggest>Continue with more details</suggest>
 </follow_up>
 </ask_followup_question>
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/consistent-system-prompt.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/consistent-system-prompt.snap
@@ -299,12 +299,17 @@ Parameters:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
   3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
+  4. Optionally include a mode attribute to switch to a specific mode when the suggestion is selected: <suggest mode="mode-slug">suggestion text</suggest>
+     - When using the mode attribute, focus the suggestion text on the action to be taken rather than mentioning the mode switch, as the mode change is handled automatically and indicated by a visual badge
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
 <follow_up>
 <suggest>
 Your suggested answer here
+</suggest>
+<suggest mode="code">
+Implement the solution
 </suggest>
 </follow_up>
 </ask_followup_question>
@@ -316,6 +321,16 @@ Example: Requesting to ask the user for the path to the frontend-config.json fil
 <suggest>./src/frontend-config.json</suggest>
 <suggest>./config/frontend-config.json</suggest>
 <suggest>./frontend-config.json</suggest>
+</follow_up>
+</ask_followup_question>
+
+Example: Asking a question with mode switching options
+<ask_followup_question>
+<question>How would you like to proceed with this task?</question>
+<follow_up>
+<suggest mode="code">Start implementing the solution</suggest>
+<suggest mode="architect">Plan the architecture first</suggest>
+<suggest>Continue with more details</suggest>
 </follow_up>
 </ask_followup_question>
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/with-computer-use-support.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/with-computer-use-support.snap
@@ -352,12 +352,17 @@ Parameters:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
   3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
+  4. Optionally include a mode attribute to switch to a specific mode when the suggestion is selected: <suggest mode="mode-slug">suggestion text</suggest>
+     - When using the mode attribute, focus the suggestion text on the action to be taken rather than mentioning the mode switch, as the mode change is handled automatically and indicated by a visual badge
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
 <follow_up>
 <suggest>
 Your suggested answer here
+</suggest>
+<suggest mode="code">
+Implement the solution
 </suggest>
 </follow_up>
 </ask_followup_question>
@@ -369,6 +374,16 @@ Example: Requesting to ask the user for the path to the frontend-config.json fil
 <suggest>./src/frontend-config.json</suggest>
 <suggest>./config/frontend-config.json</suggest>
 <suggest>./frontend-config.json</suggest>
+</follow_up>
+</ask_followup_question>
+
+Example: Asking a question with mode switching options
+<ask_followup_question>
+<question>How would you like to proceed with this task?</question>
+<follow_up>
+<suggest mode="code">Start implementing the solution</suggest>
+<suggest mode="architect">Plan the architecture first</suggest>
+<suggest>Continue with more details</suggest>
 </follow_up>
 </ask_followup_question>
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/with-diff-enabled-false.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/with-diff-enabled-false.snap
@@ -299,12 +299,17 @@ Parameters:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
   3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
+  4. Optionally include a mode attribute to switch to a specific mode when the suggestion is selected: <suggest mode="mode-slug">suggestion text</suggest>
+     - When using the mode attribute, focus the suggestion text on the action to be taken rather than mentioning the mode switch, as the mode change is handled automatically and indicated by a visual badge
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
 <follow_up>
 <suggest>
 Your suggested answer here
+</suggest>
+<suggest mode="code">
+Implement the solution
 </suggest>
 </follow_up>
 </ask_followup_question>
@@ -316,6 +321,16 @@ Example: Requesting to ask the user for the path to the frontend-config.json fil
 <suggest>./src/frontend-config.json</suggest>
 <suggest>./config/frontend-config.json</suggest>
 <suggest>./frontend-config.json</suggest>
+</follow_up>
+</ask_followup_question>
+
+Example: Asking a question with mode switching options
+<ask_followup_question>
+<question>How would you like to proceed with this task?</question>
+<follow_up>
+<suggest mode="code">Start implementing the solution</suggest>
+<suggest mode="architect">Plan the architecture first</suggest>
+<suggest>Continue with more details</suggest>
 </follow_up>
 </ask_followup_question>
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/with-diff-enabled-true.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/with-diff-enabled-true.snap
@@ -387,12 +387,17 @@ Parameters:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
   3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
+  4. Optionally include a mode attribute to switch to a specific mode when the suggestion is selected: <suggest mode="mode-slug">suggestion text</suggest>
+     - When using the mode attribute, focus the suggestion text on the action to be taken rather than mentioning the mode switch, as the mode change is handled automatically and indicated by a visual badge
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
 <follow_up>
 <suggest>
 Your suggested answer here
+</suggest>
+<suggest mode="code">
+Implement the solution
 </suggest>
 </follow_up>
 </ask_followup_question>
@@ -404,6 +409,16 @@ Example: Requesting to ask the user for the path to the frontend-config.json fil
 <suggest>./src/frontend-config.json</suggest>
 <suggest>./config/frontend-config.json</suggest>
 <suggest>./frontend-config.json</suggest>
+</follow_up>
+</ask_followup_question>
+
+Example: Asking a question with mode switching options
+<ask_followup_question>
+<question>How would you like to proceed with this task?</question>
+<follow_up>
+<suggest mode="code">Start implementing the solution</suggest>
+<suggest mode="architect">Plan the architecture first</suggest>
+<suggest>Continue with more details</suggest>
 </follow_up>
 </ask_followup_question>
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/with-diff-enabled-undefined.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/with-diff-enabled-undefined.snap
@@ -299,12 +299,17 @@ Parameters:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
   3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
+  4. Optionally include a mode attribute to switch to a specific mode when the suggestion is selected: <suggest mode="mode-slug">suggestion text</suggest>
+     - When using the mode attribute, focus the suggestion text on the action to be taken rather than mentioning the mode switch, as the mode change is handled automatically and indicated by a visual badge
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
 <follow_up>
 <suggest>
 Your suggested answer here
+</suggest>
+<suggest mode="code">
+Implement the solution
 </suggest>
 </follow_up>
 </ask_followup_question>
@@ -316,6 +321,16 @@ Example: Requesting to ask the user for the path to the frontend-config.json fil
 <suggest>./src/frontend-config.json</suggest>
 <suggest>./config/frontend-config.json</suggest>
 <suggest>./frontend-config.json</suggest>
+</follow_up>
+</ask_followup_question>
+
+Example: Asking a question with mode switching options
+<ask_followup_question>
+<question>How would you like to proceed with this task?</question>
+<follow_up>
+<suggest mode="code">Start implementing the solution</suggest>
+<suggest mode="architect">Plan the architecture first</suggest>
+<suggest>Continue with more details</suggest>
 </follow_up>
 </ask_followup_question>
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/with-different-viewport-size.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/with-different-viewport-size.snap
@@ -352,12 +352,17 @@ Parameters:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
   3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
+  4. Optionally include a mode attribute to switch to a specific mode when the suggestion is selected: <suggest mode="mode-slug">suggestion text</suggest>
+     - When using the mode attribute, focus the suggestion text on the action to be taken rather than mentioning the mode switch, as the mode change is handled automatically and indicated by a visual badge
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
 <follow_up>
 <suggest>
 Your suggested answer here
+</suggest>
+<suggest mode="code">
+Implement the solution
 </suggest>
 </follow_up>
 </ask_followup_question>
@@ -369,6 +374,16 @@ Example: Requesting to ask the user for the path to the frontend-config.json fil
 <suggest>./src/frontend-config.json</suggest>
 <suggest>./config/frontend-config.json</suggest>
 <suggest>./frontend-config.json</suggest>
+</follow_up>
+</ask_followup_question>
+
+Example: Asking a question with mode switching options
+<ask_followup_question>
+<question>How would you like to proceed with this task?</question>
+<follow_up>
+<suggest mode="code">Start implementing the solution</suggest>
+<suggest mode="architect">Plan the architecture first</suggest>
+<suggest>Continue with more details</suggest>
 </follow_up>
 </ask_followup_question>
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/with-mcp-hub-provided.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/with-mcp-hub-provided.snap
@@ -348,12 +348,17 @@ Parameters:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
   3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
+  4. Optionally include a mode attribute to switch to a specific mode when the suggestion is selected: <suggest mode="mode-slug">suggestion text</suggest>
+     - When using the mode attribute, focus the suggestion text on the action to be taken rather than mentioning the mode switch, as the mode change is handled automatically and indicated by a visual badge
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
 <follow_up>
 <suggest>
 Your suggested answer here
+</suggest>
+<suggest mode="code">
+Implement the solution
 </suggest>
 </follow_up>
 </ask_followup_question>
@@ -365,6 +370,16 @@ Example: Requesting to ask the user for the path to the frontend-config.json fil
 <suggest>./src/frontend-config.json</suggest>
 <suggest>./config/frontend-config.json</suggest>
 <suggest>./frontend-config.json</suggest>
+</follow_up>
+</ask_followup_question>
+
+Example: Asking a question with mode switching options
+<ask_followup_question>
+<question>How would you like to proceed with this task?</question>
+<follow_up>
+<suggest mode="code">Start implementing the solution</suggest>
+<suggest mode="architect">Plan the architecture first</suggest>
+<suggest>Continue with more details</suggest>
 </follow_up>
 </ask_followup_question>
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/with-undefined-mcp-hub.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/with-undefined-mcp-hub.snap
@@ -299,12 +299,17 @@ Parameters:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
   3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
+  4. Optionally include a mode attribute to switch to a specific mode when the suggestion is selected: <suggest mode="mode-slug">suggestion text</suggest>
+     - When using the mode attribute, focus the suggestion text on the action to be taken rather than mentioning the mode switch, as the mode change is handled automatically and indicated by a visual badge
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
 <follow_up>
 <suggest>
 Your suggested answer here
+</suggest>
+<suggest mode="code">
+Implement the solution
 </suggest>
 </follow_up>
 </ask_followup_question>
@@ -316,6 +321,16 @@ Example: Requesting to ask the user for the path to the frontend-config.json fil
 <suggest>./src/frontend-config.json</suggest>
 <suggest>./config/frontend-config.json</suggest>
 <suggest>./frontend-config.json</suggest>
+</follow_up>
+</ask_followup_question>
+
+Example: Asking a question with mode switching options
+<ask_followup_question>
+<question>How would you like to proceed with this task?</question>
+<follow_up>
+<suggest mode="code">Start implementing the solution</suggest>
+<suggest mode="architect">Plan the architecture first</suggest>
+<suggest>Continue with more details</suggest>
 </follow_up>
 </ask_followup_question>
 

--- a/src/core/prompts/tools/ask-followup-question.ts
+++ b/src/core/prompts/tools/ask-followup-question.ts
@@ -7,12 +7,17 @@ Parameters:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
   3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
+  4. Optionally include a mode attribute to switch to a specific mode when the suggestion is selected: <suggest mode="mode-slug">suggestion text</suggest>
+     - When using the mode attribute, focus the suggestion text on the action to be taken rather than mentioning the mode switch, as the mode change is handled automatically and indicated by a visual badge
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
 <follow_up>
 <suggest>
 Your suggested answer here
+</suggest>
+<suggest mode="code">
+Implement the solution
 </suggest>
 </follow_up>
 </ask_followup_question>
@@ -24,6 +29,16 @@ Example: Requesting to ask the user for the path to the frontend-config.json fil
 <suggest>./src/frontend-config.json</suggest>
 <suggest>./config/frontend-config.json</suggest>
 <suggest>./frontend-config.json</suggest>
+</follow_up>
+</ask_followup_question>
+
+Example: Asking a question with mode switching options
+<ask_followup_question>
+<question>How would you like to proceed with this task?</question>
+<follow_up>
+<suggest mode="code">Start implementing the solution</suggest>
+<suggest mode="architect">Plan the architecture first</suggest>
+<suggest>Continue with more details</suggest>
 </follow_up>
 </ask_followup_question>`
 }

--- a/src/core/tools/__tests__/askFollowupQuestionTool.spec.ts
+++ b/src/core/tools/__tests__/askFollowupQuestionTool.spec.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from "vitest"
+import { askFollowupQuestionTool } from "../askFollowupQuestionTool"
+import { ToolUse } from "../../../shared/tools"
+
+describe("askFollowupQuestionTool", () => {
+	let mockCline: any
+	let mockPushToolResult: any
+	let toolResult: any
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+
+		mockCline = {
+			ask: vi.fn().mockResolvedValue({ text: "Test response" }),
+			say: vi.fn().mockResolvedValue(undefined),
+			consecutiveMistakeCount: 0,
+		}
+
+		mockPushToolResult = vi.fn((result) => {
+			toolResult = result
+		})
+	})
+
+	it("should parse suggestions without mode attributes", async () => {
+		const block: ToolUse = {
+			type: "tool_use",
+			name: "ask_followup_question",
+			params: {
+				question: "What would you like to do?",
+				follow_up: "<suggest>Option 1</suggest><suggest>Option 2</suggest>",
+			},
+			partial: false,
+		}
+
+		await askFollowupQuestionTool(
+			mockCline,
+			block,
+			vi.fn(),
+			vi.fn(),
+			mockPushToolResult,
+			vi.fn((tag, content) => content),
+		)
+
+		expect(mockCline.ask).toHaveBeenCalledWith(
+			"followup",
+			expect.stringContaining('"suggest":[{"answer":"Option 1"},{"answer":"Option 2"}]'),
+			false,
+		)
+	})
+
+	it("should parse suggestions with mode attributes", async () => {
+		const block: ToolUse = {
+			type: "tool_use",
+			name: "ask_followup_question",
+			params: {
+				question: "What would you like to do?",
+				follow_up: '<suggest mode="code">Write code</suggest><suggest mode="debug">Debug issue</suggest>',
+			},
+			partial: false,
+		}
+
+		await askFollowupQuestionTool(
+			mockCline,
+			block,
+			vi.fn(),
+			vi.fn(),
+			mockPushToolResult,
+			vi.fn((tag, content) => content),
+		)
+
+		expect(mockCline.ask).toHaveBeenCalledWith(
+			"followup",
+			expect.stringContaining(
+				'"suggest":[{"answer":"Write code","mode":"code"},{"answer":"Debug issue","mode":"debug"}]',
+			),
+			false,
+		)
+	})
+
+	it("should handle mixed suggestions with and without mode attributes", async () => {
+		const block: ToolUse = {
+			type: "tool_use",
+			name: "ask_followup_question",
+			params: {
+				question: "What would you like to do?",
+				follow_up: '<suggest>Regular option</suggest><suggest mode="architect">Plan architecture</suggest>',
+			},
+			partial: false,
+		}
+
+		await askFollowupQuestionTool(
+			mockCline,
+			block,
+			vi.fn(),
+			vi.fn(),
+			mockPushToolResult,
+			vi.fn((tag, content) => content),
+		)
+
+		expect(mockCline.ask).toHaveBeenCalledWith(
+			"followup",
+			expect.stringContaining(
+				'"suggest":[{"answer":"Regular option"},{"answer":"Plan architecture","mode":"architect"}]',
+			),
+			false,
+		)
+	})
+})

--- a/webview-ui/src/components/chat/FollowUpSuggest.tsx
+++ b/webview-ui/src/components/chat/FollowUpSuggest.tsx
@@ -2,11 +2,17 @@ import { useCallback } from "react"
 import { Edit } from "lucide-react"
 
 import { Button, StandardTooltip } from "@/components/ui"
+import { vscode } from "@/utils/vscode"
 
 import { useAppTranslation } from "@src/i18n/TranslationContext"
 
+interface SuggestionItem {
+	answer: string
+	mode?: string
+}
+
 interface FollowUpSuggestProps {
-	suggestions?: string[]
+	suggestions?: (string | SuggestionItem)[]
 	onSuggestionClick?: (answer: string, event?: React.MouseEvent) => void
 	ts: number
 }
@@ -14,8 +20,19 @@ interface FollowUpSuggestProps {
 export const FollowUpSuggest = ({ suggestions = [], onSuggestionClick, ts = 1 }: FollowUpSuggestProps) => {
 	const { t } = useAppTranslation()
 	const handleSuggestionClick = useCallback(
-		(suggestion: string, event: React.MouseEvent) => {
-			onSuggestionClick?.(suggestion, event)
+		(suggestion: string | SuggestionItem, event: React.MouseEvent) => {
+			const suggestionText = typeof suggestion === "string" ? suggestion : suggestion.answer
+			const mode = typeof suggestion === "object" ? suggestion.mode : undefined
+
+			// If there's a mode switch and it's not a shift-click (which just copies to input), switch modes first
+			if (mode && !event.shiftKey) {
+				vscode.postMessage({
+					type: "mode",
+					text: mode,
+				})
+			}
+
+			onSuggestionClick?.(suggestionText, event)
 		},
 		[onSuggestionClick],
 	)
@@ -27,30 +44,41 @@ export const FollowUpSuggest = ({ suggestions = [], onSuggestionClick, ts = 1 }:
 
 	return (
 		<div className="flex mb-2 flex-col h-full gap-2">
-			{suggestions.map((suggestion) => (
-				<div key={`${suggestion}-${ts}`} className="w-full relative group">
-					<Button
-						variant="outline"
-						className="text-left whitespace-normal break-words w-full h-auto py-3 justify-start pr-8"
-						onClick={(event) => handleSuggestionClick(suggestion, event)}
-						aria-label={suggestion}>
-						<div>{suggestion}</div>
-					</Button>
-					<StandardTooltip content={t("chat:followUpSuggest.copyToInput")}>
-						<div
-							className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity"
-							onClick={(e) => {
-								e.stopPropagation()
-								// Simulate shift-click by directly calling the handler with shiftKey=true.
-								onSuggestionClick?.(suggestion, { ...e, shiftKey: true })
-							}}>
-							<Button variant="ghost" size="icon">
-								<Edit />
-							</Button>
-						</div>
-					</StandardTooltip>
-				</div>
-			))}
+			{suggestions.map((suggestion) => {
+				const suggestionText = typeof suggestion === "string" ? suggestion : suggestion.answer
+				const mode = typeof suggestion === "object" ? suggestion.mode : undefined
+
+				return (
+					<div key={`${suggestionText}-${ts}`} className="w-full relative group">
+						<Button
+							variant="outline"
+							className="text-left whitespace-normal break-words w-full h-auto py-3 justify-start pr-8"
+							onClick={(event) => handleSuggestionClick(suggestion, event)}
+							aria-label={suggestionText}>
+							{suggestionText}
+						</Button>
+						{mode && (
+							<div className="absolute bottom-0 right-0 text-[10px] bg-vscode-badge-background text-vscode-badge-foreground px-1 py-0.5 border border-vscode-badge-background flex items-center gap-0.5">
+								<span className="codicon codicon-arrow-right" style={{ fontSize: "8px" }} />
+								{mode}
+							</div>
+						)}
+						<StandardTooltip content={t("chat:followUpSuggest.copyToInput")}>
+							<div
+								className="absolute top-0 right-0 opacity-0 group-hover:opacity-100 transition-opacity"
+								onClick={(e) => {
+									e.stopPropagation()
+									// Simulate shift-click by directly calling the handler with shiftKey=true.
+									onSuggestionClick?.(suggestionText, { ...e, shiftKey: true })
+								}}>
+								<Button variant="ghost" size="icon">
+									<Edit />
+								</Button>
+							</div>
+						</StandardTooltip>
+					</div>
+				)
+			})}
 		</div>
 	)
 }


### PR DESCRIPTION
Let the LLM suggest answers that also switch modes to save you a round trip

![Screenshot 2025-06-27 at 3 27 18 PM](https://github.com/user-attachments/assets/72939b94-a425-4237-8618-2601d835e5d7)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> This PR adds mode-switching capabilities to follow-up question suggestions, allowing users to switch modes directly from the suggestion, with backend and frontend updates to support this feature.
> 
>   - **Behavior**:
>     - Adds optional `mode` attribute to `<suggest>` tags in `ask_followup_question` to switch modes when selected.
>     - Mode change is automatic and indicated by a visual badge.
>   - **Backend**:
>     - Updates `askFollowupQuestionTool` in `askFollowupQuestionTool.ts` to parse and handle `mode` attributes.
>     - Adds tests in `askFollowupQuestionTool.spec.ts` to verify parsing of suggestions with and without `mode` attributes.
>   - **Frontend**:
>     - Updates `FollowUpSuggest.tsx` to handle `mode` attribute, sending mode switch messages via `vscode.postMessage`.
>     - Displays mode badge on suggestions with a `mode` attribute.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5cb527c8b3ed03b88a7f422dd6074785f4f18867. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->