### PR TITLE
Fix new_task tool streaming issue

### DIFF
--- a/src/core/tools/newTaskTool.ts
+++ b/src/core/tools/newTaskTool.ts
@@ -22,7 +22,7 @@ export async function newTaskTool(
 			const partialMessage = JSON.stringify({
 				tool: "newTask",
 				mode: removeClosingTag("mode", mode),
-				message: removeClosingTag("message", message),
+				content: removeClosingTag("message", message),
 			})
 
 			await cline.ask("tool", partialMessage, block.partial).catch(() => {})


### PR DESCRIPTION
## Problem
The `new_task` command was not streaming partial messages to the UI like other commands do. When the `new_task` command writes a lot of instructions to a subtask, the UI appears frozen with no content until all content shows up at once, rather than streaming incrementally.

## Root Cause
The issue was in `newTaskTool.ts` where partial messages were using a `message` property that doesn't exist in the `ClineSayTool` interface. The webview expects messages to conform to this interface for proper streaming behavior.

## Solution
- Changed the `message` property to `content` in partial messages to match the `ClineSayTool` interface
- This makes the partial message format consistent with the complete message format
- Now the webview can properly handle and stream partial updates

## Testing
- ✅ All existing tests pass
- ✅ Type checking passes
- ✅ Linting passes
- ✅ The fix aligns with how other working tools like `writeToFileTool` structure their messages

## Files Changed
- `src/core/tools/newTaskTool.ts`: Fixed partial message property name

This is a minimal, targeted fix that resolves the streaming issue without affecting any other functionality.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes streaming issue in `newTaskTool.ts` by aligning partial message format with `ClineSayTool` interface.
> 
>   - **Behavior**:
>     - Fixes streaming issue in `newTaskTool.ts` by changing `message` to `content` in partial messages.
>     - Aligns partial message format with `ClineSayTool` interface for proper UI streaming.
>   - **Testing**:
>     - All existing tests, type checking, and linting pass.
>     - Consistency with other tools like `writeToFileTool` confirmed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 6982f844631bf28ec87a9e748149ac041a0076ac. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->