### PR TITLE
Add a hint about using todos for complicated tasks

### DIFF
--- a/src/core/environment/reminder.ts
+++ b/src/core/environment/reminder.ts
@@ -5,7 +5,7 @@ import { TodoItem, TodoStatus } from "@roo-code/types"
  */
 export function formatReminderSection(todoList?: TodoItem[]): string {
 	if (!todoList || todoList.length === 0) {
-		return ""
+		return "You have not created a todo list yet. Create one with `update_todo_list` if your task is complicated or involves multiple steps."
 	}
 	const statusMap: Record<TodoStatus, string> = {
 		pending: "Pending",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a hint in `formatReminderSection` in `reminder.ts` to use `update_todo_list` for complicated tasks when the todo list is empty.
> 
>   - **Behavior**:
>     - Updates `formatReminderSection` in `reminder.ts` to return a hint about using `update_todo_list` for complicated tasks when the todo list is empty.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for cc01357c72a5e9fbd9650a83f1aab92bc094caf2. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->