### PR TITLE
Remove modifier checks from prompt history navigation

### DIFF
--- a/webview-ui/src/components/chat/__tests__/ChatTextArea.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/ChatTextArea.spec.tsx
@@ -445,13 +445,15 @@ describe("ChatTextArea", () => {
 				})
 			})
 
-			it("should navigate to previous prompt on arrow up", () => {
+			it("should navigate to previous prompt on arrow up when cursor is at beginning", () => {
 				const setInputValue = vi.fn()
 				const { container } = render(
 					<ChatTextArea {...defaultProps} setInputValue={setInputValue} inputValue="" />,
 				)
 
 				const textarea = container.querySelector("textarea")!
+				// Ensure cursor is at the beginning
+				textarea.setSelectionRange(0, 0)
 
 				// Simulate arrow up key press
 				fireEvent.keyDown(textarea, { key: "ArrowUp" })
@@ -754,6 +756,86 @@ describe("ChatTextArea", () => {
 				// Should start from beginning of conversation history (newest first)
 				fireEvent.keyDown(textarea, { key: "ArrowUp" })
 				expect(setInputValue).toHaveBeenCalledWith("Message 2")
+			})
+
+			it("should not navigate history with arrow up when cursor is not at beginning", () => {
+				const setInputValue = vi.fn()
+				const { container } = render(
+					<ChatTextArea {...defaultProps} setInputValue={setInputValue} inputValue="Some text here" />,
+				)
+
+				const textarea = container.querySelector("textarea")!
+				// Set cursor to middle of text (not at beginning)
+				textarea.setSelectionRange(5, 5)
+
+				// Clear any calls from initial render
+				setInputValue.mockClear()
+
+				// Simulate arrow up key press
+				fireEvent.keyDown(textarea, { key: "ArrowUp" })
+
+				// Should not navigate history, allowing default behavior (move cursor to start)
+				expect(setInputValue).not.toHaveBeenCalled()
+			})
+
+			it("should navigate history with arrow up when cursor is at beginning", () => {
+				const setInputValue = vi.fn()
+				const { container } = render(
+					<ChatTextArea {...defaultProps} setInputValue={setInputValue} inputValue="Some text here" />,
+				)
+
+				const textarea = container.querySelector("textarea")!
+				// Set cursor to beginning of text
+				textarea.setSelectionRange(0, 0)
+
+				// Clear any calls from initial render
+				setInputValue.mockClear()
+
+				// Simulate arrow up key press
+				fireEvent.keyDown(textarea, { key: "ArrowUp" })
+
+				// Should navigate to history since cursor is at beginning
+				expect(setInputValue).toHaveBeenCalledWith("Third prompt")
+			})
+
+			it("should navigate history with Command+Up when cursor is at beginning", () => {
+				const setInputValue = vi.fn()
+				const { container } = render(
+					<ChatTextArea {...defaultProps} setInputValue={setInputValue} inputValue="Some text here" />,
+				)
+
+				const textarea = container.querySelector("textarea")!
+				// Set cursor to beginning of text
+				textarea.setSelectionRange(0, 0)
+
+				// Clear any calls from initial render
+				setInputValue.mockClear()
+
+				// Simulate Command+Up key press
+				fireEvent.keyDown(textarea, { key: "ArrowUp", metaKey: true })
+
+				// Should navigate to history since cursor is at beginning (same as regular Up)
+				expect(setInputValue).toHaveBeenCalledWith("Third prompt")
+			})
+
+			it("should not navigate history with Command+Up when cursor is not at beginning", () => {
+				const setInputValue = vi.fn()
+				const { container } = render(
+					<ChatTextArea {...defaultProps} setInputValue={setInputValue} inputValue="Some text here" />,
+				)
+
+				const textarea = container.querySelector("textarea")!
+				// Set cursor to middle of text (not at beginning)
+				textarea.setSelectionRange(5, 5)
+
+				// Clear any calls from initial render
+				setInputValue.mockClear()
+
+				// Simulate Command+Up key press
+				fireEvent.keyDown(textarea, { key: "ArrowUp", metaKey: true })
+
+				// Should not navigate history, allowing default behavior (same as regular Up)
+				expect(setInputValue).not.toHaveBeenCalled()
 			})
 		})
 	})

--- a/webview-ui/src/components/chat/hooks/usePromptHistory.ts
+++ b/webview-ui/src/components/chat/hooks/usePromptHistory.ts
@@ -139,32 +139,8 @@ export const usePromptHistory = ({
 				const isAtBeginning = selectionStart === 0 && selectionEnd === 0
 				const isAtEnd = selectionStart === value.length && selectionEnd === value.length
 
-				// Check for modifier keys (Alt or Cmd/Ctrl)
-				const hasModifier = event.altKey || event.metaKey || event.ctrlKey
-
-				// Handle explicit history navigation with Alt+Up/Down
-				if (hasModifier && (event.key === "ArrowUp" || event.key === "ArrowDown")) {
-					event.preventDefault()
-
-					if (event.key === "ArrowUp") {
-						// Save current input if starting navigation
-						if (historyIndex === -1) {
-							setTempInput(inputValue)
-						}
-						return navigateToHistory(historyIndex + 1, textarea, "start")
-					} else {
-						// ArrowDown
-						if (historyIndex > 0) {
-							return navigateToHistory(historyIndex - 1, textarea, "end")
-						} else if (historyIndex === 0) {
-							returnToCurrentInput(textarea, "end")
-							return true
-						}
-					}
-				}
-
-				// Handle smart navigation without modifiers
-				if (!hasSelection && !hasModifier) {
+				// Handle smart navigation
+				if (!hasSelection) {
 					// Only navigate history with UP if cursor is at the very beginning
 					if (event.key === "ArrowUp" && isAtBeginning) {
 						event.preventDefault()


### PR DESCRIPTION
Command+up should take you to the top of the textarea, not to the previous prompt.