### PR TITLE
Add Google Tag Manager to Website

### DIFF
--- a/apps/web-roo-code/src/app/layout.tsx
+++ b/apps/web-roo-code/src/app/layout.tsx
@@ -45,6 +45,17 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 	return (
 		<html lang="en" suppressHydrationWarning>
 			<head>
+				{/* Google Tag Manager */}
+				<script
+					dangerouslySetInnerHTML={{
+						__html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-M2JZHV8N');`,
+					}}
+				/>
+				{/* End Google Tag Manager */}
 				<link
 					rel="stylesheet"
 					type="text/css"
@@ -52,6 +63,15 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 				/>
 			</head>
 			<body className={inter.className}>
+				{/* Google Tag Manager (noscript) */}
+				<noscript>
+					<iframe
+						src="https://www.googletagmanager.com/ns.html?id=GTM-M2JZHV8N"
+						height="0"
+						width="0"
+						style={{ display: "none", visibility: "hidden" }}></iframe>
+				</noscript>
+				{/* End Google Tag Manager (noscript) */}
 				<div itemScope itemType="https://schema.org/WebSite">
 					<link itemProp="url" href="https://roocode.com" />
 					<meta itemProp="name" content="Roo Code" />


### PR DESCRIPTION
Summary
Implements Google Tag Manager (GTM) on the Roo Code marketing website to enable analytics and tracking capabilities.

Changes
Added GTM script tag in the <head> section of [apps/web-roo-code/src/app/layout.tsx](vscode-webview://1ks1l50jr91340f8i8t6602d6db2kvftbps27vej06quc3aqrgd7/apps/web-roo-code/src/app/layout.tsx) as high as possible per Google's specifications
Added GTM noscript fallback immediately after the opening <body> tag for users with JavaScript disabled
Used container ID GTM-M2JZHV8N as specified in the implementation requirements
Implemented in root layout to ensure site-wide coverage across all pages
Technical Details
Follows Google's official GTM implementation guidelines
Uses React's dangerouslySetInnerHTML for script injection (Next.js best practice)
Proper inline styles for noscript iframe element
Verified working across multiple pages (home, enterprise, privacy)
Testing
✅ Verified GTM tags render correctly on:

Home page (/)
Enterprise page (/enterprise)
Privacy page (/privacy)
Both the main GTM script and noscript fallback are properly implemented and functional.