### PR TITLE
docs: add compact testing guidelines to project rules

### DIFF
--- a/.roo/rules/rules.md
+++ b/.roo/rules/rules.md
@@ -6,6 +6,12 @@
     - Ensure all tests pass before submitting changes
     - The vitest framework is used for testing; the `describe`, `test`, `it`, etc functions are defined by default in `tsconfig.json` and therefore don't need to be imported
     - Tests must be run from the same directory as the `package.json` file that specifies `vitest` in `devDependencies`
+    - Run tests with: `npx vitest <relative-path-from-workspace-root>`
+    - Do NOT run tests from project root - this causes "vitest: command not found" error
+    - Tests must be run from inside the correct workspace:
+        - Backend tests: `cd src && npx vitest path/to/test-file` (don't include `src/` in path)
+        - UI tests: `cd webview-ui && npx vitest src/path/to/test-file`
+    - Example: For `src/tests/user.test.ts`, run `cd src && npx vitest tests/user.test.ts` NOT `npx vitest src/tests/user.test.ts`
 
 2. Lint Rules:
 


### PR DESCRIPTION
## Description

This PR adds clear and compact testing guidelines to the project rules documentation to help developers understand how to properly run tests in the Roo Code project.

## Changes Made

- Added testing execution guidelines to .roo/rules/rules.md under the Test Coverage section
- Specified that tests must be run from inside the correct workspace (src/ or webview-ui/)
- Included clear examples of correct vs incorrect test commands
- Emphasized the common error of running tests from project root

## Why This Change?

These guidelines address a common source of confusion when running tests, particularly the 'vitest: command not found' error that occurs when tests are run from the project root instead of the appropriate workspace directory.

## Testing

- Documentation has been reviewed for clarity
- Examples are accurate and tested
- Guidelines integrate seamlessly with existing rules

## Checklist

- Code follows project style guidelines
- Self-review completed
- Documentation is clear and concise
- No breaking changes