### PR TITLE
fix: resolve terminal working directory tracking after cd commands (#5424)

### DIFF
--- a/src/integrations/terminal/__tests__/TerminalRegistry.workingDirectory.spec.ts
+++ b/src/integrations/terminal/__tests__/TerminalRegistry.workingDirectory.spec.ts
@@ -1,0 +1,170 @@
+// npx vitest run src/integrations/terminal/__tests__/TerminalRegistry.workingDirectory.spec.ts
+
+import * as vscode from "vscode"
+import { Terminal } from "../Terminal"
+import { TerminalRegistry } from "../TerminalRegistry"
+
+vi.mock("execa", () => ({
+	execa: vi.fn(),
+}))
+
+describe("TerminalRegistry - Working Directory Tracking", () => {
+	let mockCreateTerminal: any
+
+	beforeEach(() => {
+		// Clear any existing terminals
+		TerminalRegistry["terminals"] = []
+
+		mockCreateTerminal = vi.spyOn(vscode.window, "createTerminal").mockImplementation((...args: any[]) => {
+			const mockShellIntegration = {
+				executeCommand: vi.fn(),
+				cwd: vscode.Uri.file("/test/path"), // Initial working directory
+			}
+
+			return {
+				exitStatus: undefined,
+				name: "Roo Code",
+				processId: Promise.resolve(123),
+				creationOptions: {},
+				state: {
+					isInteractedWith: true,
+					shell: { id: "test-shell", executable: "/bin/bash", args: [] },
+				},
+				dispose: vi.fn(),
+				hide: vi.fn(),
+				show: vi.fn(),
+				sendText: vi.fn(),
+				shellIntegration: mockShellIntegration,
+			} as any
+		})
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	describe("getOrCreateTerminal with changed working directory", () => {
+		it("should reuse terminal when working directory matches current directory", async () => {
+			// Create a terminal with initial working directory
+			const terminal1 = await TerminalRegistry.getOrCreateTerminal("/test/path", false, "task1", "vscode")
+
+			// Simulate the terminal's working directory changing (like after cd command)
+			if (terminal1 instanceof Terminal) {
+				// Mock the shell integration to return the new working directory
+				Object.defineProperty(terminal1.terminal.shellIntegration!, "cwd", {
+					value: vscode.Uri.file("/test/path/subdir"),
+					writable: true,
+					configurable: true,
+				})
+			}
+
+			// Mark terminal as not busy
+			terminal1.busy = false
+
+			// Request a terminal for the new working directory
+			const terminal2 = await TerminalRegistry.getOrCreateTerminal("/test/path/subdir", false, "task1", "vscode")
+
+			// Should reuse the same terminal since its current working directory matches
+			expect(terminal2).toBe(terminal1)
+			expect(mockCreateTerminal).toHaveBeenCalledTimes(1) // Only one terminal created
+		})
+
+		it("should create new terminal when no existing terminal matches current working directory", async () => {
+			// Create a terminal with initial working directory
+			const terminal1 = await TerminalRegistry.getOrCreateTerminal("/test/path", false, "task1", "vscode")
+
+			// Simulate the terminal's working directory changing (like after cd command)
+			if (terminal1 instanceof Terminal) {
+				// Mock the shell integration to return the new working directory
+				Object.defineProperty(terminal1.terminal.shellIntegration!, "cwd", {
+					value: vscode.Uri.file("/test/path/subdir"),
+					writable: true,
+					configurable: true,
+				})
+			}
+
+			// Mark terminal as not busy
+			terminal1.busy = false
+
+			// Request a terminal for a different working directory
+			const terminal2 = await TerminalRegistry.getOrCreateTerminal("/test/path/other", false, "task1", "vscode")
+
+			// Should create a new terminal since no existing terminal matches the requested directory
+			expect(terminal2).not.toBe(terminal1)
+			expect(mockCreateTerminal).toHaveBeenCalledTimes(2) // Two terminals created
+		})
+
+		it("should handle terminals without shell integration gracefully", async () => {
+			// Create a terminal without shell integration
+			mockCreateTerminal.mockImplementationOnce(
+				(...args: any[]) =>
+					({
+						exitStatus: undefined,
+						name: "Roo Code",
+						processId: Promise.resolve(123),
+						creationOptions: {},
+						state: {
+							isInteractedWith: true,
+							shell: { id: "test-shell", executable: "/bin/bash", args: [] },
+						},
+						dispose: vi.fn(),
+						hide: vi.fn(),
+						show: vi.fn(),
+						sendText: vi.fn(),
+						shellIntegration: undefined, // No shell integration
+					}) as any,
+			)
+
+			const terminal1 = await TerminalRegistry.getOrCreateTerminal("/test/path", false, "task1", "vscode")
+			terminal1.busy = false
+
+			// Request a terminal for the same working directory
+			const terminal2 = await TerminalRegistry.getOrCreateTerminal("/test/path", false, "task1", "vscode")
+
+			// Should reuse the same terminal since it falls back to initial CWD
+			expect(terminal2).toBe(terminal1)
+			expect(mockCreateTerminal).toHaveBeenCalledTimes(1)
+		})
+
+		it("should prioritize task-specific terminals with matching current working directory", async () => {
+			// Create a terminal for task1
+			const terminal1 = await TerminalRegistry.getOrCreateTerminal("/test/path", false, "task1", "vscode")
+
+			// Create a terminal for task2
+			const terminal2 = await TerminalRegistry.getOrCreateTerminal("/test/path", false, "task2", "vscode")
+
+			// Simulate terminal1's working directory changing
+			if (terminal1 instanceof Terminal) {
+				// Mock the shell integration to return the new working directory
+				Object.defineProperty(terminal1.terminal.shellIntegration!, "cwd", {
+					value: vscode.Uri.file("/test/path/subdir"),
+					writable: true,
+					configurable: true,
+				})
+			}
+
+			// Mark both terminals as not busy
+			terminal1.busy = false
+			terminal2.busy = false
+
+			// Request a terminal for task1 with the new working directory
+			const terminal3 = await TerminalRegistry.getOrCreateTerminal("/test/path/subdir", false, "task1", "vscode")
+
+			// Should reuse terminal1 since it's assigned to task1 and has matching current working directory
+			expect(terminal3).toBe(terminal1)
+			expect(mockCreateTerminal).toHaveBeenCalledTimes(2) // Only two terminals created
+		})
+
+		it("should create separate terminals for different tasks", async () => {
+			// Create a terminal for task1
+			const terminal1 = await TerminalRegistry.getOrCreateTerminal("/test/path", false, "task1", "vscode")
+
+			// Create a terminal for task2 - should create a new terminal
+			const terminal2 = await TerminalRegistry.getOrCreateTerminal("/test/path", false, "task2", "vscode")
+
+			// Should be different terminals
+			expect(terminal2).not.toBe(terminal1)
+			expect(mockCreateTerminal).toHaveBeenCalledTimes(2)
+		})
+	})
+})


### PR DESCRIPTION
## Description

Fixes #5424

This PR resolves the issue where subsequent execute_command calls would run in the wrong directory after the LLM used commands like cd <dir>. The problem occurred because the terminal registry was reusing terminals whose working directory had changed via cd commands, without properly tracking these changes.

## Changes Made

- Enhanced TerminalRegistry.getOrCreateTerminal() to properly track working directory changes using VSCode's terminal.shellIntegration.cwd
- Added strict working directory matching in all three priority levels of terminal selection
- Implemented task isolation to prevent terminals from different tasks being inappropriately reused
- Added comprehensive test coverage with 5 new tests

## Testing

- All existing tests pass (47 terminal integration tests)
- New tests pass (5 working directory-specific tests)
- No linting or TypeScript errors
- Verified fix resolves the reported issue

## Files Changed

- src/integrations/terminal/TerminalRegistry.ts - Enhanced terminal selection logic
- src/integrations/terminal/__tests__/TerminalRegistry.workingDirectory.spec.ts - Test coverage
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes terminal working directory tracking in `TerminalRegistry.ts` to ensure correct execution after `cd` commands, with new tests added.
> 
>   - **Behavior**:
>     - Fixes terminal working directory tracking in `TerminalRegistry.ts` to ensure commands run in correct directory after `cd`.
>     - Implements task isolation to prevent terminal reuse across different tasks.
>   - **Testing**:
>     - Adds 5 new tests in `TerminalRegistry.workingDirectory.spec.ts` to cover working directory changes and task-specific terminal reuse.
>     - All existing and new tests pass, ensuring no regressions.
>   - **Misc**:
>     - Enhances `getOrCreateTerminal()` to track working directory using `terminal.shellIntegration.cwd` and match strictly by directory.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 156698f96589a64e80dc635de981783e8953b687. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->