### PR TITLE
fix: use actual max_completion_tokens from OpenRouter API

### DIFF
--- a/src/api/providers/fetchers/openrouter.ts
+++ b/src/api/providers/fetchers/openrouter.ts
@@ -190,10 +190,8 @@ export const parseOpenRouterModel = ({
 
 	const supportsPromptCache = typeof cacheWritesPrice !== "undefined" && typeof cacheReadsPrice !== "undefined"
 
-	const useMaxTokens = OPEN_ROUTER_REASONING_BUDGET_MODELS.has(id) || id.startsWith("anthropic/")
-
 	const modelInfo: ModelInfo = {
-		maxTokens: useMaxTokens ? maxTokens || 0 : 0,
+		maxTokens: maxTokens || Math.ceil(model.context_length * 0.2),
 		contextWindow: model.context_length,
 		supportsImages: modality?.includes("image") ?? false,
 		supportsPromptCache,

--- a/src/shared/__tests__/api.spec.ts
+++ b/src/shared/__tests__/api.spec.ts
@@ -66,7 +66,7 @@ describe("getMaxTokensForModel", () => {
 		expect(getModelMaxOutputTokens({ modelId, model, settings })).toBe(8000)
 	})
 
-	it("should return undefined for non-thinking models with undefined maxTokens", () => {
+	it("should return 20% of context window for non-thinking models with undefined maxTokens", () => {
 		const model: ModelInfo = {
 			contextWindow: 200_000,
 			supportsPromptCache: true,
@@ -76,7 +76,8 @@ describe("getMaxTokensForModel", () => {
 			modelMaxTokens: 4000,
 		}
 
-		expect(getModelMaxOutputTokens({ modelId, model, settings })).toBeUndefined()
+		// Should return 20% of context window when maxTokens is undefined
+		expect(getModelMaxOutputTokens({ modelId, model, settings })).toBe(40000)
 	})
 
 	test("should return maxTokens from modelInfo when thinking is false", () => {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -71,7 +71,9 @@ export const getModelMaxOutputTokens = ({
 		return ANTHROPIC_DEFAULT_MAX_TOKENS
 	}
 
-	return model.maxTokens ?? undefined
+	// If maxTokens is 0 or undefined, fall back to 20% of context window
+	// This matches the sliding window logic
+	return model.maxTokens || Math.ceil(model.contextWindow * 0.2)
 }
 
 // GetModelsOptions


### PR DESCRIPTION
Closes: #3817 

### Description

This PR fixes the incorrect reserved token calculation for OpenRouter models. Previously, most OpenRouter models (except reasoning budget and Anthropic models) had their `maxTokens` artificially set to `0`, causing the UI to fall back to displaying 20% of the context window as reserved tokens. This resulted in users seeing ~209k reserved tokens for large context models like Gemini 2.5 Pro, instead of the actual 65,536 token limit.

**Key Changes:**
- Update `parseOpenRouterModel` to always use actual `max_completion_tokens` from OpenRouter API
- Remove artificial restriction that only reasoning budget and Anthropic models get their actual max tokens  
- Fall back to 20% of context window when `max_completion_tokens` is null
- Update `getModelMaxOutputTokens` to use same fallback logic for consistency
- Update tests to reflect new behavior

**Impact:**
- Gemini 2.5 Pro: ~209k → 65,536 reserved tokens
- GPT-4o: ~25k → 16,384 reserved tokens  
- Better context space utilization and accurate model limit representation

### Test Procedure

**Manual Testing:**
1. Configure OpenRouter provider with API key
2. Select `google/gemini-2.5-pro` model
3. Start a conversation and hover over the context window progress bar
4. Verify reserved tokens show 65,536 instead of ~209k
5. Test with `openai/gpt-4o` - should show 16,384 reserved tokens
6. Test with `mistralai/mistral-small-3.2-24b-instruct` - should show ~20% fallback since `max_completion_tokens` is null

**Automated Testing:**
- All existing tests pass
- Updated `getModelMaxOutputTokens` test to verify 20% fallback behavior
- OpenRouter fetcher tests verify model parsing logic

**Verification Commands:**
```bash
cd src && npx vitest run shared/__tests__/api.spec.ts
cd src && npx vitest run api/providers/fetchers/__tests__/openrouter.spec.ts
```

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

**Before (Gemini 2.5 Pro):**
```
Reserved for model response: 209,715 tokens
```

**After (Gemini 2.5 Pro):**
```
Reserved for model response: 65,536 tokens
```

The context window progress bar now shows a much smaller reserved section (medium gray) and larger available space, providing more accurate representation of actual model capabilities.

### Documentation Updates

- [x] No documentation updates are required.

This is an internal bug fix that improves accuracy of existing UI elements without changing user-facing functionality or requiring documentation updates.

### Additional Notes

This fix ensures consistency between the sliding window logic (which already correctly falls back to 20% of context window) and the UI display logic. The change is backward compatible and maintains the same fallback behavior for models without specified `max_completion_tokens`.

The fix was verified with the exact model mentioned in the original issue (Gemini 2.5 Pro) and confirmed to resolve the ~209k reserved tokens problem.

### Get in Touch

Discord: shariqriaz