### PR TITLE
Fix #5298: Update apply_diff tool description to mark :start_line: as optional

### DIFF
--- a/src/core/diff/strategies/multi-file-search-replace.ts
+++ b/src/core/diff/strategies/multi-file-search-replace.ts
@@ -112,7 +112,7 @@ Parameters:
 Diff format:
 \`\`\`
 <<<<<<< SEARCH
-:start_line: (required) The line number of original content where the search block starts.
+:start_line: (optional) The line number of original content where the search block starts.
 -------
 [exact content to find including whitespace]
 =======

--- a/src/core/diff/strategies/multi-search-replace.ts
+++ b/src/core/diff/strategies/multi-search-replace.ts
@@ -106,7 +106,7 @@ Parameters:
 Diff format:
 \`\`\`
 <<<<<<< SEARCH
-:start_line: (required) The line number of original content where the search block starts.
+:start_line: (optional) The line number of original content where the search block starts.
 -------
 [exact content to find including whitespace]
 =======


### PR DESCRIPTION
Fixes #5298 by updating apply_diff tool descriptions in Human Relay Mode to correctly mark :start_line: as optional instead of required. Updated both MultiSearchReplaceDiffStrategy and MultiFileSearchReplaceDiffStrategy getToolDescription() methods to align with official documentation.