### PR TITLE
Remove changeset that is preventing release

### DIFF
--- a/.changeset/stale-rivers-travel.md
+++ b/.changeset/stale-rivers-travel.md
@@ -1,5 +1,0 @@
----
-roo-code: minor
----
-
-Add copy prompt button to task actions. Based on [@vultrnerd's feedback](https://github.com/Kilo-Org/kilocode/discussions/850).


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes `.changeset/stale-rivers-travel.md` to unblock the release process.
> 
>   - **Changeset Removal**:
>     - Deletes `.changeset/stale-rivers-travel.md` which was preventing the release.
>     - The changeset included a minor change for adding a copy prompt button to task actions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 6045fc7e4dd56b987ba3daf134c322eda158a0e7. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->