### PR TITLE
Give Mermaid buttons a light background in light mode

### DIFF
--- a/webview-ui/src/components/common/MermaidButton.tsx
+++ b/webview-ui/src/components/common/MermaidButton.tsx
@@ -127,7 +127,7 @@ export function MermaidButton({ containerRef, code, isLoading, svgToPng, childre
 			<div className="relative w-full" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
 				{children}
 				{!isLoading && isHovering && (
-					<div className="absolute bottom-2 right-2 flex gap-1 bg-black/70 rounded p-0.5 z-10 opacity-100 transition-opacity duration-200 ease-in-out">
+					<div className="absolute bottom-2 right-2 flex gap-1 bg-vscode-editor-background/90 rounded p-0.5 z-10 opacity-100 transition-opacity duration-200 ease-in-out">
 						<MermaidActionButtons
 							onZoom={handleZoom}
 							onCopy={handleCopy}


### PR DESCRIPTION
Kilo Code PR: https://github.com/Kilo-Org/kilocode/pull/949

### Description

In light mode, the buttons on the toolbar of a Mermaid diagram are very hard to see, because the background is dark gray while the icons are black. In dark mode there's no such issue, because the icons are white.

Proposed solution: use `bg-vscode-editor-background` or similar class which is light/dark mode aware.

### Test Procedure

Hover over a Mermaid diagram in light mode and check if the button icons are visible.

### Screenshots / Videos

#### Before

![CleanShot 2025-07-02 at 16 40 07](https://github.com/user-attachments/assets/4155fd6d-55ff-4133-95e6-123f9890d9a9)

![CleanShot 2025-07-02 at 16 29 46](https://github.com/user-attachments/assets/4752c9bf-70e0-49bb-bdd2-80b18884e347)

#### After

![CleanShot 2025-07-02 at 16 32 34](https://github.com/user-attachments/assets/92bb81a2-ba1a-4f89-9793-17280fb93cbc)

![CleanShot 2025-07-02 at 16 33 13](https://github.com/user-attachments/assets/3c4b8976-46d7-4ee8-82c5-2bd0538adbd4)

### Get in Touch

chrarnoldus on Discord

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `MermaidButton` to improve toolbar button visibility in light mode by changing background color.
> 
>   - **UI Update**:
>     - In `MermaidButton.tsx`, change button background from `bg-black/70` to `bg-vscode-editor-background/90` for light mode visibility.
>   - **Behavior**:
>     - Ensures toolbar buttons on Mermaid diagrams are visible in both light and dark modes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ad845981976b8a81cf1d787d3f02058330baf95e. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->