### PR TITLE
Move codebase indexing out of experimental

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1510,7 +1510,7 @@ export class ClineProvider
 			customCondensingPrompt,
 			codebaseIndexModels: codebaseIndexModels ?? EMBEDDING_MODEL_PROFILES,
 			codebaseIndexConfig: codebaseIndexConfig ?? {
-				codebaseIndexEnabled: false,
+				codebaseIndexEnabled: true,
 				codebaseIndexQdrantUrl: "http://localhost:6333",
 				codebaseIndexEmbedderProvider: "openai",
 				codebaseIndexEmbedderBaseUrl: "",
@@ -1668,7 +1668,7 @@ export class ClineProvider
 			customCondensingPrompt: stateValues.customCondensingPrompt,
 			codebaseIndexModels: stateValues.codebaseIndexModels ?? EMBEDDING_MODEL_PROFILES,
 			codebaseIndexConfig: stateValues.codebaseIndexConfig ?? {
-				codebaseIndexEnabled: false,
+				codebaseIndexEnabled: true,
 				codebaseIndexQdrantUrl: "http://localhost:6333",
 				codebaseIndexEmbedderProvider: "openai",
 				codebaseIndexEmbedderBaseUrl: "",

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -501,7 +501,7 @@ describe("ClineProvider", () => {
 			alwaysAllowReadOnlyOutsideWorkspace: false,
 			alwaysAllowWrite: false,
 			codebaseIndexConfig: {
-				codebaseIndexEnabled: false,
+				codebaseIndexEnabled: true,
 				codebaseIndexQdrantUrl: "",
 				codebaseIndexEmbedderProvider: "openai",
 				codebaseIndexEmbedderBaseUrl: "",

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -1223,21 +1223,6 @@ export const webviewMessageHandler = async (
 			await updateGlobalState("browserToolEnabled", message.bool ?? true)
 			await provider.postStateToWebview()
 			break
-		case "codebaseIndexEnabled":
-			// Update the codebaseIndexConfig with the new enabled state
-			const currentCodebaseConfig = getGlobalState("codebaseIndexConfig") || {}
-			await updateGlobalState("codebaseIndexConfig", {
-				...currentCodebaseConfig,
-				codebaseIndexEnabled: message.bool ?? false,
-			})
-
-			// Notify the code index manager about the change
-			if (provider.codeIndexManager) {
-				await provider.codeIndexManager.handleSettingsChange()
-			}
-
-			await provider.postStateToWebview()
-			break
 		case "language":
 			changeLanguage(message.text ?? "en")
 			await updateGlobalState("language", message.text as Language)

--- a/src/services/code-index/__tests__/config-manager.spec.ts
+++ b/src/services/code-index/__tests__/config-manager.spec.ts
@@ -32,7 +32,7 @@ describe("CodeIndexConfigManager", () => {
 	describe("constructor", () => {
 		it("should initialize with ContextProxy", () => {
 			expect(configManager).toBeDefined()
-			expect(configManager.isFeatureEnabled).toBe(false)
+			expect(configManager.isFeatureEnabled).toBe(true)
 			expect(configManager.currentEmbedderProvider).toBe("openai")
 		})
 	})
@@ -45,7 +45,7 @@ describe("CodeIndexConfigManager", () => {
 			const result = await configManager.loadConfiguration()
 
 			expect(result.currentConfig).toEqual({
-				isEnabled: false,
+				isEnabled: true,
 				isConfigured: false,
 				embedderProvider: "openai",
 				modelId: undefined,
@@ -326,14 +326,14 @@ describe("CodeIndexConfigManager", () => {
 		})
 
 		it("should detect restart requirement when transitioning to enabled+configured", async () => {
-			// Initial state - disabled
+			// Initial state - enabled but not configured
 			mockContextProxy.getGlobalState.mockReturnValue({
-				codebaseIndexEnabled: false,
+				codebaseIndexEnabled: true,
 			})
 
 			await configManager.loadConfiguration()
 
-			// Enable and configure
+			// Configure the feature
 			mockContextProxy.getGlobalState.mockReturnValue({
 				codebaseIndexEnabled: true,
 				codebaseIndexQdrantUrl: "http://qdrant.local",
@@ -689,29 +689,28 @@ describe("CodeIndexConfigManager", () => {
 				expect(result.requiresRestart).toBe(true)
 			})
 
-			it("should not require restart when disabled remains disabled", async () => {
-				// Initial state - disabled but configured
+			it("should require restart when enabled and provider changes even if unconfigured", async () => {
+				// Initial state - enabled but not configured (missing API key)
 				mockContextProxy.getGlobalState.mockReturnValue({
-					codebaseIndexEnabled: false,
+					codebaseIndexEnabled: true,
 					codebaseIndexQdrantUrl: "http://qdrant.local",
 					codebaseIndexEmbedderProvider: "openai",
 				})
-				setupSecretMocks({
-					codeIndexOpenAiKey: "test-key",
-				})
+				setupSecretMocks({})
 
 				await configManager.loadConfiguration()
 
-				// Still disabled but change other settings
+				// Still enabled but change provider while remaining unconfigured
 				mockContextProxy.getGlobalState.mockReturnValue({
-					codebaseIndexEnabled: false,
-					codebaseIndexQdrantUrl: "http://different-qdrant.local",
+					codebaseIndexEnabled: true,
+					codebaseIndexQdrantUrl: "http://qdrant.local",
 					codebaseIndexEmbedderProvider: "ollama",
 					codebaseIndexEmbedderBaseUrl: "http://ollama.local",
 				})
 
 				const result = await configManager.loadConfiguration()
-				expect(result.requiresRestart).toBe(false)
+				// Should require restart because provider changed while enabled
+				expect(result.requiresRestart).toBe(true)
 			})
 
 			it("should not require restart when unconfigured remains unconfigured", async () => {
@@ -970,7 +969,7 @@ describe("CodeIndexConfigManager", () => {
 			it("should not require restart when API keys transition from undefined to empty string", async () => {
 				// Initial state with undefined API keys
 				mockContextProxy.getGlobalState.mockReturnValue({
-					codebaseIndexEnabled: false, // Start disabled to avoid restart due to enable+configure
+					codebaseIndexEnabled: true, // Always enabled now
 					codebaseIndexQdrantUrl: "http://qdrant.local",
 					codebaseIndexEmbedderProvider: "openai",
 				})
@@ -1267,7 +1266,7 @@ describe("CodeIndexConfigManager", () => {
 		it("should properly initialize with current config to prevent false restarts", async () => {
 			// Setup configuration
 			mockContextProxy.getGlobalState.mockReturnValue({
-				codebaseIndexEnabled: false, // Start disabled to avoid transition restart
+				codebaseIndexEnabled: true, // Always enabled now
 				codebaseIndexQdrantUrl: "http://qdrant.local",
 				codebaseIndexEmbedderProvider: "openai",
 				codebaseIndexEmbedderModelId: "text-embedding-3-small",

--- a/src/services/code-index/__tests__/config-manager.spec.ts
+++ b/src/services/code-index/__tests__/config-manager.spec.ts
@@ -45,7 +45,6 @@ describe("CodeIndexConfigManager", () => {
 			const result = await configManager.loadConfiguration()
 
 			expect(result.currentConfig).toEqual({
-				isEnabled: true,
 				isConfigured: false,
 				embedderProvider: "openai",
 				modelId: undefined,
@@ -77,7 +76,6 @@ describe("CodeIndexConfigManager", () => {
 			const result = await configManager.loadConfiguration()
 
 			expect(result.currentConfig).toEqual({
-				isEnabled: true,
 				isConfigured: true,
 				embedderProvider: "openai",
 				modelId: "text-embedding-3-large",
@@ -111,7 +109,6 @@ describe("CodeIndexConfigManager", () => {
 			const result = await configManager.loadConfiguration()
 
 			expect(result.currentConfig).toEqual({
-				isEnabled: true,
 				isConfigured: true,
 				embedderProvider: "openai-compatible",
 				modelId: "text-embedding-3-large",
@@ -149,7 +146,6 @@ describe("CodeIndexConfigManager", () => {
 			const result = await configManager.loadConfiguration()
 
 			expect(result.currentConfig).toEqual({
-				isEnabled: true,
 				isConfigured: true,
 				embedderProvider: "openai-compatible",
 				modelId: "custom-model",
@@ -188,7 +184,6 @@ describe("CodeIndexConfigManager", () => {
 			const result = await configManager.loadConfiguration()
 
 			expect(result.currentConfig).toEqual({
-				isEnabled: true,
 				isConfigured: true,
 				embedderProvider: "openai-compatible",
 				modelId: "custom-model",
@@ -227,7 +222,6 @@ describe("CodeIndexConfigManager", () => {
 			const result = await configManager.loadConfiguration()
 
 			expect(result.currentConfig).toEqual({
-				isEnabled: true,
 				isConfigured: true,
 				embedderProvider: "openai-compatible",
 				modelId: "custom-model",
@@ -1207,7 +1201,6 @@ describe("CodeIndexConfigManager", () => {
 		it("should return correct configuration via getConfig", () => {
 			const config = configManager.getConfig()
 			expect(config).toEqual({
-				isEnabled: true,
 				isConfigured: true,
 				embedderProvider: "openai",
 				modelId: "text-embedding-3-large",

--- a/src/services/code-index/__tests__/manager.spec.ts
+++ b/src/services/code-index/__tests__/manager.spec.ts
@@ -81,7 +81,6 @@ describe("CodeIndexManager - handleSettingsChange regression", () => {
 				isFeatureConfigured: true,
 				isFeatureEnabled: true,
 				getConfig: vi.fn().mockReturnValue({
-					isEnabled: true,
 					isConfigured: true,
 					embedderProvider: "openai",
 					modelId: "text-embedding-3-small",
@@ -149,7 +148,6 @@ describe("CodeIndexManager - handleSettingsChange regression", () => {
 				isFeatureConfigured: true,
 				isFeatureEnabled: true,
 				getConfig: vi.fn().mockReturnValue({
-					isEnabled: true,
 					isConfigured: true,
 					embedderProvider: "openai",
 					modelId: "text-embedding-3-small",
@@ -276,7 +274,6 @@ describe("CodeIndexManager - handleSettingsChange regression", () => {
 				isFeatureConfigured: true,
 				isFeatureEnabled: true,
 				getConfig: vitest.fn().mockReturnValue({
-					isEnabled: true,
 					isConfigured: true,
 					embedderProvider: "openai",
 					modelId: "text-embedding-3-small",

--- a/src/services/code-index/config-manager.ts
+++ b/src/services/code-index/config-manager.ts
@@ -42,7 +42,7 @@ export class CodeIndexConfigManager {
 	private _loadAndSetConfiguration(): void {
 		// Load configuration from storage
 		const codebaseIndexConfig = this.contextProxy?.getGlobalState("codebaseIndexConfig") ?? {
-			codebaseIndexEnabled: false,
+			codebaseIndexEnabled: true,
 			codebaseIndexQdrantUrl: "http://localhost:6333",
 			codebaseIndexEmbedderProvider: "openai",
 			codebaseIndexEmbedderBaseUrl: "",
@@ -69,7 +69,7 @@ export class CodeIndexConfigManager {
 		const geminiApiKey = this.contextProxy?.getSecret("codebaseIndexGeminiApiKey") ?? ""
 
 		// Update instance variables with configuration
-		this.isEnabled = codebaseIndexEnabled || false
+		this.isEnabled = codebaseIndexEnabled ?? true
 		this.qdrantUrl = codebaseIndexQdrantUrl
 		this.qdrantApiKey = qdrantApiKey ?? ""
 		this.searchMinScore = codebaseIndexSearchMinScore
@@ -362,7 +362,7 @@ export class CodeIndexConfigManager {
 	 * Gets whether the code indexing feature is enabled
 	 */
 	public get isFeatureEnabled(): boolean {
-		return this.isEnabled
+		return true
 	}
 
 	/**

--- a/src/services/code-index/config-manager.ts
+++ b/src/services/code-index/config-manager.ts
@@ -256,50 +256,49 @@ export class CodeIndexConfigManager {
 
 		// 4. CRITICAL CHANGES - Always restart for these
 		// Since feature is always enabled, we always check for critical changes
-		{
-			// Provider change
-			if (prevProvider !== this.embedderProvider) {
-				return true
-			}
 
-			// Authentication changes (API keys)
-			const currentOpenAiKey = this.openAiOptions?.openAiNativeApiKey ?? ""
-			const currentOllamaBaseUrl = this.ollamaOptions?.ollamaBaseUrl ?? ""
-			const currentOpenAiCompatibleBaseUrl = this.openAiCompatibleOptions?.baseUrl ?? ""
-			const currentOpenAiCompatibleApiKey = this.openAiCompatibleOptions?.apiKey ?? ""
-			const currentModelDimension = this.modelDimension
-			const currentGeminiApiKey = this.geminiOptions?.apiKey ?? ""
-			const currentQdrantUrl = this.qdrantUrl ?? ""
-			const currentQdrantApiKey = this.qdrantApiKey ?? ""
+		// Provider change
+		if (prevProvider !== this.embedderProvider) {
+			return true
+		}
 
-			if (prevOpenAiKey !== currentOpenAiKey) {
-				return true
-			}
+		// Authentication changes (API keys)
+		const currentOpenAiKey = this.openAiOptions?.openAiNativeApiKey ?? ""
+		const currentOllamaBaseUrl = this.ollamaOptions?.ollamaBaseUrl ?? ""
+		const currentOpenAiCompatibleBaseUrl = this.openAiCompatibleOptions?.baseUrl ?? ""
+		const currentOpenAiCompatibleApiKey = this.openAiCompatibleOptions?.apiKey ?? ""
+		const currentModelDimension = this.modelDimension
+		const currentGeminiApiKey = this.geminiOptions?.apiKey ?? ""
+		const currentQdrantUrl = this.qdrantUrl ?? ""
+		const currentQdrantApiKey = this.qdrantApiKey ?? ""
 
-			if (prevOllamaBaseUrl !== currentOllamaBaseUrl) {
-				return true
-			}
+		if (prevOpenAiKey !== currentOpenAiKey) {
+			return true
+		}
 
-			if (
-				prevOpenAiCompatibleBaseUrl !== currentOpenAiCompatibleBaseUrl ||
-				prevOpenAiCompatibleApiKey !== currentOpenAiCompatibleApiKey
-			) {
-				return true
-			}
+		if (prevOllamaBaseUrl !== currentOllamaBaseUrl) {
+			return true
+		}
 
-			// Check for model dimension changes (generic for all providers)
-			if (prevModelDimension !== currentModelDimension) {
-				return true
-			}
+		if (
+			prevOpenAiCompatibleBaseUrl !== currentOpenAiCompatibleBaseUrl ||
+			prevOpenAiCompatibleApiKey !== currentOpenAiCompatibleApiKey
+		) {
+			return true
+		}
 
-			if (prevQdrantUrl !== currentQdrantUrl || prevQdrantApiKey !== currentQdrantApiKey) {
-				return true
-			}
+		// Check for model dimension changes (generic for all providers)
+		if (prevModelDimension !== currentModelDimension) {
+			return true
+		}
 
-			// Vector dimension changes (still important for compatibility)
-			if (this._hasVectorDimensionChanged(prevProvider, prev?.modelId)) {
-				return true
-			}
+		if (prevQdrantUrl !== currentQdrantUrl || prevQdrantApiKey !== currentQdrantApiKey) {
+			return true
+		}
+
+		// Vector dimension changes (still important for compatibility)
+		if (this._hasVectorDimensionChanged(prevProvider, prev?.modelId)) {
+			return true
 		}
 
 		return false

--- a/src/services/code-index/interfaces/config.ts
+++ b/src/services/code-index/interfaces/config.ts
@@ -5,7 +5,6 @@ import { EmbedderProvider } from "./manager"
  * Configuration state for the code indexing feature
  */
 export interface CodeIndexConfig {
-	isEnabled: boolean
 	isConfigured: boolean
 	embedderProvider: EmbedderProvider
 	modelId?: string

--- a/webview-ui/src/components/chat/CodeIndexPopover.tsx
+++ b/webview-ui/src/components/chat/CodeIndexPopover.tsx
@@ -81,7 +81,7 @@ export const CodeIndexPopover: React.FC<CodeIndexPopoverProps> = ({
 
 	// Default settings template
 	const getDefaultSettings = (): LocalCodeIndexSettings => ({
-		codebaseIndexEnabled: false,
+		codebaseIndexEnabled: true,
 		codebaseIndexQdrantUrl: "",
 		codebaseIndexEmbedderProvider: "openai",
 		codebaseIndexEmbedderBaseUrl: "",
@@ -111,7 +111,7 @@ export const CodeIndexPopover: React.FC<CodeIndexPopoverProps> = ({
 	useEffect(() => {
 		if (codebaseIndexConfig) {
 			const settings = {
-				codebaseIndexEnabled: codebaseIndexConfig.codebaseIndexEnabled || false,
+				codebaseIndexEnabled: codebaseIndexConfig.codebaseIndexEnabled ?? true,
 				codebaseIndexQdrantUrl: codebaseIndexConfig.codebaseIndexQdrantUrl || "",
 				codebaseIndexEmbedderProvider: codebaseIndexConfig.codebaseIndexEmbedderProvider || "openai",
 				codebaseIndexEmbedderBaseUrl: codebaseIndexConfig.codebaseIndexEmbedderBaseUrl || "",

--- a/webview-ui/src/components/settings/ExperimentalSettings.tsx
+++ b/webview-ui/src/components/settings/ExperimentalSettings.tsx
@@ -1,40 +1,26 @@
 import { HTMLAttributes } from "react"
 import { FlaskConical } from "lucide-react"
-import { VSCodeCheckbox, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
-import { Trans } from "react-i18next"
 
-import type { Experiments, CodebaseIndexConfig, CodebaseIndexModels } from "@roo-code/types"
+import type { Experiments } from "@roo-code/types"
 
 import { EXPERIMENT_IDS, experimentConfigsMap } from "@roo/experiments"
 
 import { useAppTranslation } from "@src/i18n/TranslationContext"
 import { cn } from "@src/lib/utils"
-import { buildDocLink } from "@src/utils/docLinks"
 
 import { SetExperimentEnabled } from "./types"
 import { SectionHeader } from "./SectionHeader"
 import { Section } from "./Section"
 import { ExperimentalFeature } from "./ExperimentalFeature"
-import { SetCachedStateField } from "./types"
 
 type ExperimentalSettingsProps = HTMLAttributes<HTMLDivElement> & {
 	experiments: Experiments
 	setExperimentEnabled: SetExperimentEnabled
-	// CodeIndexSettings props
-	codebaseIndexModels: CodebaseIndexModels | undefined
-	codebaseIndexConfig: CodebaseIndexConfig | undefined
-	// For codebase index enabled toggle
-	codebaseIndexEnabled?: boolean
-	setCachedStateField?: SetCachedStateField<any>
 }
 
 export const ExperimentalSettings = ({
 	experiments,
 	setExperimentEnabled,
-	codebaseIndexModels,
-	codebaseIndexConfig,
-	codebaseIndexEnabled,
-	setCachedStateField,
 	className,
 	...props
 }: ExperimentalSettingsProps) => {
@@ -79,32 +65,6 @@ export const ExperimentalSettings = ({
 							/>
 						)
 					})}
-
-				{/* Codebase Indexing Enable/Disable Toggle */}
-				<div className="mt-4">
-					<div className="flex items-center gap-2">
-						<VSCodeCheckbox
-							checked={codebaseIndexEnabled || false}
-							onChange={(e: any) => {
-								const newEnabledState = e.target.checked
-								if (setCachedStateField && codebaseIndexConfig) {
-									setCachedStateField("codebaseIndexConfig", {
-										...codebaseIndexConfig,
-										codebaseIndexEnabled: newEnabledState,
-									})
-								}
-							}}>
-							<span className="font-medium">{t("settings:codeIndex.enableLabel")}</span>
-						</VSCodeCheckbox>
-					</div>
-					<p className="text-vscode-descriptionForeground text-sm mt-1 ml-6">
-						<Trans i18nKey="settings:codeIndex.enableDescription">
-							<VSCodeLink
-								href={buildDocLink("features/experimental/codebase-indexing", "settings")}
-								style={{ display: "inline" }}></VSCodeLink>
-						</Trans>
-					</p>
-				</div>
 			</Section>
 		</div>
 	)

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -170,8 +170,6 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 		maxConcurrentFileReads,
 		condensingApiConfigId,
 		customCondensingPrompt,
-		codebaseIndexConfig,
-		codebaseIndexModels,
 		customSupportPrompts,
 		profileThresholds,
 		alwaysAllowFollowupQuestions,
@@ -322,9 +320,6 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 			vscode.postMessage({ type: "updateSupportPrompt", values: customSupportPrompts || {} })
 			vscode.postMessage({ type: "upsertApiConfiguration", text: currentApiConfigName, apiConfiguration })
 			vscode.postMessage({ type: "telemetrySetting", text: telemetrySetting })
-			if (codebaseIndexConfig) {
-				vscode.postMessage({ type: "codebaseIndexEnabled", bool: codebaseIndexConfig.codebaseIndexEnabled })
-			}
 			vscode.postMessage({ type: "profileThresholds", values: profileThresholds })
 			setChangeDetected(false)
 		}
@@ -691,14 +686,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 
 					{/* Experimental Section */}
 					{activeTab === "experimental" && (
-						<ExperimentalSettings
-							setExperimentEnabled={setExperimentEnabled}
-							experiments={experiments}
-							codebaseIndexModels={codebaseIndexModels}
-							codebaseIndexConfig={codebaseIndexConfig}
-							codebaseIndexEnabled={codebaseIndexConfig?.codebaseIndexEnabled}
-							setCachedStateField={setCachedStateField}
-						/>
+						<ExperimentalSettings setExperimentEnabled={setExperimentEnabled} experiments={experiments} />
 					)}
 
 					{/* Language Section */}

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -214,7 +214,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		autoCondenseContextPercent: 100,
 		profileThresholds: {},
 		codebaseIndexConfig: {
-			codebaseIndexEnabled: false,
+			codebaseIndexEnabled: true,
 			codebaseIndexQdrantUrl: "http://localhost:6333",
 			codebaseIndexEmbedderProvider: "openai",
 			codebaseIndexEmbedderBaseUrl: "",


### PR DESCRIPTION
## Description

This PR moves codebase indexing out of experimental settings and makes it always enabled by default.

## Changes

- Removed the codebase indexing checkbox from experimental settings UI
- Set `codebaseIndexEnabled` to `true` by default across all configuration files
- Updated `isFeatureEnabled` in config-manager to always return `true`
- Removed the message handler for toggling codebase index setting
- Updated all related tests to reflect the always-enabled state
- Removed the `isEnabled` property from CodeIndexConfig interface and simplified the configuration logic

## Impact

Users will no longer see the codebase indexing option in experimental settings. The feature will be enabled by default for all users, though they can still configure the indexing settings (provider, model, etc.) through the existing configuration UI.

## Testing

- All existing tests have been updated and are passing
- Linting checks pass for both frontend and backend
- Type checking passes
- No TypeScript errors or warnings
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Codebase indexing is now always enabled, removed from experimental settings, with updated configurations, UI, and tests.
> 
>   - **Behavior**:
>     - Codebase indexing is now always enabled, removed from experimental settings.
>     - `codebaseIndexEnabled` set to `true` by default in `ClineProvider.ts` and `CodeIndexPopover.tsx`.
>     - `isFeatureEnabled` in `config-manager.ts` always returns `true`.
>     - Removed message handler for toggling codebase index setting in `webviewMessageHandler.ts`.
>   - **Configuration**:
>     - Removed `isEnabled` from `CodeIndexConfig` interface.
>     - Simplified configuration logic in `config-manager.ts`.
>   - **UI**:
>     - Removed codebase indexing checkbox from `ExperimentalSettings.tsx`.
>     - Updated `CodeIndexPopover.tsx` to reflect always-enabled state.
>   - **Testing**:
>     - Updated tests in `config-manager.spec.ts` and `manager.spec.ts` to reflect always-enabled state.
>     - Tests ensure no restart is required when settings are unchanged.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d6d646f8b3d4a4c4109024d4cc96ef8af70f4a26. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->