### PR TITLE
Add changeset for v3.22.5 patch release

### DIFF
--- a/.changeset/v3.22.5.md
+++ b/.changeset/v3.22.5.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+- Remove Gemini CLI provider while we work with Google on a better integration


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove Gemini CLI provider in patch v3.22.5 for better future Google integration.
> 
>   - **Behavior**:
>     - Remove Gemini CLI provider as a temporary measure while developing better integration with Google.
>   - **Changeset**:
>     - Add changeset file `v3.22.5.md` to document the removal of the Gemini CLI provider.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 2955eb6bb26da44266f50af5361e243dece80763. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->