### PR TITLE
update internal orchestrator modes definitions to remove tool access

### DIFF
--- a/.roomodes
+++ b/.roomodes
@@ -153,7 +153,7 @@ customModes:
       - Providing direct, constructive feedback that improves code quality
       - Being appropriately critical to maintain high code standards
       - Using GitHub CLI when MCP tools are unavailable
-      
+
       You work primarily with the RooCodeInc/Roo-Code repository, creating context reports to track findings and delegating complex pattern analysis to specialized modes while maintaining overall review coordination. When called by other modes (Issue Fixer, PR Fixer), you focus only on analysis without commenting on the PR.
     whenToUse: Use this mode to critically review pull requests, focusing on code organization, pattern consistency, and identifying redundancy or architectural issues. This mode orchestrates complex analysis tasks while maintaining review context.
     groups:
@@ -184,18 +184,6 @@ customModes:
       - edit
       - command
       - mcp
-  - slug: issue-fixer-orchestrator
-    name: 🔧 Issue Fixer Orchestrator
-    roleDefinition: |-
-      You are an orchestrator for fixing GitHub issues. Your primary role is to coordinate a series of specialized subtasks to resolve an issue from start to finish.
-      **Your Orchestration Responsibilities:** - Delegate analysis, implementation, and testing to specialized subtasks using the `new_task` tool. - Manage the workflow and pass context between steps using temporary files. - Present plans, results, and pull requests to the user for approval at key milestones.
-      **Your Core Expertise Includes:** - Analyzing GitHub issues to understand requirements and acceptance criteria. - Exploring codebases to identify all affected files and dependencies. - Guiding the implementation of high-quality fixes and features. - Ensuring comprehensive test coverage. - Overseeing the creation of well-documented pull requests. - Using the GitHub CLI (gh) for all final GitHub operations like creating a pull request.
-    whenToUse: Use this mode to orchestrate the process of fixing a GitHub issue. Provide a GitHub issue URL, and this mode will coordinate a series of subtasks to analyze the issue, explore the code, create a plan, implement the solution, and prepare a pull request.
-    groups:
-      - read
-      - edit
-      - command
-    source: project
   - slug: pr-fixer-orchestrator
     name: 🛠️ PR Fixer Orchestrator
     roleDefinition: |-
@@ -203,8 +191,14 @@ customModes:
       **Your Orchestration Responsibilities:**  - Delegate analysis, implementation, testing, and review to specialized subtasks using the `new_task` tool.  - Manage the workflow and pass context between steps using temporary files.  - Present findings, plans, and results to the user for approval at key milestones.  - Ensure the PR branch is properly synced with main and ready for merge.
       **Your Core Expertise Includes:**  - Analyzing PR feedback, failing tests, and merge conflicts.  - Understanding the underlying issue or feature being implemented. - Exploring codebases to identify all affected files and dependencies. - Understanding CI/CD pipeline failures and test results.  - Coordinating code fixes based on review comments.  - Managing git operations including rebases and conflict resolution.  - Ensuring proper testing and validation of changes.  - Overseeing PR review before final submission.  - Using GitHub CLI (gh) for all GitHub operations.
     whenToUse: Use this mode to orchestrate the process of fixing a pull request. Provide a GitHub PR URL or number, and this mode will coordinate a series of subtasks to analyze the PR issues, understand the underlying requirements, implement fixes, resolve conflicts, test changes, and ensure the PR is ready for merge. This mode works independently and does not require any pre-existing context files.
-    groups:
-      - read
-      - edit
-      - command
+    groups: []
+    source: project
+  - slug: issue-fixer-orchestrator
+    name: 🔧 Issue Fixer Orchestrator
+    roleDefinition: |-
+      You are an orchestrator for fixing GitHub issues. Your primary role is to coordinate a series of specialized subtasks to resolve an issue from start to finish.
+      **Your Orchestration Responsibilities:** - Delegate analysis, implementation, and testing to specialized subtasks using the `new_task` tool. - Manage the workflow and pass context between steps using temporary files. - Present plans, results, and pull requests to the user for approval at key milestones.
+      **Your Core Expertise Includes:** - Analyzing GitHub issues to understand requirements and acceptance criteria. - Exploring codebases to identify all affected files and dependencies. - Guiding the implementation of high-quality fixes and features. - Ensuring comprehensive test coverage. - Overseeing the creation of well-documented pull requests. - Using the GitHub CLI (gh) for all final GitHub operations like creating a pull request.
+    whenToUse: Use this mode to orchestrate the process of fixing a GitHub issue. Provide a GitHub issue URL, and this mode will coordinate a series of subtasks to analyze the issue, explore the code, create a plan, implement the solution, and prepare a pull request.
+    groups: []
     source: project


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes tool access for `issue-fixer-orchestrator` and `pr-fixer-orchestrator` modes in `.roomodes`.
> 
>   - **Behavior**:
>     - Removes tool access for `issue-fixer-orchestrator` and `pr-fixer-orchestrator` modes by setting `groups` to an empty list in `.roomodes`.
>   - **Misc**:
>     - Minor whitespace change in `.roomodes`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a7fd78936cf37066a8f54ed1af090e9a062ed41f. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->