### PR TITLE
Fixes #5165 - Remove context indicators from model-facing environment details

### DIFF
--- a/src/core/environment/__tests__/getEnvironmentDetails.spec.ts
+++ b/src/core/environment/__tests__/getEnvironmentDetails.spec.ts
@@ -146,7 +146,6 @@ describe("getEnvironmentDetails", () => {
 		expect(result).toContain("# VSCode Visible Files")
 		expect(result).toContain("# VSCode Open Tabs")
 		expect(result).toContain("# Current Time")
-		expect(result).toContain("# Current Context Size (Tokens)")
 		expect(result).toContain("# Current Cost")
 		expect(result).toContain("# Current Mode")
 		expect(result).toContain("<model>test-model</model>")

--- a/src/core/environment/getEnvironmentDetails.ts
+++ b/src/core/environment/getEnvironmentDetails.ts
@@ -203,7 +203,6 @@ export async function getEnvironmentDetails(cline: Task, includeFileDetails: boo
 	const contextPercentage =
 		contextTokens && contextWindow ? Math.round((contextTokens / contextWindow) * 100) : undefined
 
-	details += `\n\n# Current Context Size (Tokens)\n${contextTokens ? `${contextTokens.toLocaleString()} (${contextPercentage}%)` : "(Not available)"}`
 	details += `\n\n# Current Cost\n${totalCost !== null ? `$${totalCost.toFixed(2)}` : "(Not available)"}`
 
 	// Add current mode and any mode-specific warnings.


### PR DESCRIPTION
- Removed context token information (token count and percentage) from environment details sent to AI models
- Models were inappropriately modifying their behavior based on perceived token constraints
- Preserved cost information which is still useful for user-facing displays
- Updated corresponding test to reflect the change
