### PR TITLE
chore: add changeset for v3.22.4 patch release

### DIFF
--- a/.changeset/v3.22.4.md
+++ b/.changeset/v3.22.4.md
@@ -1,0 +1,7 @@
+---
+"roo-cline": patch
+---
+
+- Fix: resolve E2BIG error by passing large prompts via stdin to Claude CLI (thanks @Fovty!)
+- Add optional mode suggestions to follow-up questions (thanks @mrubens!)
+- Fix: move StandardTooltip inside PopoverTrigger in ShareButton (thanks @daniel-lxs!)


### PR DESCRIPTION
This PR adds a changeset for patch release v3.22.4 with the following changes:

- Fix: resolve E2BIG error by passing large prompts via stdin to Claude CLI (thanks @Fovty!)
- Add optional mode suggestions to follow-up questions (thanks @mrubens!)
- Fix: move StandardTooltip inside PopoverTrigger in ShareButton (thanks @daniel-lxs!)

This changeset includes all 3 PRs merged since v3.22.3.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds changeset for v3.22.4 patch release with fixes for E2BIG error, UI adjustment in ShareButton, and mode suggestions.
> 
>   - **Changeset**:
>     - Adds `.changeset/v3.22.4.md` for patch release v3.22.4.
>   - **Fixes**:
>     - Resolves E2BIG error by passing large prompts via stdin to Claude CLI.
>     - Moves `StandardTooltip` inside `PopoverTrigger` in `ShareButton`.
>   - **Features**:
>     - Adds optional mode suggestions to follow-up questions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 208c3d94c9f7ccfc95184ecb108c8f48b558f354. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->