### PR TITLE
fix

### DIFF
--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -14,6 +14,7 @@ import { registerHumanRelayCallback, unregisterHumanRelayCallback, handleHumanRe
 import { handleNewTask } from "./handleTask"
 import { CodeIndexManager } from "../services/code-index/manager"
 import { importSettingsWithFeedback } from "../core/config/importExport"
+import { MdmService } from "../services/mdm/MdmService"
 import { t } from "../i18n"
 
 /**
@@ -226,7 +227,17 @@ export const openClineInNewTab = async ({ context, outputChannel }: Omit<Registe
 	// https://github.com/microsoft/vscode-extension-samples/blob/main/webview-sample/src/extension.ts
 	const contextProxy = await ContextProxy.getInstance(context)
 	const codeIndexManager = CodeIndexManager.getInstance(context)
-	const tabProvider = new ClineProvider(context, outputChannel, "editor", contextProxy, codeIndexManager)
+
+	// Get the existing MDM service instance to ensure consistent policy enforcement
+	let mdmService: MdmService | undefined
+	try {
+		mdmService = MdmService.getInstance()
+	} catch (error) {
+		// MDM service not initialized, which is fine - extension can work without it
+		mdmService = undefined
+	}
+
+	const tabProvider = new ClineProvider(context, outputChannel, "editor", contextProxy, codeIndexManager, mdmService)
 	const lastCol = Math.max(...vscode.window.visibleTextEditors.map((editor) => editor.viewColumn || 0))
 
 	// Check if there are any visible text editors, otherwise open a new group


### PR DESCRIPTION
Thanks to someone from Roo Vet for pointing out this bug.

The Roo Code extension had a security vulnerability where users could bypass organizational MDM (Mobile Device Management) policies by opening the extension in a new tab/window. The openClineInNewTab function was creating new ClineProvider instances without passing the MDM service parameter, but patched now!
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix security vulnerability by passing `MdmService` to `ClineProvider` in `openClineInNewTab()` to enforce MDM policies.
> 
>   - **Security Fix**:
>     - In `openClineInNewTab()` in `registerCommands.ts`, ensure `MdmService` instance is passed to `ClineProvider` to enforce MDM policies.
>     - Handles case where `MdmService` is not initialized by setting it to `undefined`.
>   - **Misc**:
>     - Add import for `MdmService` in `registerCommands.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b8923df006a5c51891843dc919382651e50f9af0. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->