### PR TITLE
list-files must include at least the first-level directory contents

### DIFF
--- a/src/services/glob/__tests__/list-files.spec.ts
+++ b/src/services/glob/__tests__/list-files.spec.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect, vi } from "vitest"
+import { vi, describe, it, expect, beforeEach } from "vitest"
+import * as path from "path"
 import { listFiles } from "../list-files"
+import * as childProcess from "child_process"
 
 vi.mock("../list-files", async () => {
 	const actual = await vi.importActual("../list-files")
@@ -14,5 +16,213 @@ describe("listFiles", () => {
 		const result = await listFiles("/test/path", true, 0)
 
 		expect(result).toEqual([[], false])
+	})
+})
+
+// Mock ripgrep to avoid filesystem dependencies
+vi.mock("../../ripgrep", () => ({
+	getBinPath: vi.fn().mockResolvedValue("/mock/path/to/rg"),
+}))
+
+// Mock vscode
+vi.mock("vscode", () => ({
+	env: {
+		appRoot: "/mock/app/root",
+	},
+}))
+
+// Mock filesystem operations
+vi.mock("fs", () => ({
+	promises: {
+		access: vi.fn().mockRejectedValue(new Error("Not found")),
+		readFile: vi.fn().mockResolvedValue(""),
+		readdir: vi.fn().mockResolvedValue([]),
+	},
+}))
+
+// Import fs to set up mocks
+import * as fs from "fs"
+
+vi.mock("child_process", () => ({
+	spawn: vi.fn(),
+}))
+
+vi.mock("../../path", () => ({
+	arePathsEqual: vi.fn().mockReturnValue(false),
+}))
+
+describe("list-files symlink support", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("should include --follow flag in ripgrep arguments", async () => {
+		const mockSpawn = vi.mocked(childProcess.spawn)
+		const mockProcess = {
+			stdout: {
+				on: vi.fn((event, callback) => {
+					if (event === "data") {
+						// Simulate some output to complete the process
+						setTimeout(() => callback("test-file.txt\n"), 10)
+					}
+				}),
+			},
+			stderr: {
+				on: vi.fn(),
+			},
+			on: vi.fn((event, callback) => {
+				if (event === "close") {
+					setTimeout(() => callback(0), 20)
+				}
+				if (event === "error") {
+					// No error simulation
+				}
+			}),
+			kill: vi.fn(),
+		}
+
+		mockSpawn.mockReturnValue(mockProcess as any)
+
+		// Call listFiles to trigger ripgrep execution
+		await listFiles("/test/dir", false, 100)
+
+		// Verify that spawn was called with --follow flag (the critical fix)
+		const [rgPath, args] = mockSpawn.mock.calls[0]
+		expect(rgPath).toBe("/mock/path/to/rg")
+		expect(args).toContain("--files")
+		expect(args).toContain("--hidden")
+		expect(args).toContain("--follow") // This is the critical assertion - the fix should add this flag
+
+		// Platform-agnostic path check - verify the last argument is the resolved path
+		const expectedPath = path.resolve("/test/dir")
+		expect(args[args.length - 1]).toBe(expectedPath)
+	})
+
+	it("should include --follow flag for recursive listings too", async () => {
+		const mockSpawn = vi.mocked(childProcess.spawn)
+		const mockProcess = {
+			stdout: {
+				on: vi.fn((event, callback) => {
+					if (event === "data") {
+						setTimeout(() => callback("test-file.txt\n"), 10)
+					}
+				}),
+			},
+			stderr: {
+				on: vi.fn(),
+			},
+			on: vi.fn((event, callback) => {
+				if (event === "close") {
+					setTimeout(() => callback(0), 20)
+				}
+				if (event === "error") {
+					// No error simulation
+				}
+			}),
+			kill: vi.fn(),
+		}
+
+		mockSpawn.mockReturnValue(mockProcess as any)
+
+		// Mock readdir to return some test entries
+		vi.mocked(fs.promises.readdir).mockResolvedValue([
+			{ name: "test-file.txt", isDirectory: () => false, isSymbolicLink: () => false, isFile: () => true } as any,
+			{ name: "test-dir", isDirectory: () => true, isSymbolicLink: () => false, isFile: () => false } as any,
+		])
+
+		// Call listFiles with recursive=true
+		await listFiles("/test/dir", true, 100)
+
+		// For breadth-first implementation, ripgrep is called for filtering files
+		// It should still include the --follow flag
+		expect(mockSpawn).toHaveBeenCalled()
+		const calls = mockSpawn.mock.calls
+
+		// Find a call that includes --follow flag
+		const hasFollowFlag = calls.some((call) => {
+			const [, args] = call
+			return args && args.includes("--follow")
+		})
+
+		expect(hasFollowFlag).toBe(true)
+	})
+
+	it("should ensure first-level directories are included when limit is reached", async () => {
+		// Mock fs.promises.readdir to simulate a directory structure
+		const mockReaddir = vi.mocked(fs.promises.readdir)
+
+		// Root directory with many items
+		mockReaddir.mockResolvedValueOnce([
+			{ name: "a_dir", isDirectory: () => true, isSymbolicLink: () => false, isFile: () => false } as any,
+			{ name: "b_dir", isDirectory: () => true, isSymbolicLink: () => false, isFile: () => false } as any,
+			{ name: "c_dir", isDirectory: () => true, isSymbolicLink: () => false, isFile: () => false } as any,
+			{ name: "file1.txt", isDirectory: () => false, isSymbolicLink: () => false, isFile: () => true } as any,
+			{ name: "file2.txt", isDirectory: () => false, isSymbolicLink: () => false, isFile: () => true } as any,
+		])
+
+		// a_dir contents (many files to trigger limit)
+		const manyFiles = Array.from(
+			{ length: 50 },
+			(_, i) =>
+				({
+					name: `file_a_${i}.txt`,
+					isDirectory: () => false,
+					isSymbolicLink: () => false,
+					isFile: () => true,
+				}) as any,
+		)
+		mockReaddir.mockResolvedValueOnce(manyFiles)
+
+		// b_dir and c_dir won't be read due to limit
+
+		// Mock ripgrep to approve all files
+		const mockSpawn = vi.mocked(childProcess.spawn)
+		const mockProcess = {
+			stdout: {
+				on: vi.fn((event, callback) => {
+					if (event === "data") {
+						// Return many file names
+						const fileNames =
+							Array.from({ length: 52 }, (_, i) =>
+								i < 2 ? `file${i + 1}.txt` : `file_a_${i - 2}.txt`,
+							).join("\n") + "\n"
+						setTimeout(() => callback(fileNames), 10)
+					}
+				}),
+			},
+			stderr: {
+				on: vi.fn(),
+			},
+			on: vi.fn((event, callback) => {
+				if (event === "close") {
+					setTimeout(() => callback(0), 20)
+				}
+			}),
+			kill: vi.fn(),
+		}
+		mockSpawn.mockReturnValue(mockProcess as any)
+
+		// Call listFiles with recursive=true and a small limit
+		const [results, limitReached] = await listFiles("/test/dir", true, 10)
+
+		// Verify that we got results and hit the limit
+		expect(results.length).toBe(10)
+		expect(limitReached).toBe(true)
+
+		// Count directories in results
+		const directories = results.filter((r) => r.endsWith("/"))
+
+		// With breadth-first, we should have at least the 3 first-level directories
+		// even if we hit the limit while processing subdirectories
+		expect(directories.length).toBeGreaterThanOrEqual(3)
+
+		// Verify all first-level directories are included
+		const hasADir = results.some((r) => r.endsWith("a_dir/"))
+		const hasBDir = results.some((r) => r.endsWith("b_dir/"))
+		const hasCDir = results.some((r) => r.endsWith("c_dir/"))
+
+		expect(hasADir).toBe(true)
+		expect(hasBDir).toBe(true)
+		expect(hasCDir).toBe(true)
 	})
 })

