### PR TITLE
fix: preserve chat input focus during automated file editing (#4574)

### DIFF
--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -503,8 +503,9 @@ export class DiffViewProvider {
 
 			// Pre-open the file as a text document to ensure it doesn't open in preview mode
 			// This fixes issues with files that have custom editor associations (like markdown preview)
+			const showOptions = { preview: false, viewColumn: vscode.ViewColumn.Active, preserveFocus: true }
 			vscode.window
-				.showTextDocument(uri, { preview: false, viewColumn: vscode.ViewColumn.Active, preserveFocus: true })
+				.showTextDocument(uri, showOptions)
 				.then(() => {
 					// Execute the diff command after ensuring the file is open as text
 					return vscode.commands.executeCommand(

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -504,7 +504,7 @@ export class DiffViewProvider {
 			// Pre-open the file as a text document to ensure it doesn't open in preview mode
 			// This fixes issues with files that have custom editor associations (like markdown preview)
 			vscode.window
-				.showTextDocument(uri, { preview: false, viewColumn: vscode.ViewColumn.Active })
+				.showTextDocument(uri, { preview: false, viewColumn: vscode.ViewColumn.Active, preserveFocus: true })
 				.then(() => {
 					// Execute the diff command after ensuring the file is open as text
 					return vscode.commands.executeCommand(

--- a/src/integrations/editor/__tests__/DiffViewProvider.spec.ts
+++ b/src/integrations/editor/__tests__/DiffViewProvider.spec.ts
@@ -176,7 +176,7 @@ describe("DiffViewProvider", () => {
 			// Mock showTextDocument to track when it's called
 			vi.mocked(vscode.window.showTextDocument).mockImplementation(async (uri, options) => {
 				callOrder.push("showTextDocument")
-				expect(options).toEqual({ preview: false, viewColumn: vscode.ViewColumn.Active })
+				expect(options).toEqual({ preview: false, viewColumn: vscode.ViewColumn.Active, preserveFocus: true })
 				return mockEditor as any
 			})
 
@@ -211,7 +211,7 @@ describe("DiffViewProvider", () => {
 			// Verify that showTextDocument was called with preview: false
 			expect(vscode.window.showTextDocument).toHaveBeenCalledWith(
 				expect.objectContaining({ fsPath: `${mockCwd}/test.md` }),
-				{ preview: false, viewColumn: vscode.ViewColumn.Active },
+				{ preview: false, viewColumn: vscode.ViewColumn.Active, preserveFocus: true },
 			)
 
 			// Verify that the diff command was executed

--- a/src/integrations/editor/__tests__/DiffViewProvider.spec.ts
+++ b/src/integrations/editor/__tests__/DiffViewProvider.spec.ts
@@ -176,7 +176,13 @@ describe("DiffViewProvider", () => {
 			// Mock showTextDocument to track when it's called
 			vi.mocked(vscode.window.showTextDocument).mockImplementation(async (uri, options) => {
 				callOrder.push("showTextDocument")
-				expect(options).toEqual({ preview: false, viewColumn: vscode.ViewColumn.Active, preserveFocus: true })
+				expect(options).toEqual(
+					expect.objectContaining({
+						preview: false,
+						viewColumn: vscode.ViewColumn.Active,
+						preserveFocus: true,
+					}),
+				)
 				return mockEditor as any
 			})
 
@@ -211,7 +217,7 @@ describe("DiffViewProvider", () => {
 			// Verify that showTextDocument was called with preview: false
 			expect(vscode.window.showTextDocument).toHaveBeenCalledWith(
 				expect.objectContaining({ fsPath: `${mockCwd}/test.md` }),
-				{ preview: false, viewColumn: vscode.ViewColumn.Active, preserveFocus: true },
+				expect.objectContaining({ preview: false, viewColumn: vscode.ViewColumn.Active, preserveFocus: true }),
 			)
 
 			// Verify that the diff command was executed


### PR DESCRIPTION
## Description

Fixes #4574

This PR fixes the issue where the chat input box loses focus during automated file editing workflows, causing user input to be typed into files instead of the chat.

## Changes Made

- Added `preserveFocus: true` option to the `showTextDocument` call in `DiffViewProvider.ts` (line 507)
- Updated unit tests in `DiffViewProvider.spec.ts` to reflect the new expected behavior

## Testing

- [x] All existing tests pass (2585 tests)
- [x] Updated unit tests for DiffViewProvider to expect `preserveFocus: true`
- [x] Manual testing completed:
  - Tested with mode-writer mode using the prompt: "lets improve @ /.roo/rules-translate so its more structured."
  - Verified that chat input maintains focus during automated file edits

## Verification of Acceptance Criteria

- [x] Chat input box no longer loses focus during automated file editing
- [x] User input is no longer typed into files when Roo is editing in auto-mode
- [x] Focus remains on the chat input throughout the automated workflow

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (not needed for this simple fix)
- [x] Documentation updated (not needed)
- [x] No breaking changes
- [x] Tests updated and passing
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `preserveFocus: true` to maintain chat input focus during automated file editing in `DiffViewProvider.ts`.
> 
>   - **Behavior**:
>     - Adds `preserveFocus: true` to `showTextDocument` in `DiffViewProvider.ts` to maintain chat input focus during automated file editing.
>     - Ensures user input is not mistakenly typed into files.
>   - **Testing**:
>     - Updates unit tests in `DiffViewProvider.spec.ts` to check for `preserveFocus: true`.
>     - Manual testing confirms chat input focus is preserved during file edits.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 18dcd17bc9cbca51fd098c6a5a9c854434b35259. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->