### PR TITLE
feat: allow disabling codebase indexing

### DIFF
--- a/src/package.nls.json
+++ b/src/package.nls.json
@@ -32,5 +32,6 @@
 	"settings.vsCodeLmModelSelector.family.description": "The family of the language model (e.g. gpt-4)",
 	"settings.customStoragePath.description": "Custom storage path. Leave empty to use the default location. Supports absolute paths (e.g. 'D:\\RooCodeStorage')",
 	"settings.enableCodeActions.description": "Enable Roo Code quick fixes",
-	"settings.autoImportSettingsPath.description": "Path to a RooCode configuration file to automatically import on extension startup. Supports absolute paths and paths relative to the home directory (e.g. '~/Documents/roo-code-settings.json'). Leave empty to disable auto-import."
+	"settings.autoImportSettingsPath.description": "Path to a RooCode configuration file to automatically import on extension startup. Supports absolute paths and paths relative to the home directory (e.g. '~/Documents/roo-code-settings.json'). Leave empty to disable auto-import.",
+	"settings.codebaseIndexing.enabled.description": "Enable or disable the codebase indexing feature. When disabled, semantic search will not be available."
 }


### PR DESCRIPTION
This PR introduces the ability to disable the codebase indexing feature via VS Code settings. It addresses the oversight where the indexing feature, once enabled, could not be easily turned off.\n\nChanges include:\n- Modifying  to read  from user configuration and update  accordingly.\n- Exposing  in  and  for user control.\n- Updating  and  to correctly handle the new setting.\n- Modifying  to gracefully handle disabled or unconfigured indexing by returning empty results instead of throwing errors.\n\nCloses #5623
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a setting to enable or disable codebase indexing in VS Code, affecting semantic search availability.
> 
>   - **Settings**:
>     - Adds `settings.codebaseIndexing.enabled.description` to `package.nls.json` to allow enabling or disabling codebase indexing.
>   - **Behavior**:
>     - When codebase indexing is disabled, semantic search is unavailable.
>     - Handles disabled or unconfigured indexing by returning empty results instead of errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 6b0179288cfe19f39721251370c14dd6ac31a7e5. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->