### PR TITLE
Stop double-capturing cloud telemetry

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -375,13 +375,18 @@ export class Task extends EventEmitter<ClineEvents> {
 		await provider?.postMessageToWebview({ type: "messageUpdated", clineMessage: message })
 		this.emit("message", { action: "updated", message })
 
-		const shouldCaptureMessage = message.partial !== true && CloudService.isEnabled()
+		// Only check for telemetry if the message is complete and CloudService is enabled
+		if (message.partial !== true && CloudService.isEnabled()) {
+			// Now check if this message was already captured
+			const previousMessage = this.clineMessages.find((m) => m.ts === message.ts)
+			const wasAlreadyCaptured = previousMessage && previousMessage.partial !== true
 
-		if (shouldCaptureMessage) {
-			CloudService.instance.captureEvent({
-				event: TelemetryEventName.TASK_MESSAGE,
-				properties: { taskId: this.taskId, message },
-			})
+			if (!wasAlreadyCaptured) {
+				CloudService.instance.captureEvent({
+					event: TelemetryEventName.TASK_MESSAGE,
+					properties: { taskId: this.taskId, message },
+				})
+			}
 		}
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevents double-capturing of telemetry events in `Task.ts` by checking if messages were already captured before sending to `CloudService`.
> 
>   - **Behavior**:
>     - Prevents double-capturing of telemetry events in `Task.ts` by checking if a message was already captured before sending to `CloudService`.
>     - Specifically, in `updateClineMessage()`, checks if `previousMessage` exists and is not partial before capturing the event.
>   - **Misc**:
>     - Adds comments to clarify the conditions under which telemetry events are captured.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b82bd88f8ff94dec76659d6181e27e7c7ad8fd86. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->