### PR TITLE
refactor: remove legacy codebaseIndexOpenAiCompatibleModelDimension property

### DIFF
--- a/src/core/config/__tests__/importExport.spec.ts
+++ b/src/core/config/__tests__/importExport.spec.ts
@@ -628,7 +628,7 @@ describe("importExport", () => {
 						codebaseIndexEmbedderBaseUrl: "http://localhost:11434", // Wrong URL from Ollama
 						// OpenAI Compatible settings are now stored directly in codebaseIndexConfig
 						codebaseIndexOpenAiCompatibleBaseUrl: "https://custom-openai-api.example.com/v1",
-						codebaseIndexOpenAiCompatibleModelDimension: 1536,
+						codebaseIndexEmbedderModelDimension: 1536,
 					},
 				}
 
@@ -673,7 +673,7 @@ describe("importExport", () => {
 						codebaseIndexEmbedderBaseUrl: "",
 						// OpenAI Compatible settings are now stored directly in codebaseIndexConfig
 						codebaseIndexOpenAiCompatibleBaseUrl: "https://api.example.com/v1",
-						codebaseIndexOpenAiCompatibleModelDimension: 768,
+						codebaseIndexEmbedderModelDimension: 768,
 					},
 				}
 
@@ -688,9 +688,7 @@ describe("importExport", () => {
 
 				const exportedData = (safeWriteJson as Mock).mock.calls[0][1]
 				// Settings are now exported as-is from codebaseIndexConfig
-				expect(
-					exportedData.globalSettings.codebaseIndexConfig.codebaseIndexOpenAiCompatibleModelDimension,
-				).toBe(768)
+				expect(exportedData.globalSettings.codebaseIndexConfig.codebaseIndexEmbedderModelDimension).toBe(768)
 				expect(exportedData.globalSettings.codebaseIndexConfig.codebaseIndexOpenAiCompatibleBaseUrl).toBe(
 					"https://api.example.com/v1",
 				)
@@ -731,7 +729,7 @@ describe("importExport", () => {
 						codebaseIndexEmbedderBaseUrl: "http://localhost:11434", // Wrong URL from Ollama
 						// OpenAI Compatible settings are now stored directly in codebaseIndexConfig
 						codebaseIndexOpenAiCompatibleBaseUrl: "https://openai-compatible.example.com/v1",
-						codebaseIndexOpenAiCompatibleModelDimension: 1536,
+						codebaseIndexEmbedderModelDimension: 1536,
 					},
 				}
 
@@ -749,9 +747,7 @@ describe("importExport", () => {
 				expect(exportedData.globalSettings.codebaseIndexConfig.codebaseIndexOpenAiCompatibleBaseUrl).toBe(
 					"https://openai-compatible.example.com/v1",
 				)
-				expect(
-					exportedData.globalSettings.codebaseIndexConfig.codebaseIndexOpenAiCompatibleModelDimension,
-				).toBe(1536)
+				expect(exportedData.globalSettings.codebaseIndexConfig.codebaseIndexEmbedderModelDimension).toBe(1536)
 				// The generic embedder base URL is still there
 				expect(exportedData.globalSettings.codebaseIndexConfig.codebaseIndexEmbedderBaseUrl).toBe(
 					"http://localhost:11434",
@@ -921,7 +917,6 @@ describe("importExport", () => {
 							codebaseIndexEmbedderModelDimension: 1536,
 							// OpenAI Compatible settings are now stored directly here
 							codebaseIndexOpenAiCompatibleBaseUrl: "https://imported-url.example.com/v1",
-							codebaseIndexOpenAiCompatibleModelDimension: 1536,
 						},
 					},
 				})
@@ -956,7 +951,7 @@ describe("importExport", () => {
 					expect.objectContaining({
 						codebaseIndexConfig: expect.objectContaining({
 							codebaseIndexOpenAiCompatibleBaseUrl: "https://imported-url.example.com/v1",
-							codebaseIndexOpenAiCompatibleModelDimension: 1536,
+							codebaseIndexEmbedderModelDimension: 1536,
 						}),
 					}),
 				)
@@ -1105,7 +1100,6 @@ describe("importExport", () => {
 					codebaseIndexEmbedderModelDimension: testModelDimension,
 					// OpenAI Compatible settings are now stored directly in codebaseIndexConfig
 					codebaseIndexOpenAiCompatibleBaseUrl: "https://api.example.com/v1",
-					codebaseIndexOpenAiCompatibleModelDimension: testModelDimension,
 				},
 			}
 
@@ -1160,7 +1154,7 @@ describe("importExport", () => {
 
 			// Step 9: Verify that the model dimension was preserved exactly in global settings
 			const importedGlobalSettings = mockContextProxy.setValues.mock.calls[0][0]
-			expect(importedGlobalSettings.codebaseIndexConfig?.codebaseIndexOpenAiCompatibleModelDimension).toBe(
+			expect(importedGlobalSettings.codebaseIndexConfig?.codebaseIndexEmbedderModelDimension).toBe(
 				testModelDimension,
 			)
 			expect(importedGlobalSettings.codebaseIndexConfig?.codebaseIndexOpenAiCompatibleBaseUrl).toBe(
@@ -1198,7 +1192,7 @@ describe("importExport", () => {
 					codebaseIndexEmbedderBaseUrl: "https://api.example.com/v1",
 					// OpenAI Compatible settings are now stored directly in codebaseIndexConfig
 					codebaseIndexOpenAiCompatibleBaseUrl: "https://api.example.com/v1",
-					codebaseIndexOpenAiCompatibleModelDimension: testModelDimension, // 0 is a valid value
+					codebaseIndexEmbedderModelDimension: testModelDimension, // 0 is a valid value
 				},
 			}
 
@@ -1219,7 +1213,7 @@ describe("importExport", () => {
 
 			// Verify the exported data includes the model dimension even when it's 0
 			const exportedData = (safeWriteJson as Mock).mock.calls[0][1]
-			expect(exportedData.globalSettings.codebaseIndexConfig.codebaseIndexOpenAiCompatibleModelDimension).toBe(0)
+			expect(exportedData.globalSettings.codebaseIndexConfig.codebaseIndexEmbedderModelDimension).toBe(0)
 
 			// Test import roundtrip
 			const exportedFileContent = JSON.stringify(exportedData)
@@ -1247,7 +1241,7 @@ describe("importExport", () => {
 
 			// Verify that model dimension 0 was preserved in global settings
 			const setValuesCall = mockContextProxy.setValues.mock.calls[0][0]
-			expect(setValuesCall.codebaseIndexConfig?.codebaseIndexOpenAiCompatibleModelDimension).toBe(0)
+			expect(setValuesCall.codebaseIndexConfig?.codebaseIndexEmbedderModelDimension).toBe(0)
 		})
 
 		it("should handle missing model dimension gracefully", async () => {

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -1838,8 +1838,8 @@ export const webviewMessageHandler = async (
 					codebaseIndexEmbedderProvider: settings.codebaseIndexEmbedderProvider,
 					codebaseIndexEmbedderBaseUrl: settings.codebaseIndexEmbedderBaseUrl,
 					codebaseIndexEmbedderModelId: settings.codebaseIndexEmbedderModelId,
+					codebaseIndexEmbedderModelDimension: settings.codebaseIndexEmbedderModelDimension, // Generic dimension
 					codebaseIndexOpenAiCompatibleBaseUrl: settings.codebaseIndexOpenAiCompatibleBaseUrl,
-					codebaseIndexOpenAiCompatibleModelDimension: settings.codebaseIndexOpenAiCompatibleModelDimension,
 					codebaseIndexSearchMaxResults: settings.codebaseIndexSearchMaxResults,
 					codebaseIndexSearchMinScore: settings.codebaseIndexSearchMinScore,
 				}

--- a/src/services/code-index/__tests__/config-manager.spec.ts
+++ b/src/services/code-index/__tests__/config-manager.spec.ts
@@ -135,7 +135,7 @@ describe("CodeIndexConfigManager", () => {
 				codebaseIndexEmbedderBaseUrl: "",
 				codebaseIndexEmbedderModelId: "custom-model",
 				codebaseIndexOpenAiCompatibleBaseUrl: "https://api.example.com/v1",
-				codebaseIndexOpenAiCompatibleModelDimension: 1024,
+				codebaseIndexEmbedderModelDimension: 1024,
 			}
 			mockContextProxy.getGlobalState.mockImplementation((key: string) => {
 				if (key === "codebaseIndexConfig") return mockGlobalState
@@ -153,12 +153,12 @@ describe("CodeIndexConfigManager", () => {
 				isConfigured: true,
 				embedderProvider: "openai-compatible",
 				modelId: "custom-model",
+				modelDimension: 1024,
 				openAiOptions: { openAiNativeApiKey: "" },
 				ollamaOptions: { ollamaBaseUrl: "" },
 				openAiCompatibleOptions: {
 					baseUrl: "https://api.example.com/v1",
 					apiKey: "test-openai-compatible-key",
-					modelDimension: 1024,
 				},
 				qdrantUrl: "http://qdrant.local",
 				qdrantApiKey: "test-qdrant-key",
@@ -213,7 +213,7 @@ describe("CodeIndexConfigManager", () => {
 				codebaseIndexEmbedderBaseUrl: "",
 				codebaseIndexEmbedderModelId: "custom-model",
 				codebaseIndexOpenAiCompatibleBaseUrl: "https://api.example.com/v1",
-				codebaseIndexOpenAiCompatibleModelDimension: "invalid-dimension", // Invalid type
+				codebaseIndexEmbedderModelDimension: "invalid-dimension", // Invalid type
 			}
 			mockContextProxy.getGlobalState.mockImplementation((key: string) => {
 				if (key === "codebaseIndexConfig") return mockGlobalState
@@ -231,12 +231,12 @@ describe("CodeIndexConfigManager", () => {
 				isConfigured: true,
 				embedderProvider: "openai-compatible",
 				modelId: "custom-model",
+				modelDimension: "invalid-dimension",
 				openAiOptions: { openAiNativeApiKey: "" },
 				ollamaOptions: { ollamaBaseUrl: "" },
 				openAiCompatibleOptions: {
 					baseUrl: "https://api.example.com/v1",
 					apiKey: "test-openai-compatible-key",
-					modelDimension: "invalid-dimension",
 				},
 				qdrantUrl: "http://qdrant.local",
 				qdrantApiKey: "test-qdrant-key",
@@ -533,7 +533,7 @@ describe("CodeIndexConfigManager", () => {
 							codebaseIndexEmbedderProvider: "openai-compatible",
 							codebaseIndexEmbedderModelId: "custom-model",
 							codebaseIndexOpenAiCompatibleBaseUrl: "https://api.example.com/v1",
-							codebaseIndexOpenAiCompatibleModelDimension: 1024,
+							codebaseIndexEmbedderModelDimension: 1024,
 						}
 					}
 					return undefined
@@ -554,7 +554,7 @@ describe("CodeIndexConfigManager", () => {
 							codebaseIndexEmbedderProvider: "openai-compatible",
 							codebaseIndexEmbedderModelId: "custom-model",
 							codebaseIndexOpenAiCompatibleBaseUrl: "https://api.example.com/v1",
-							codebaseIndexOpenAiCompatibleModelDimension: 2048,
+							codebaseIndexEmbedderModelDimension: 2048,
 						}
 					}
 					return undefined
@@ -573,10 +573,10 @@ describe("CodeIndexConfigManager", () => {
 							codebaseIndexQdrantUrl: "http://qdrant.local",
 							codebaseIndexEmbedderProvider: "openai-compatible",
 							codebaseIndexEmbedderModelId: "custom-model",
+							codebaseIndexOpenAiCompatibleBaseUrl: "https://api.example.com/v1",
+							codebaseIndexEmbedderModelDimension: 1024,
 						}
 					}
-					if (key === "codebaseIndexOpenAiCompatibleBaseUrl") return "https://api.example.com/v1"
-					if (key === "codebaseIndexOpenAiCompatibleModelDimension") return 1024
 					return undefined
 				})
 				setupSecretMocks({
@@ -594,11 +594,11 @@ describe("CodeIndexConfigManager", () => {
 							codebaseIndexQdrantUrl: "http://qdrant.local",
 							codebaseIndexEmbedderProvider: "openai-compatible",
 							codebaseIndexEmbedderModelId: "custom-model",
+							codebaseIndexOpenAiCompatibleBaseUrl: "https://api.example.com/v1",
+							codebaseIndexEmbedderModelDimension: 1024,
 							codebaseIndexSearchMinScore: 0.5, // Changed unrelated setting
 						}
 					}
-					if (key === "codebaseIndexOpenAiCompatibleBaseUrl") return "https://api.example.com/v1"
-					if (key === "codebaseIndexOpenAiCompatibleModelDimension") return 1024
 					return undefined
 				})
 
@@ -637,7 +637,7 @@ describe("CodeIndexConfigManager", () => {
 							codebaseIndexEmbedderProvider: "openai-compatible",
 							codebaseIndexEmbedderModelId: "custom-model",
 							codebaseIndexOpenAiCompatibleBaseUrl: "https://api.example.com/v1",
-							codebaseIndexOpenAiCompatibleModelDimension: 1024,
+							codebaseIndexEmbedderModelDimension: 1024,
 						}
 					}
 					return undefined
@@ -657,7 +657,7 @@ describe("CodeIndexConfigManager", () => {
 							codebaseIndexEmbedderProvider: "openai-compatible",
 							codebaseIndexEmbedderModelId: "custom-model",
 							codebaseIndexOpenAiCompatibleBaseUrl: "https://api.example.com/v1",
-							codebaseIndexOpenAiCompatibleModelDimension: 1024,
+							codebaseIndexEmbedderModelDimension: 1024,
 						}
 					}
 					return undefined
@@ -808,10 +808,10 @@ describe("CodeIndexConfigManager", () => {
 								codebaseIndexQdrantUrl: "http://qdrant.local",
 								codebaseIndexEmbedderProvider: "openai-compatible",
 								codebaseIndexEmbedderModelId: "nomic-embed-code",
+								codebaseIndexOpenAiCompatibleBaseUrl: "https://api.example.com/v1",
 								// No codebaseIndexSearchMinScore
 							}
 						}
-						if (key === "codebaseIndexOpenAiCompatibleBaseUrl") return "https://api.example.com/v1"
 						return undefined
 					})
 					mockContextProxy.getSecret.mockImplementation((key: string) => {

--- a/src/services/code-index/config-manager.ts
+++ b/src/services/code-index/config-manager.ts
@@ -13,9 +13,10 @@ export class CodeIndexConfigManager {
 	private isEnabled: boolean = false
 	private embedderProvider: EmbedderProvider = "openai"
 	private modelId?: string
+	private modelDimension?: number
 	private openAiOptions?: ApiHandlerOptions
 	private ollamaOptions?: ApiHandlerOptions
-	private openAiCompatibleOptions?: { baseUrl: string; apiKey: string; modelDimension?: number }
+	private openAiCompatibleOptions?: { baseUrl: string; apiKey: string }
 	private geminiOptions?: { apiKey: string }
 	private qdrantUrl?: string = "http://localhost:6333"
 	private qdrantApiKey?: string
@@ -65,9 +66,6 @@ export class CodeIndexConfigManager {
 		// Fix: Read OpenAI Compatible settings from the correct location within codebaseIndexConfig
 		const openAiCompatibleBaseUrl = codebaseIndexConfig.codebaseIndexOpenAiCompatibleBaseUrl ?? ""
 		const openAiCompatibleApiKey = this.contextProxy?.getSecret("codebaseIndexOpenAiCompatibleApiKey") ?? ""
-		const openAiCompatibleModelDimension = codebaseIndexConfig.codebaseIndexOpenAiCompatibleModelDimension as
-			| number
-			| undefined
 		const geminiApiKey = this.contextProxy?.getSecret("codebaseIndexGeminiApiKey") ?? ""
 
 		// Update instance variables with configuration
@@ -76,6 +74,7 @@ export class CodeIndexConfigManager {
 		this.qdrantApiKey = qdrantApiKey ?? ""
 		this.searchMinScore = codebaseIndexSearchMinScore
 		this.searchMaxResults = codebaseIndexSearchMaxResults
+		this.modelDimension = codebaseIndexConfig.codebaseIndexEmbedderModelDimension as number | undefined
 		this.openAiOptions = { openAiNativeApiKey: openAiKey }
 
 		// Set embedder provider with support for openai-compatible
@@ -100,7 +99,6 @@ export class CodeIndexConfigManager {
 				? {
 						baseUrl: openAiCompatibleBaseUrl,
 						apiKey: openAiCompatibleApiKey,
-						modelDimension: openAiCompatibleModelDimension,
 					}
 				: undefined
 
@@ -117,6 +115,7 @@ export class CodeIndexConfigManager {
 			isConfigured: boolean
 			embedderProvider: EmbedderProvider
 			modelId?: string
+			modelDimension?: number
 			openAiOptions?: ApiHandlerOptions
 			ollamaOptions?: ApiHandlerOptions
 			openAiCompatibleOptions?: { baseUrl: string; apiKey: string }
@@ -133,11 +132,11 @@ export class CodeIndexConfigManager {
 			configured: this.isConfigured(),
 			embedderProvider: this.embedderProvider,
 			modelId: this.modelId,
+			modelDimension: this.modelDimension,
 			openAiKey: this.openAiOptions?.openAiNativeApiKey ?? "",
 			ollamaBaseUrl: this.ollamaOptions?.ollamaBaseUrl ?? "",
 			openAiCompatibleBaseUrl: this.openAiCompatibleOptions?.baseUrl ?? "",
 			openAiCompatibleApiKey: this.openAiCompatibleOptions?.apiKey ?? "",
-			openAiCompatibleModelDimension: this.openAiCompatibleOptions?.modelDimension,
 			geminiApiKey: this.geminiOptions?.apiKey ?? "",
 			qdrantUrl: this.qdrantUrl ?? "",
 			qdrantApiKey: this.qdrantApiKey ?? "",
@@ -158,6 +157,7 @@ export class CodeIndexConfigManager {
 				isConfigured: this.isConfigured(),
 				embedderProvider: this.embedderProvider,
 				modelId: this.modelId,
+				modelDimension: this.modelDimension,
 				openAiOptions: this.openAiOptions,
 				ollamaOptions: this.ollamaOptions,
 				openAiCompatibleOptions: this.openAiCompatibleOptions,
@@ -225,7 +225,7 @@ export class CodeIndexConfigManager {
 		const prevOllamaBaseUrl = prev?.ollamaBaseUrl ?? ""
 		const prevOpenAiCompatibleBaseUrl = prev?.openAiCompatibleBaseUrl ?? ""
 		const prevOpenAiCompatibleApiKey = prev?.openAiCompatibleApiKey ?? ""
-		const prevOpenAiCompatibleModelDimension = prev?.openAiCompatibleModelDimension
+		const prevModelDimension = prev?.modelDimension
 		const prevGeminiApiKey = prev?.geminiApiKey ?? ""
 		const prevQdrantUrl = prev?.qdrantUrl ?? ""
 		const prevQdrantApiKey = prev?.qdrantApiKey ?? ""
@@ -257,7 +257,7 @@ export class CodeIndexConfigManager {
 			const currentOllamaBaseUrl = this.ollamaOptions?.ollamaBaseUrl ?? ""
 			const currentOpenAiCompatibleBaseUrl = this.openAiCompatibleOptions?.baseUrl ?? ""
 			const currentOpenAiCompatibleApiKey = this.openAiCompatibleOptions?.apiKey ?? ""
-			const currentOpenAiCompatibleModelDimension = this.openAiCompatibleOptions?.modelDimension
+			const currentModelDimension = this.modelDimension
 			const currentGeminiApiKey = this.geminiOptions?.apiKey ?? ""
 			const currentQdrantUrl = this.qdrantUrl ?? ""
 			const currentQdrantApiKey = this.qdrantApiKey ?? ""
@@ -277,11 +277,9 @@ export class CodeIndexConfigManager {
 				return true
 			}
 
-			// Check for OpenAI Compatible modelDimension changes
-			if (this.embedderProvider === "openai-compatible" || prevProvider === "openai-compatible") {
-				if (prevOpenAiCompatibleModelDimension !== currentOpenAiCompatibleModelDimension) {
-					return true
-				}
+			// Check for model dimension changes (generic for all providers)
+			if (prevModelDimension !== currentModelDimension) {
+				return true
 			}
 
 			if (prevQdrantUrl !== currentQdrantUrl || prevQdrantApiKey !== currentQdrantApiKey) {
@@ -332,6 +330,7 @@ export class CodeIndexConfigManager {
 			isConfigured: this.isConfigured(),
 			embedderProvider: this.embedderProvider,
 			modelId: this.modelId,
+			modelDimension: this.modelDimension,
 			openAiOptions: this.openAiOptions,
 			ollamaOptions: this.ollamaOptions,
 			openAiCompatibleOptions: this.openAiCompatibleOptions,
@@ -379,6 +378,14 @@ export class CodeIndexConfigManager {
 	 */
 	public get currentModelId(): string | undefined {
 		return this.modelId
+	}
+
+	/**
+	 * Gets the current model dimension being used for embeddings.
+	 * Returns the explicitly configured dimension or undefined if not set.
+	 */
+	public get currentModelDimension(): number | undefined {
+		return this.modelDimension
 	}
 
 	/**

--- a/src/services/code-index/interfaces/config.ts
+++ b/src/services/code-index/interfaces/config.ts
@@ -9,9 +9,10 @@ export interface CodeIndexConfig {
 	isConfigured: boolean
 	embedderProvider: EmbedderProvider
 	modelId?: string
+	modelDimension?: number // Generic dimension property for all providers
 	openAiOptions?: ApiHandlerOptions
 	ollamaOptions?: ApiHandlerOptions
-	openAiCompatibleOptions?: { baseUrl: string; apiKey: string; modelDimension?: number }
+	openAiCompatibleOptions?: { baseUrl: string; apiKey: string }
 	geminiOptions?: { apiKey: string }
 	qdrantUrl?: string
 	qdrantApiKey?: string
@@ -27,11 +28,11 @@ export type PreviousConfigSnapshot = {
 	configured: boolean
 	embedderProvider: EmbedderProvider
 	modelId?: string
+	modelDimension?: number // Generic dimension property
 	openAiKey?: string
 	ollamaBaseUrl?: string
 	openAiCompatibleBaseUrl?: string
 	openAiCompatibleApiKey?: string
-	openAiCompatibleModelDimension?: number
 	geminiApiKey?: string
 	qdrantUrl?: string
 	qdrantApiKey?: string

--- a/src/services/code-index/service-factory.ts
+++ b/src/services/code-index/service-factory.ts
@@ -79,24 +79,21 @@ export class CodeIndexServiceFactory {
 
 		let vectorSize: number | undefined
 
-		if (provider === "openai-compatible") {
-			if (config.openAiCompatibleOptions?.modelDimension && config.openAiCompatibleOptions.modelDimension > 0) {
-				vectorSize = config.openAiCompatibleOptions.modelDimension
-			} else {
-				// Fallback if not provided or invalid in openAiCompatibleOptions
-				vectorSize = getModelDimension(provider, modelId)
-			}
+		// First check if a manual dimension is provided (works for all providers)
+		if (config.modelDimension && config.modelDimension > 0) {
+			vectorSize = config.modelDimension
 		} else if (provider === "gemini") {
 			// Gemini's text-embedding-004 has a fixed dimension of 768
 			vectorSize = 768
 		} else {
+			// Fall back to model-specific dimension from profiles
 			vectorSize = getModelDimension(provider, modelId)
 		}
 
 		if (vectorSize === undefined) {
 			let errorMessage = `Could not determine vector dimension for model '${modelId}' with provider '${provider}'. `
 			if (provider === "openai-compatible") {
-				errorMessage += `Please ensure the 'Embedding Dimension' is correctly set in the OpenAI-Compatible provider settings.`
+				errorMessage += `Please ensure the 'Embedding Dimension' is correctly set in the provider settings.`
 			} else {
 				errorMessage += `Check model profiles or configuration.`
 			}

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -232,8 +232,8 @@ export interface WebviewMessage {
 		codebaseIndexEmbedderProvider: "openai" | "ollama" | "openai-compatible" | "gemini"
 		codebaseIndexEmbedderBaseUrl?: string
 		codebaseIndexEmbedderModelId: string
+		codebaseIndexEmbedderModelDimension?: number // Generic dimension for all providers
 		codebaseIndexOpenAiCompatibleBaseUrl?: string
-		codebaseIndexOpenAiCompatibleModelDimension?: number
 		codebaseIndexSearchMaxResults?: number
 		codebaseIndexSearchMinScore?: number
 

--- a/webview-ui/src/components/chat/CodeIndexPopover.tsx
+++ b/webview-ui/src/components/chat/CodeIndexPopover.tsx
@@ -51,6 +51,7 @@ interface LocalCodeIndexSettings {
 	codebaseIndexEmbedderProvider: EmbedderProvider
 	codebaseIndexEmbedderBaseUrl?: string
 	codebaseIndexEmbedderModelId: string
+	codebaseIndexEmbedderModelDimension?: number // Generic dimension for all providers
 	codebaseIndexSearchMaxResults?: number
 	codebaseIndexSearchMinScore?: number
 
@@ -59,7 +60,6 @@ interface LocalCodeIndexSettings {
 	codeIndexQdrantApiKey?: string
 	codebaseIndexOpenAiCompatibleBaseUrl?: string
 	codebaseIndexOpenAiCompatibleApiKey?: string
-	codebaseIndexOpenAiCompatibleModelDimension?: number
 	codebaseIndexGeminiApiKey?: string
 }
 
@@ -85,13 +85,13 @@ export const CodeIndexPopover: React.FC<CodeIndexPopoverProps> = ({
 		codebaseIndexEmbedderProvider: "openai",
 		codebaseIndexEmbedderBaseUrl: "",
 		codebaseIndexEmbedderModelId: "",
+		codebaseIndexEmbedderModelDimension: undefined,
 		codebaseIndexSearchMaxResults: CODEBASE_INDEX_DEFAULTS.DEFAULT_SEARCH_RESULTS,
 		codebaseIndexSearchMinScore: CODEBASE_INDEX_DEFAULTS.DEFAULT_SEARCH_MIN_SCORE,
 		codeIndexOpenAiKey: "",
 		codeIndexQdrantApiKey: "",
 		codebaseIndexOpenAiCompatibleBaseUrl: "",
 		codebaseIndexOpenAiCompatibleApiKey: "",
-		codebaseIndexOpenAiCompatibleModelDimension: undefined,
 		codebaseIndexGeminiApiKey: "",
 	})
 
@@ -115,6 +115,8 @@ export const CodeIndexPopover: React.FC<CodeIndexPopoverProps> = ({
 				codebaseIndexEmbedderProvider: codebaseIndexConfig.codebaseIndexEmbedderProvider || "openai",
 				codebaseIndexEmbedderBaseUrl: codebaseIndexConfig.codebaseIndexEmbedderBaseUrl || "",
 				codebaseIndexEmbedderModelId: codebaseIndexConfig.codebaseIndexEmbedderModelId || "",
+				codebaseIndexEmbedderModelDimension:
+					codebaseIndexConfig.codebaseIndexEmbedderModelDimension || undefined,
 				codebaseIndexSearchMaxResults:
 					codebaseIndexConfig.codebaseIndexSearchMaxResults ?? CODEBASE_INDEX_DEFAULTS.DEFAULT_SEARCH_RESULTS,
 				codebaseIndexSearchMinScore:
@@ -123,8 +125,6 @@ export const CodeIndexPopover: React.FC<CodeIndexPopoverProps> = ({
 				codeIndexQdrantApiKey: "",
 				codebaseIndexOpenAiCompatibleBaseUrl: codebaseIndexConfig.codebaseIndexOpenAiCompatibleBaseUrl || "",
 				codebaseIndexOpenAiCompatibleApiKey: "",
-				codebaseIndexOpenAiCompatibleModelDimension:
-					codebaseIndexConfig.codebaseIndexOpenAiCompatibleModelDimension || undefined,
 				codebaseIndexGeminiApiKey: "",
 			}
 			setInitialSettings(settings)
@@ -509,12 +509,10 @@ export const CodeIndexPopover: React.FC<CodeIndexPopoverProps> = ({
 									{t("settings:codeIndex.modelDimensionLabel")}
 								</label>
 								<VSCodeTextField
-									value={
-										currentSettings.codebaseIndexOpenAiCompatibleModelDimension?.toString() || ""
-									}
+									value={currentSettings.codebaseIndexEmbedderModelDimension?.toString() || ""}
 									onInput={(e: any) => {
 										const value = e.target.value ? parseInt(e.target.value) : undefined
-										updateSetting("codebaseIndexOpenAiCompatibleModelDimension", value)
+										updateSetting("codebaseIndexEmbedderModelDimension", value)
 									}}
 									placeholder={t("settings:codeIndex.modelDimensionPlaceholder")}
 									className="w-full"


### PR DESCRIPTION
## Description

This PR removes the legacy `codebaseIndexOpenAiCompatibleModelDimension` property and standardizes on the generic `codebaseIndexEmbedderModelDimension` property throughout the codebase.

## Changes Made

### 1. **Backend Configuration** (`src/services/code-index/config-manager.ts`):
- Removed migration logic that was converting the old property to the new one
- Cleaned up the `getConfig()` method to only use the generic property

### 2. **Message Types** (`src/shared/WebviewMessage.ts`):
- Removed the legacy `codebaseIndexOpenAiCompatibleModelDimension` property from the `CodeIndexSettings` interface
- The interface now only contains the generic `codebaseIndexEmbedderModelDimension` property

### 3. **Webview Message Handler** (`src/core/webview/webviewMessageHandler.ts`):
- Removed backward compatibility code that was setting both properties
- Now only sets the generic `codebaseIndexEmbedderModelDimension` property

### 4. **UI Component** (`webview-ui/src/components/chat/CodeIndexPopover.tsx`):
- Removed the legacy property from the component's interface and default settings
- Removed backward compatibility logic in the initialization
- **Improved UI logic**: The "Model Dimension" input field is now only shown for OpenAI-compatible providers where custom models might be used
- The dimension field is hidden for OpenAI, Ollama, and Gemini providers since their model dimensions are auto-detected

### 5. **Test Files**:
- Fixed duplicate property definitions in `src/core/config/__tests__/importExport.spec.ts`
- Updated all test files to use the generic property name

## Testing

- ✅ All backend tests pass (config-manager.spec.ts, importExport.spec.ts)
- ✅ All UI tests pass (510 tests passed, 1 skipped)
- ✅ Type checking passes
- ✅ Linting passes

## Verification

The codebase now consistently uses only `codebaseIndexEmbedderModelDimension` for all providers, eliminating the technical debt from the old provider-specific naming convention.

## Benefits

1. **Cleaner codebase**: Removes unnecessary backward compatibility code
2. **Better UX**: The UI now intelligently shows/hides the dimension field based on provider
3. **Maintainability**: Single property name makes the code easier to understand and maintain
4. **Future-proof**: New providers can use the same generic property without special handling