### PR TITLE
Only show share modal from sharebutton

### DIFF
--- a/webview-ui/src/components/chat/ShareButton.tsx
+++ b/webview-ui/src/components/chat/ShareButton.tsx
@@ -35,19 +35,31 @@ export const ShareButton = ({ item, disabled = false }: ShareButtonProps) => {
 	const { t } = useTranslation()
 	const { sharingEnabled, cloudIsAuthenticated, cloudUserInfo } = useExtensionState()
 	const wasUnauthenticatedRef = useRef(false)
+	const initiatedAuthFromThisButtonRef = useRef(false)
 
 	// Track authentication state changes to auto-open popover after login
 	useEffect(() => {
 		if (!cloudIsAuthenticated || !sharingEnabled) {
 			wasUnauthenticatedRef.current = true
 		} else if (wasUnauthenticatedRef.current && cloudIsAuthenticated && sharingEnabled) {
-			// User just authenticated, send telemetry, close modal, and open the popover
-			telemetryClient.capture(TelemetryEventName.ACCOUNT_CONNECT_SUCCESS)
-			setConnectModalOpen(false)
-			setShareDropdownOpen(true)
+			// Only open dropdown if auth was initiated from this button
+			if (initiatedAuthFromThisButtonRef.current) {
+				// User just authenticated from this share button, send telemetry, close modal, and open the popover
+				telemetryClient.capture(TelemetryEventName.ACCOUNT_CONNECT_SUCCESS)
+				setConnectModalOpen(false)
+				setShareDropdownOpen(true)
+				initiatedAuthFromThisButtonRef.current = false // Reset the flag
+			}
 			wasUnauthenticatedRef.current = false
 		}
 	}, [cloudIsAuthenticated, sharingEnabled])
+
+	// Cleanup effect to reset flag on unmount
+	useEffect(() => {
+		return () => {
+			initiatedAuthFromThisButtonRef.current = false
+		}
+	}, [])
 
 	// Listen for share success messages from the extension
 	useEffect(() => {
@@ -92,6 +104,8 @@ export const ShareButton = ({ item, disabled = false }: ShareButtonProps) => {
 		// Send telemetry for connect to cloud action
 		telemetryClient.capture(TelemetryEventName.SHARE_CONNECT_TO_CLOUD_CLICKED)
 
+		// Mark that authentication was initiated from this button
+		initiatedAuthFromThisButtonRef.current = true
 		vscode.postMessage({ type: "rooCloudSignIn" })
 		setShareDropdownOpen(false)
 		setConnectModalOpen(false)


### PR DESCRIPTION
Fixes an issue where connecting to Roo Code Cloud from the account tab was popping up a share modal
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue where share modal was incorrectly shown from the account tab by ensuring it only opens when authentication is initiated from the share button.
> 
>   - **Behavior**:
>     - Fixes issue where share modal was incorrectly shown when connecting to Roo Code Cloud from the account tab.
>     - Introduces `initiatedAuthFromThisButtonRef` in `ShareButton.tsx` to track if authentication was initiated from the share button.
>     - Share modal only opens if authentication is initiated from the share button.
>   - **Tests**:
>     - Updates `TaskActions.spec.tsx` to test that the share modal does not open when authentication is initiated from elsewhere.
>     - Adds test to verify share modal opens when authentication is initiated from the share button.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 6b6c2755f56f1349c41d544deda7377824735376. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->