### PR TITLE
fix: Mitigate extension host crash from Qdrant batch deletes

### DIFF
--- a/src/services/code-index/processors/file-watcher.ts
+++ b/src/services/code-index/processors/file-watcher.ts
@@ -203,6 +203,8 @@ export class FileWatcher implements IFileWatcher {
 				}
 			} catch (error) {
 				overallBatchError = error as Error
+				// Log the full, potentially multi-line, aggregated error message
+				console.error(`[FileWatcher] Failed to delete points for ${allPathsToClearFromDB.size} files:`, error)
 				for (const path of pathsToExplicitlyDelete) {
 					batchResults.push({ path, status: "error", error: error as Error })
 					processedCountInBatch++

--- a/src/services/code-index/processors/scanner.ts
+++ b/src/services/code-index/processors/scanner.ts
@@ -309,11 +309,16 @@ export class DirectoryScanner implements IDirectoryScanner {
 							`[DirectoryScanner] Failed to delete points for ${uniqueFilePaths.length} files before upsert in workspace ${scanWorkspace}:`,
 							deleteError,
 						)
-						// Re-throw the error with workspace context
-						throw new Error(
-							`Failed to delete points for ${uniqueFilePaths.length} files. Workspace: ${scanWorkspace}. ${deleteError instanceof Error ? deleteError.message : String(deleteError)}`,
-							{ cause: deleteError },
-						)
+						// Log the error and call onError callback if it exists, but continue processing
+						if (onError) {
+							onError(
+								new Error(
+									`Failed to delete points for ${uniqueFilePaths.length} files. Workspace: ${scanWorkspace}. ${deleteError instanceof Error ? deleteError.message : String(deleteError)}`,
+									{ cause: deleteError },
+								),
+							)
+						}
+						// Continue processing instead of throwing
 					}
 				}
 				// --- End Deletion Step ---


### PR DESCRIPTION
This PR fixes issue #5516, where the extension host would crash due to repeated "Bad Request" errors from the Qdrant `deletePointsByMultipleFilePaths` function.

The root cause was large batches of file deletion requests overwhelming the Qdrant API, with no retry logic or graceful error handling to prevent a crash loop.

Key changes in this PR include:
- **Chunking**: The `deletePointsByMultipleFilePaths` function in `qdrant-client.ts` now splits large deletion requests into smaller, more manageable chunks.
- **Retry with Exponential Backoff**: Each chunk benefits from a retry mechanism, making the process more resilient to transient API failures.
- **Graceful Error Handling**: The `scanner.ts` and `file-watcher.ts` services now log errors from failed chunks and continue processing, preventing the extension from crashing. A consolidated error is thrown at the end if any chunks failed permanently.
- **Comprehensive Unit Tests**: New tests were added to `qdrant-client.spec.ts` to validate the new chunking, retry, and error-handling logic.

Closes #5516