--- a/src/services/glob/list-files.ts
+++ b/src/services/glob/list-files.ts
@@ -32,33 +32,105 @@ export async function listFiles(dirPath: string, recursive: boolean, limit: numb
 	// Get ripgrep path
 	const rgPath = await getRipgrepPath()
 
-	// Get files using ripgrep
-	const files = await listFilesWithRipgrep(rgPath, dirPath, recursive, limit)
-
-	// Get directories with proper filtering using ignore library
-	const ignoreInstance = await createIgnoreInstance(dirPath)
-	const directories = await listFilteredDirectories(dirPath, recursive, ignoreInstance)
-
-	let allFiles = files
-	let allDirectories = directories
-	const limitReached = files.length + directories.length >= limit
-
-	// If limit is reached in recursive mode, fetch one more layer non-recursively and merge results
-	if (recursive && limitReached) {
-		// Get files and directories in one layer (non-recursive)
-		const filesNonRecursive = await listFilesWithRipgrep(rgPath, dirPath, false, limit)
-		const directoriesNonRecursive = await listFilteredDirectories(dirPath, false, [])
-
-		// Merge recursive and non-recursive results, deduplicate
-		const filesSet = new Set([...files, ...filesNonRecursive])
-		const directoriesSet = new Set([...directories, ...directoriesNonRecursive])
-
-		allFiles = Array.from(filesSet)
-		allDirectories = Array.from(directoriesSet)
+	if (!recursive) {
+		// For non-recursive, use the existing approach
+		const files = await listFilesWithRipgrep(rgPath, dirPath, false, limit)
+		const ignoreInstance = await createIgnoreInstance(dirPath)
+		const directories = await listFilteredDirectories(dirPath, false, ignoreInstance)
+		return formatAndCombineResults(files, directories, limit)
 	}
 
-	// Combine and format the results
-	return formatAndCombineResults(allFiles, allDirectories, limit)
+	// For recursive mode, use the original approach but ensure first-level directories are included
+	const files = await listFilesWithRipgrep(rgPath, dirPath, true, limit)
+	const ignoreInstance = await createIgnoreInstance(dirPath)
+	const directories = await listFilteredDirectories(dirPath, true, ignoreInstance)
+
+	// Combine and check if we hit the limit
+	const [results, limitReached] = formatAndCombineResults(files, directories, limit)
+
+	// If we hit the limit, ensure all first-level directories are included
+	if (limitReached) {
+		const firstLevelDirs = await getFirstLevelDirectories(dirPath, ignoreInstance)
+		return ensureFirstLevelDirectoriesIncluded(results, firstLevelDirs, limit)
+	}
+
+	return [results, limitReached]
+}
+
+/**
+ * Get only the first-level directories in a path
+ */
+async function getFirstLevelDirectories(dirPath: string, ignoreInstance: ReturnType<typeof ignore>): Promise<string[]> {
+	const absolutePath = path.resolve(dirPath)
+	const directories: string[] = []
+
+	try {
+		const entries = await fs.promises.readdir(absolutePath, { withFileTypes: true })
+
+		for (const entry of entries) {
+			if (entry.isDirectory() && !entry.isSymbolicLink()) {
+				const fullDirPath = path.join(absolutePath, entry.name)
+				if (shouldIncludeDirectory(entry.name, fullDirPath, dirPath, ignoreInstance)) {
+					const formattedPath = fullDirPath.endsWith("/") ? fullDirPath : `${fullDirPath}/`
+					directories.push(formattedPath)
+				}
+			}
+		}
+	} catch (err) {
+		console.warn(`Could not read directory ${absolutePath}: ${err}`)
+	}
+
+	return directories
+}
+
+/**
+ * Ensure all first-level directories are included in the results
+ */
+function ensureFirstLevelDirectoriesIncluded(
+	results: string[],
+	firstLevelDirs: string[],
+	limit: number,
+): [string[], boolean] {
+	// Create a set of existing paths for quick lookup
+	const existingPaths = new Set(results)
+
+	// Find missing first-level directories
+	const missingDirs = firstLevelDirs.filter((dir) => !existingPaths.has(dir))
+
+	if (missingDirs.length === 0) {
+		// All first-level directories are already included
+		return [results, true]
+	}
+
+	// We need to make room for the missing directories
+	// Remove items from the end (which are likely deeper in the tree)
+	const itemsToRemove = Math.min(missingDirs.length, results.length)
+	const adjustedResults = results.slice(0, results.length - itemsToRemove)
+
+	// Add the missing directories at the beginning (after any existing first-level dirs)
+	// First, separate existing results into first-level and others
+	const resultPaths = adjustedResults.map((r) => path.resolve(r))
+	const basePath = path.resolve(firstLevelDirs[0]).split(path.sep).slice(0, -1).join(path.sep)
+
+	const firstLevelResults: string[] = []
+	const otherResults: string[] = []
+
+	for (let i = 0; i < adjustedResults.length; i++) {
+		const resolvedPath = resultPaths[i]
+		const relativePath = path.relative(basePath, resolvedPath)
+		const depth = relativePath.split(path.sep).length
+
+		if (depth === 1) {
+			firstLevelResults.push(adjustedResults[i])
+		} else {
+			otherResults.push(adjustedResults[i])
+		}
+	}
+
+	// Combine: existing first-level dirs + missing first-level dirs + other results
+	const finalResults = [...firstLevelResults, ...missingDirs, ...otherResults].slice(0, limit)
+
+	return [finalResults, true]
 }
 
 /**

--- a/src/services/glob/list-files.ts
+++ b/src/services/glob/list-files.ts
@@ -402,7 +402,6 @@ function isDirectoryExplicitlyIgnored(dirName: string): boolean {
 	return false
 }
 
-
 /**
  * Combine file and directory results and format them properly
  */
@@ -416,16 +415,6 @@ function formatAndCombineResults(files: string[], directories: string[], limit: 
 
 	// Sort to ensure directories come first, followed by files
 	uniquePaths.sort((a: string, b: string) => {
-		// Remove trailing slash for depth calculation
-		const aPath = a.endsWith("/") ? a.slice(0, -1) : a
-		const bPath = b.endsWith("/") ? b.slice(0, -1) : b
-		const aDepth = aPath.split("/").length
-		const bDepth = bPath.split("/").length
-
-		if (aDepth !== bDepth) {
-			return aDepth - bDepth
-		}
-
 		const aIsDir = a.endsWith("/")
 		const bIsDir = b.endsWith("/")
 


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #5301 

### Description

When asking the model to “summarize the current project” in projects with a large number of files, it may make inferences based on the content returned by the Current Workspace Directory or the List Files tool.

However, the current List-files tool uses a depth-first search strategy, which can result in returning detailed structures for only part of the project directories, while the model has no awareness of the other directories at all. In some weaker models, instead of requesting the agent to fetch all subfolders, they directly infer based on the partial information available, which can lead to completely incorrect results.

Changes:
* If the number of files retrieved by list-files reaches the limit, perform an additional retrieval of all directories and files under the top-level folders separately, then merge the results before proceeding with further processing.
* formatAndCombineResults uses a breadth-first traversal approach.
* (Note: listFilesWithRipgrep still uses depth-first search, which may lead to incomplete results in some cases, but at least the first-level directory structure will not be missing.)

### Test Procedure

When viewing the prompt in human-relay mode, the Current Workspace Directory will include at least all files in the first-level directories.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->

### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance `listFiles` to include first-level directory contents when file limit is reached, ensuring complete directory awareness.
> 
>   - **Behavior**:
>     - `listFiles` in `list-files.ts` now performs an additional non-recursive retrieval of top-level directories if the file limit is reached in recursive mode.
>     - Ensures at least first-level directory contents are included in results.
>   - **Functions**:
>     - `formatAndCombineResults` updated to sort paths by depth, ensuring directories are listed before files.
>   - **Misc**:
>     - `listFilesWithRipgrep` still uses depth-first search, but first-level directory structure is guaranteed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e64dd2a743d22008ac788e5e4806ed3a738759b6. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->