### PR TITLE
Add support for multi-root workspace file search and @ mentions

### DIFF
--- a/src/core/environment/__tests__/getEnvironmentDetails.spec.ts
+++ b/src/core/environment/__tests__/getEnvironmentDetails.spec.ts
@@ -11,7 +11,7 @@ import { getApiMetrics } from "../../../shared/getApiMetrics"
 import { listFiles } from "../../../services/glob/list-files"
 import { TerminalRegistry } from "../../../integrations/terminal/TerminalRegistry"
 import { Terminal } from "../../../integrations/terminal/Terminal"
-import { arePathsEqual } from "../../../utils/path"
+import { arePathsEqual, getAllWorkspacePaths } from "../../../utils/path"
 import { FileContextTracker } from "../../context-tracking/FileContextTracker"
 import { ApiHandler } from "../../../api/index"
 import { ClineProvider } from "../../webview/ClineProvider"
@@ -129,6 +129,7 @@ describe("getEnvironmentDetails", () => {
 		;(listFiles as Mock).mockResolvedValue([["file1.ts", "file2.ts"], false])
 		;(formatResponse.formatFilesList as Mock).mockReturnValue("file1.ts\nfile2.ts")
 		;(arePathsEqual as Mock).mockReturnValue(false)
+		;(getAllWorkspacePaths as Mock).mockReturnValue([mockCwd])
 		;(Terminal.compressTerminalOutput as Mock).mockImplementation((output: string) => output)
 		;(TerminalRegistry.getTerminals as Mock).mockReturnValue([])
 		;(TerminalRegistry.getBackgroundTerminals as Mock).mockReturnValue([])

--- a/src/core/environment/getEnvironmentDetails.ts
+++ b/src/core/environment/getEnvironmentDetails.ts
@@ -14,7 +14,7 @@ import { getApiMetrics } from "../../shared/getApiMetrics"
 import { listFiles } from "../../services/glob/list-files"
 import { TerminalRegistry } from "../../integrations/terminal/TerminalRegistry"
 import { Terminal } from "../../integrations/terminal/Terminal"
-import { arePathsEqual } from "../../utils/path"
+import { arePathsEqual, getAllWorkspacePaths } from "../../utils/path"
 import { formatResponse } from "../prompts/responses"
 
 import { Task } from "../task/Task"
@@ -249,27 +249,37 @@ export async function getEnvironmentDetails(cline: Task, includeFileDetails: boo
 
 	if (includeFileDetails) {
 		details += `\n\n# Current Workspace Directory (${cline.cwd.toPosix()}) Files\n`
-		const isDesktop = arePathsEqual(cline.cwd, path.join(os.homedir(), "Desktop"))
 
-		if (isDesktop) {
+		const allWorkspacePaths = getAllWorkspacePaths()
+		const maxFilesPerWorkspace = Math.floor((maxWorkspaceFiles ?? 200) / allWorkspacePaths.length)
+
+		// Collect all files from all workspaces
+		let allFiles: string[] = []
+		let anyDidHitLimit = false
+
+		for (const workspacePath of allWorkspacePaths) {
+			const isDesktop = arePathsEqual(workspacePath, path.join(os.homedir(), "Desktop"))
 			// Don't want to immediately access desktop since it would show
 			// permission popup.
-			details += "(Desktop files not shown automatically. Use list_files to explore if needed.)"
-		} else {
-			const maxFiles = maxWorkspaceFiles ?? 200
-			const [files, didHitLimit] = await listFiles(cline.cwd, true, maxFiles)
-			const { showRooIgnoredFiles = true } = state ?? {}
+			if (isDesktop) {
+				details += "(Desktop files not shown automatically. Use list_files to explore if needed.)\n"
+				continue
+			}
 
-			const result = formatResponse.formatFilesList(
-				cline.cwd,
-				files,
-				didHitLimit,
-				cline.rooIgnoreController,
-				showRooIgnoredFiles,
-			)
-
-			details += result
+			const [files, didHitLimit] = await listFiles(workspacePath, true, maxFilesPerWorkspace)
+			anyDidHitLimit = anyDidHitLimit || didHitLimit
+			allFiles.push(...files)
 		}
+
+		// Format all file paths relative to `cline.cwd`
+		const { showRooIgnoredFiles = true } = state ?? {}
+		details += formatResponse.formatFilesList(
+			cline.cwd,
+			allFiles,
+			anyDidHitLimit,
+			cline.rooIgnoreController,
+			showRooIgnoredFiles,
+		)
 	}
 
 	return `<environment_details>\n${details.trim()}\n</environment_details>`

--- a/src/core/mentions/__tests__/index.spec.ts
+++ b/src/core/mentions/__tests__/index.spec.ts
@@ -98,7 +98,7 @@ vi.mock("../../../integrations/misc/extract-text", () => ({
 import { parseMentions, openMention } from "../index"
 import { UrlContentFetcher } from "../../../services/browser/UrlContentFetcher"
 import * as git from "../../../utils/git"
-import { getWorkspacePath } from "../../../utils/path"
+import { getWorkspacePath, getAllWorkspacePaths } from "../../../utils/path"
 import fs from "fs/promises"
 import * as path from "path"
 import { openFile } from "../../../integrations/misc/open-file"
@@ -141,6 +141,7 @@ describe("mentions", () => {
 			mockUrlFetcher = new (UrlContentFetcher as any)()
 			;(fs.stat as Mock).mockResolvedValue({ isFile: () => true, isDirectory: () => false })
 			;(extractTextFromFile as Mock).mockResolvedValue("Mock file content")
+			;(getAllWorkspacePaths as Mock).mockReturnValue([mockCwd])
 		})
 
 		it("should parse git commit mentions", async () => {

--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -127,6 +127,9 @@ vi.mock("vscode", () => {
 			from: vi.fn(),
 		},
 		TabInputText: vi.fn(),
+		RelativePattern: vi.fn().mockImplementation((base, pattern) => ({ base, pattern })),
+		Uri: { file: vi.fn((path) => ({ fsPath: path })) },
+		FileType: { File: 1, Directory: 2 },
 	}
 })
 

--- a/src/core/tools/searchFilesTool.ts
+++ b/src/core/tools/searchFilesTool.ts
@@ -1,9 +1,10 @@
+import * as vscode from "vscode"
 import path from "path"
 
 import { Task } from "../task/Task"
 import { ToolUse, AskApproval, HandleError, PushToolResult, RemoveClosingTag } from "../../shared/tools"
 import { ClineSayTool } from "../../shared/ExtensionMessage"
-import { getReadablePath } from "../../utils/path"
+import { getAllWorkspacePaths, getReadablePath } from "../../utils/path"
 import { isPathOutsideWorkspace } from "../../utils/pathUtils"
 import { regexSearchFiles } from "../../services/ripgrep"
 
@@ -52,9 +53,10 @@ export async function searchFilesTool(
 
 			cline.consecutiveMistakeCount = 0
 
+			const workspacePaths = getAllWorkspacePaths()
 			const results = await regexSearchFiles(
 				cline.cwd,
-				absolutePath,
+				workspacePaths,
 				regex,
 				filePattern,
 				cline.rooIgnoreController,

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -23,7 +23,7 @@ import { openImage, saveImage } from "../../integrations/misc/image-handler"
 import { selectImages } from "../../integrations/misc/process-images"
 import { getTheme } from "../../integrations/theme/getTheme"
 import { discoverChromeHostUrl, tryChromeHostUrl } from "../../services/browser/browserDiscovery"
-import { searchWorkspaceFiles } from "../../services/search/file-search"
+import { searchAllWorkspaceFiles } from "../../services/search/file-search"
 import { fileExistsAtPath } from "../../utils/fs"
 import { playTts, setTtsEnabled, setTtsSpeed, stopTts } from "../../utils/tts"
 import { singleCompletionHandler } from "../../utils/single-completion-handler"
@@ -33,7 +33,7 @@ import { getOpenAiModels } from "../../api/providers/openai"
 import { getVsCodeLmModels } from "../../api/providers/vscode-lm"
 import { openMention } from "../mentions"
 import { TelemetrySetting } from "../../shared/TelemetrySetting"
-import { getWorkspacePath } from "../../utils/path"
+import { getPrimaryWorkspaceFolder } from "../../utils/path"
 import { Mode, defaultModeSlug } from "../../shared/modes"
 import { getModels, flushModels } from "../../api/providers/fetchers/modelCache"
 import { GetModelsOptions } from "../../shared/api"
@@ -600,7 +600,7 @@ export const webviewMessageHandler = async (
 				return
 			}
 
-			const workspaceFolder = vscode.workspace.workspaceFolders[0]
+			const workspaceFolder = getPrimaryWorkspaceFolder()
 			const rooDir = path.join(workspaceFolder.uri.fsPath, ".roo")
 			const mcpPath = path.join(rooDir, "mcp.json")
 
@@ -1252,27 +1252,8 @@ export const webviewMessageHandler = async (
 			break
 		}
 		case "searchFiles": {
-			const workspacePath = getWorkspacePath()
-
-			if (!workspacePath) {
-				// Handle case where workspace path is not available
-				await provider.postMessageToWebview({
-					type: "fileSearchResults",
-					results: [],
-					requestId: message.requestId,
-					error: "No workspace path available",
-				})
-				break
-			}
 			try {
-				// Call file search service with query from message
-				const results = await searchWorkspaceFiles(
-					message.query || "",
-					workspacePath,
-					20, // Use default limit, as filtering is now done in the backend
-				)
-
-				// Send results back to webview
+				const results = await searchAllWorkspaceFiles(message.query || "", 20)
 				await provider.postMessageToWebview({
 					type: "fileSearchResults",
 					results,

--- a/src/integrations/workspace/WorkspaceTracker.ts
+++ b/src/integrations/workspace/WorkspaceTracker.ts
@@ -3,7 +3,7 @@ import * as path from "path"
 
 import { listFiles } from "../../services/glob/list-files"
 import { ClineProvider } from "../../core/webview/ClineProvider"
-import { toRelativePath, getWorkspacePath } from "../../utils/path"
+import { toRelativePath, getWorkspacePath, getAllWorkspacePaths } from "../../utils/path"
 
 const MAX_INITIAL_FILES = 1_000
 
@@ -19,6 +19,7 @@ class WorkspaceTracker {
 	get cwd() {
 		return getWorkspacePath()
 	}
+
 	constructor(provider: ClineProvider) {
 		this.providerRef = new WeakRef(provider)
 		this.registerListeners()
@@ -30,17 +31,47 @@ class WorkspaceTracker {
 			return
 		}
 		const tempCwd = this.cwd
-		const [files, _] = await listFiles(tempCwd, true, MAX_INITIAL_FILES)
-		if (this.prevWorkSpacePath !== tempCwd) {
-			return
+		const allWorkspaces = getAllWorkspacePaths()
+
+		// Distribute file limit across all workspaces
+		const filesPerWorkspace = Math.ceil(MAX_INITIAL_FILES / allWorkspaces.length)
+		for (const workspacePath of allWorkspaces) {
+			const [files, _] = await listFiles(workspacePath, true, filesPerWorkspace)
+			if (this.prevWorkSpacePath !== tempCwd) {
+				return
+			}
+			files.slice(0, filesPerWorkspace).forEach((file) => {
+				const absolutePath = path.resolve(workspacePath, file)
+				this.filePaths.add(this.normalizeFilePath(absolutePath))
+			})
 		}
-		files.slice(0, MAX_INITIAL_FILES).forEach((file) => this.filePaths.add(this.normalizeFilePath(file)))
 		this.workspaceDidUpdate()
 	}
 
 	private registerListeners() {
-		const watcher = vscode.workspace.createFileSystemWatcher("**")
 		this.prevWorkSpacePath = this.cwd
+
+		const workspaceFolders = vscode.workspace.workspaceFolders ?? ["."]
+		workspaceFolders.forEach((folder) => {
+			const pattern = new vscode.RelativePattern(folder, "**")
+			const watcher = vscode.workspace.createFileSystemWatcher(pattern)
+			this.setupWatcherEvents(watcher)
+			this.disposables.push(watcher)
+		})
+
+		this.disposables.push(
+			vscode.window.tabGroups.onDidChangeTabs(() => {
+				// Reset if workspace path has changed
+				if (this.prevWorkSpacePath !== this.cwd) {
+					this.workspaceDidReset()
+				} else {
+					this.workspaceDidUpdate()
+				}
+			}),
+		)
+	}
+
+	private setupWatcherEvents(watcher: vscode.FileSystemWatcher) {
 		this.disposables.push(
 			watcher.onDidCreate(async (uri) => {
 				await this.addFilePath(uri.fsPath)
@@ -52,21 +83,6 @@ class WorkspaceTracker {
 		this.disposables.push(
 			watcher.onDidDelete(async (uri) => {
 				if (await this.removeFilePath(uri.fsPath)) {
-					this.workspaceDidUpdate()
-				}
-			}),
-		)
-
-		this.disposables.push(watcher)
-
-		// Listen for tab changes and call workspaceDidUpdate directly
-		this.disposables.push(
-			vscode.window.tabGroups.onDidChangeTabs(() => {
-				// Reset if workspace path has changed
-				if (this.prevWorkSpacePath !== this.cwd) {
-					this.workspaceDidReset()
-				} else {
-					// Otherwise just update
 					this.workspaceDidUpdate()
 				}
 			}),

--- a/src/services/ripgrep/__tests__/index.spec.ts
+++ b/src/services/ripgrep/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 // npx vitest run src/services/ripgrep/__tests__/index.spec.ts
 
-import { truncateLine } from "../index"
+import { truncateLine, regexSearchFiles } from "../index"
 
 describe("Ripgrep line truncation", () => {
 	// The default MAX_LINE_LENGTH is 500 in the implementation
@@ -46,5 +46,22 @@ describe("Ripgrep line truncation", () => {
 
 		expect(truncated.length).toEqual(customLength + " [truncated...]".length)
 		expect(truncated).toContain("[truncated...]")
+	})
+})
+
+describe("Multi-workspace search", () => {
+	it("should handle empty workspace paths array", async () => {
+		const result = await regexSearchFiles("/mock/cwd", [], "test")
+		expect(result).toBe("No workspace paths provided")
+	})
+
+	it("should search multiple workspace paths", async () => {
+		const workspacePaths = ["/workspace1", "/workspace2"]
+
+		try {
+			await regexSearchFiles("/mock/cwd", workspacePaths, "test")
+		} catch (error) {
+			expect(error).toBeDefined()
+		}
 	})
 })

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -115,3 +115,17 @@ export const getWorkspacePath = (defaultCwdPath = "") => {
 	}
 	return cwdPath
 }
+
+export const getAllWorkspacePaths = (): string[] => {
+	return vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath) || []
+}
+
+/**
+ * Gets the primary workspace folder object for accessing .roo config resources
+ */
+export const getPrimaryWorkspaceFolder = (): vscode.WorkspaceFolder => {
+	const workspacePath = getWorkspacePath()
+	const uri = vscode.Uri.file(workspacePath)
+	const name = path.basename(workspacePath)
+	return { uri, name, index: 0 }
+}


### PR DESCRIPTION
Introduce support for searching and mentioning files across multiple workspace folders in multi-root workspace scenarios.

Previously all of the searching and file mentioning logic only looked at the `cwd` or the `workspaceRoot[0]`

Changes:
- Update ripgrep service to search across multiple workspace paths
- Enhance file search to support all workspace folders with workspace names
- Modify WorkspaceTracker to monitor files across all workspaces
- Update environment details to show files from all workspace folders
- Add workspace folder information to extension messages
- Update search tools to leverage multi-workspace capabilities
- Enhance test coverage for multi-workspace scenarios

This enables users to search, mention, and work with files across all workspace folders in multi-root workspace setups, improving the overall development experience in complex project structures.

![2025-06-27 19 15 29](https://github.com/user-attachments/assets/7c4987ea-cae1-4523-9122-9fec32b4eca9)

![2025-06-27 19 16 38](https://github.com/user-attachments/assets/85c96c05-a31d-45e9-b2b1-d8cc263f89c3)

