### PR TITLE
chore: prepare v3.23.7 patch release

### DIFF
--- a/.changeset/v3.23.7.md
+++ b/.changeset/v3.23.7.md
@@ -1,0 +1,18 @@
+---
+"roo-cline": patch
+---
+
+- Fix Mermaid syntax warning (thanks @MuriloFP!)
+- Expand Vertex AI region config to include all available regions in GCP Vertex AI (thanks @shubhamgupta731!)
+- Handle Qdrant vector dimension mismatch when switching embedding models (thanks @daniel-lxs!)
+- Fix typos in comment & document (thanks @noritaka1166!)
+- Improve the display of codebase search results
+- Correct translation fallback logic for embedding errors (thanks @daniel-lxs!)
+- Clean up MCP tool disabling
+- Link to marketplace from modes and MCP tab
+- Fix TTS button display (thanks @sensei-woo!)
+- Add Devstral Medium model support
+- Add comprehensive error telemetry to code-index service (thanks @daniel-lxs!)
+- Exclude cache tokens from context window calculation (thanks @daniel-lxs!)
+- Enable dynamic tool selection in architect mode for context discovery
+- Add configurable max output tokens setting for claude-code


### PR DESCRIPTION
This PR adds a changeset for the v3.23.7 patch release, including all 17 merged PRs since v3.23.6.

## Changes included:
- Bug fixes for Mermaid syntax, Qdrant vector dimensions, translation fallback, cache tokens, and eval issues
- New features: Vertex AI regions expansion, Devstral Medium model, error telemetry, architect mode tools, max output tokens
- UI/UX improvements: softer language for profiles, better codebase search display, marketplace links
- Maintenance updates

The GitHub Actions workflow will automatically create a version bump PR when this is merged.