### PR TITLE
Remove unnecessary useEffect from sharebutton

### DIFF
--- a/webview-ui/src/components/chat/ShareButton.tsx
+++ b/webview-ui/src/components/chat/ShareButton.tsx
@@ -54,13 +54,6 @@ export const ShareButton = ({ item, disabled = false }: ShareButtonProps) => {
 		}
 	}, [cloudIsAuthenticated, sharingEnabled])
 
-	// Cleanup effect to reset flag on unmount
-	useEffect(() => {
-		return () => {
-			initiatedAuthFromThisButtonRef.current = false
-		}
-	}, [])
-
 	// Listen for share success messages from the extension
 	useEffect(() => {
 		const handleMessage = (event: MessageEvent) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove unnecessary `useEffect` from `ShareButton.tsx` to simplify code.
> 
>   - **Code Simplification**:
>     - Removed unnecessary `useEffect` in `ShareButton.tsx` that reset `initiatedAuthFromThisButtonRef` on unmount.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for fa120253c280a05561fb6c0e399819c74c78694e. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->