### PR TITLE
fix: handle null/empty custom modes files to prevent 'Cannot read properties of null' error

### DIFF
--- a/src/core/config/CustomModesManager.ts
+++ b/src/core/config/CustomModesManager.ts
@@ -182,6 +182,12 @@ export class CustomModesManager {
 		try {
 			const content = await fs.readFile(filePath, "utf-8")
 			const settings = this.parseYamlSafely(content, filePath)
+
+			// Ensure settings has customModes property
+			if (!settings || typeof settings !== "object" || !settings.customModes) {
+				return []
+			}
+
 			const result = customModesSettingsSchema.safeParse(settings)
 
 			if (!result.success) {
@@ -460,7 +466,15 @@ export class CustomModesManager {
 			settings = { customModes: [] }
 		}
 
-		settings.customModes = operation(settings.customModes || [])
+		// Ensure settings is an object and has customModes property
+		if (!settings || typeof settings !== "object") {
+			settings = { customModes: [] }
+		}
+		if (!settings.customModes) {
+			settings.customModes = []
+		}
+
+		settings.customModes = operation(settings.customModes)
 		await fs.writeFile(filePath, yaml.stringify(settings, { lineWidth: 0 }), "utf-8")
 	}
 

--- a/src/core/config/CustomModesManager.ts
+++ b/src/core/config/CustomModesManager.ts
@@ -148,7 +148,9 @@ export class CustomModesManager {
 		cleanedContent = this.cleanInvisibleCharacters(cleanedContent)
 
 		try {
-			return yaml.parse(cleanedContent)
+			const parsed = yaml.parse(cleanedContent)
+			// Ensure we never return null or undefined
+			return parsed ?? {}
 		} catch (yamlError) {
 			// For .roomodes files, try JSON as fallback
 			if (filePath.endsWith(ROOMODES_FILENAME)) {


### PR DESCRIPTION
## Description

Fixes the issue where empty or null custom modes configuration files (custom_modes.yaml or .roomodes) cause a 'Cannot read properties of null (reading customModes)' error.

## Problem

When the custom modes configuration file exists but is empty or contains null/undefined content, the YAML parser returns null, which causes a null pointer exception when trying to access the customModes property.

## Solution

1. **SimpleInstaller.ts**:
   - Modified installMode and removeMode methods to ensure existingData is always a valid object after yaml.parse
   - Added explicit checks to convert null/undefined to an empty object with customModes array
   - Ensures customModes array is always initialized before use

2. **CustomModesManager.ts**:
   - Modified parseYamlSafely to return an empty object ({}) instead of null when yaml.parse returns null/undefined
   - This prevents null pointer exceptions in downstream code

## Testing

- Added comprehensive test cases for handling empty files, null content, and missing customModes property
- Updated existing tests to match the correct behavior
- All tests pass successfully

## Verification

The fix ensures that:
- Empty custom modes files are handled gracefully
- Files with null content (e.g., '---\n') are properly initialized
- Files without customModes property get the property added
- The file structure is always valid after any operation

This resolves the reported error and ensures robust handling of edge cases in custom modes configuration files.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes null pointer exceptions by ensuring `customModes` is always initialized in `SimpleInstaller.ts` and `CustomModesManager.ts`.
> 
>   - **Behavior**:
>     - Fixes null pointer exception in `SimpleInstaller.ts` and `CustomModesManager.ts` by ensuring `customModes` is always initialized.
>     - `parseYamlSafely` in `CustomModesManager.ts` returns `{}` instead of `null`.
>     - `installMode` and `removeMode` in `SimpleInstaller.ts` handle empty or null `.roomodes` files by initializing `customModes`.
>   - **Testing**:
>     - Adds tests in `SimpleInstaller.spec.ts` for empty, null, and missing `customModes` cases.
>     - Verifies correct behavior for invalid YAML and JSON scenarios.
>   - **Misc**:
>     - Minor refactoring for error handling and initialization logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for bd517dac4f1f9fecb1e975ae84d0842f40c83296. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->