### PR TITLE
feat: change default mode to architect for new installations

### DIFF
--- a/src/shared/__tests__/modes.spec.ts
+++ b/src/shared/__tests__/modes.spec.ts
@@ -356,7 +356,7 @@ describe("FileRestrictionError", () => {
 			const result = await getFullModeDetails("non-existent")
 			expect(result).toMatchObject({
 				...modes[0],
-				customInstructions: "",
+				// The first mode (architect) has its own customInstructions
 			})
 		})
 	})

--- a/src/shared/modes.ts
+++ b/src/shared/modes.ts
@@ -62,16 +62,6 @@ export function getToolsForMode(groups: readonly GroupEntry[]): string[] {
 // Main modes configuration as an ordered array
 export const modes: readonly ModeConfig[] = [
 	{
-		slug: "code",
-		name: "💻 Code",
-		roleDefinition:
-			"You are Roo, a highly skilled software engineer with extensive knowledge in many programming languages, frameworks, design patterns, and best practices.",
-		whenToUse:
-			"Use this mode when you need to write, modify, or refactor code. Ideal for implementing features, fixing bugs, creating new files, or making code improvements across any programming language or framework.",
-		description: "Write, modify, and refactor code",
-		groups: ["read", "edit", "browser", "command", "mcp"],
-	},
-	{
 		slug: "architect",
 		name: "🏗️ Architect",
 		roleDefinition:
@@ -82,6 +72,16 @@ export const modes: readonly ModeConfig[] = [
 		groups: ["read", ["edit", { fileRegex: "\\.md$", description: "Markdown files only" }], "browser", "mcp"],
 		customInstructions:
 			"1. Do some information gathering (for example using read_file or search_files) to get more context about the task.\n\n2. You should also ask the user clarifying questions to get a better understanding of the task.\n\n3. Once you've gained more context about the user's request, you should create a detailed plan for how to accomplish the task. Include Mermaid diagrams if they help make your plan clearer.\n\n4. Ask the user if they are pleased with this plan, or if they would like to make any changes. Think of this as a brainstorming session where you can discuss the task and plan the best way to accomplish it.\n\n5. Once the user confirms the plan, ask them if they'd like you to write it to a markdown file.\n\n6. Use the switch_mode tool to request that the user switch to another mode to implement the solution.",
+	},
+	{
+		slug: "code",
+		name: "💻 Code",
+		roleDefinition:
+			"You are Roo, a highly skilled software engineer with extensive knowledge in many programming languages, frameworks, design patterns, and best practices.",
+		whenToUse:
+			"Use this mode when you need to write, modify, or refactor code. Ideal for implementing features, fixing bugs, creating new files, or making code improvements across any programming language or framework.",
+		description: "Write, modify, and refactor code",
+		groups: ["read", "edit", "browser", "command", "mcp"],
 	},
 	{
 		slug: "ask",


### PR DESCRIPTION
## Description

This PR changes the default mode for new Roo Code installations from "code" to "architect" mode, as requested.

## Changes Made

- Reordered the modes array in `src/shared/modes.ts` to put architect mode first
- Updated the test in `src/shared/__tests__/modes.spec.ts` to reflect that architect is now the default mode

## Implementation Details

The change was implemented using the simple approach suggested - just reordering the modes array rather than adding complex logic. This ensures:
- New installations will default to architect mode
- Existing users are unaffected (their saved preferences remain)
- The code remains clean and maintainable

## Testing

- [x] All existing tests pass
- [x] Updated the mode fallback test to account for architect having customInstructions
- [x] Verified that `defaultModeSlug` correctly points to "architect"

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests updated to reflect changes
- [x] No breaking changes for existing users