### PR TITLE
Remove warning about writing not being allowed

### DIFF
--- a/src/core/environment/__tests__/getEnvironmentDetails.spec.ts
+++ b/src/core/environment/__tests__/getEnvironmentDetails.spec.ts
@@ -313,25 +313,6 @@ describe("getEnvironmentDetails", () => {
 		expect(mockInactiveTerminal.getCurrentWorkingDirectory).toHaveBeenCalled()
 	})
 
-	it("should include warning when file writing is not allowed", async () => {
-		;(isToolAllowedForMode as Mock).mockReturnValue(false)
-		;(getModeBySlug as Mock).mockImplementation((slug: string) => {
-			if (slug === "code") {
-				return { name: "💻 Code" }
-			}
-
-			if (slug === defaultModeSlug) {
-				return { name: "Default Mode" }
-			}
-
-			return null
-		})
-
-		const result = await getEnvironmentDetails(mockCline as Task)
-
-		expect(result).toContain("NOTE: You are currently in '💻 Code' mode, which does not allow write operations")
-	})
-
 	it("should include experiment-specific details when Power Steering is enabled", async () => {
 		mockState.experiments = { [EXPERIMENT_IDS.POWER_STEERING]: true }
 		;(experiments.isEnabled as Mock).mockReturnValue(true)

--- a/src/core/environment/getEnvironmentDetails.ts
+++ b/src/core/environment/getEnvironmentDetails.ts
@@ -233,16 +233,6 @@ export async function getEnvironmentDetails(cline: Task, includeFileDetails: boo
 		}
 	}
 
-	// Add warning if not in code mode.
-	if (
-		!isToolAllowedForMode("write_to_file", currentMode, customModes ?? [], { apply_diff: cline.diffEnabled }) &&
-		!isToolAllowedForMode("apply_diff", currentMode, customModes ?? [], { apply_diff: cline.diffEnabled })
-	) {
-		const currentModeName = getModeBySlug(currentMode, customModes)?.name ?? currentMode
-		const defaultModeName = getModeBySlug(defaultModeSlug, customModes)?.name ?? defaultModeSlug
-		details += `\n\nNOTE: You are currently in '${currentModeName}' mode, which does not allow write operations. To write files, the user will need to switch to a mode that supports file writing, such as '${defaultModeName}' mode.`
-	}
-
 	if (includeFileDetails) {
 		details += `\n\n# Current Workspace Directory (${cline.cwd.toPosix()}) Files\n`
 		const isDesktop = arePathsEqual(cline.cwd, path.join(os.homedir(), "Desktop"))


### PR DESCRIPTION
This was pointing to architect anyway since we made it the default mode... but in general I think it's better not to hardcode references to other modes in the prompt.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove warning about file writing restrictions in `getEnvironmentDetails` and its test cases.
> 
>   - **Behavior**:
>     - Removes warning about file writing restrictions in `getEnvironmentDetails`.
>     - Simplifies prompt by not referencing specific modes.
>   - **Tests**:
>     - Removes test case for file writing warning in `getEnvironmentDetails.spec.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0bf8f0d984418dc91821765ec2692fa597df7e75. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->