### PR TITLE
Add description field to create_mode instructions

### DIFF
--- a/src/core/prompts/instructions/create-mode.ts
+++ b/src/core/prompts/instructions/create-mode.ts
@@ -26,6 +26,7 @@ If asked to create a project mode, create it in .roomodes in the workspace root.
   * groups: Array of allowed tool groups (can be empty). Each group can be specified either as a string (e.g., "edit" to allow editing any file) or with file restrictions (e.g., ["edit", { fileRegex: "\\.md$", description: "Markdown files only" }] to only allow editing markdown files)
 
 - The following fields are optional but highly recommended:
+  * description: A short, human-readable description of what this mode does (1-2 sentences)
   * whenToUse: A clear description of when this mode should be selected and what types of tasks it's best suited for. This helps the Orchestrator mode make better decisions.
   * customInstructions: Additional instructions for how the mode should operate
 
@@ -36,6 +37,7 @@ Both files should follow this structure (in YAML format):
 customModes:
   - slug: designer  # Required: unique slug with lowercase letters, numbers, and hyphens
     name: Designer  # Required: mode display name
+    description: A UI/UX expert specializing in design systems and responsive frontend development.  # Optional but recommended: short description
     roleDefinition: >-
       You are Roo, a UI/UX expert specializing in design systems and frontend development. Your expertise includes:
       - Creating and maintaining design systems
@@ -43,8 +45,8 @@ customModes:
       - Working with CSS, HTML, and modern frontend frameworks
       - Ensuring consistent user experiences across platforms  # Required: non-empty
     whenToUse: >-
-      Use this mode when creating or modifying UI components, implementing design systems, 
-      or ensuring responsive web interfaces. This mode is especially effective with CSS, 
+      Use this mode when creating or modifying UI components, implementing design systems,
+      or ensuring responsive web interfaces. This mode is especially effective with CSS,
       HTML, and modern frontend frameworks.  # Optional but recommended
     groups:  # Required: array of tool groups (can be empty)
       - read     # Read files group (read_file, fetch_instructions, search_files, list_files, list_code_definition_names)

--- a/src/core/prompts/instructions/create-mode.ts
+++ b/src/core/prompts/instructions/create-mode.ts
@@ -26,7 +26,7 @@ If asked to create a project mode, create it in .roomodes in the workspace root.
   * groups: Array of allowed tool groups (can be empty). Each group can be specified either as a string (e.g., "edit" to allow editing any file) or with file restrictions (e.g., ["edit", { fileRegex: "\\.md$", description: "Markdown files only" }] to only allow editing markdown files)
 
 - The following fields are optional but highly recommended:
-  * description: A short, human-readable description of what this mode does (1-2 sentences)
+  * description: A short, human-readable description of what this mode does (5 words)
   * whenToUse: A clear description of when this mode should be selected and what types of tasks it's best suited for. This helps the Orchestrator mode make better decisions.
   * customInstructions: Additional instructions for how the mode should operate
 
@@ -37,7 +37,7 @@ Both files should follow this structure (in YAML format):
 customModes:
   - slug: designer  # Required: unique slug with lowercase letters, numbers, and hyphens
     name: Designer  # Required: mode display name
-    description: A UI/UX expert specializing in design systems and responsive frontend development.  # Optional but recommended: short description
+    description: UI/UX design systems expert  # Optional but recommended: short description (5 words)
     roleDefinition: >-
       You are Roo, a UI/UX expert specializing in design systems and frontend development. Your expertise includes:
       - Creating and maintaining design systems


### PR DESCRIPTION
## Summary

This PR adds the missing  field to the create_mode instructions.

## Changes

- Added  field to the optional but recommended fields list
- Added  field to the YAML example with clear guidance
- The  field already exists in the ModeConfig schema but was missing from the instructions

## Details

The  field provides a short, human-readable description of what the mode does (1-2 sentences). This helps users understand the purpose of a mode at a glance.

The field was already supported in the schema ( line 69) but wasn't documented in the create_mode instructions, which could lead to confusion for users creating custom modes.

## Testing

- ✅ All existing tests pass
- ✅ Linting passes
- ✅ Type checking passes
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `description` field to create_mode instructions in `create-mode.ts`, documenting its use and updating the YAML example.
> 
>   - **Behavior**:
>     - Adds `description` field to optional fields in `createModeInstructions` in `create-mode.ts`.
>     - Updates YAML example to include `description` field with guidance.
>   - **Documentation**:
>     - Documents `description` field, which was already in the ModeConfig schema but missing from instructions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1df5c4b96c406095b8b39ae61f50f6deaadad03f. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->