### PR TITLE
Remove duplicate PR link in issue fixer workflow

### DIFF
--- a/.roo/rules-issue-fixer-orchestrator/5_pull_request_workflow.xml
+++ b/.roo/rules-issue-fixer-orchestrator/5_pull_request_workflow.xml
@@ -94,7 +94,7 @@
   <after_creation>
     1. Comment on original issue with PR link:
        <execute_command>
-       <command>gh issue comment [issue-number] --repo [owner]/[repo] --body "PR #[pr-number] has been created to address this issue: [PR URL]"</command>
+       <command>gh issue comment [issue-number] --repo [owner]/[repo] --body "PR #[pr-number] has been created to address this issue"</command>
        </execute_command>
     2. Inform user of successful creation
     3. Provide next steps and tracking info

--- a/.roo/rules-issue-fixer/1_Workflow.xml
+++ b/.roo/rules-issue-fixer/1_Workflow.xml
@@ -478,7 +478,7 @@
       3. Inform the user of the successful creation
       
       <execute_command>
-      <command>gh issue comment [original issue number] --repo [owner]/[repo] --body "PR #[new PR number] has been created to address this issue: [PR URL]"</command>
+      <command>gh issue comment [original issue number] --repo [owner]/[repo] --body "PR #[new PR number] has been created to address this issue"</command>
       </execute_command>
       
       Final message to user:

--- a/.roo/rules-issue-fixer/5_pull_request_workflow.xml
+++ b/.roo/rules-issue-fixer/5_pull_request_workflow.xml
@@ -40,7 +40,7 @@
   <after_creation>
     1. Comment on original issue with PR link:
        <execute_command>
-       <command>gh issue comment [issue-number] --repo [owner]/[repo] --body "PR #[pr-number] has been created to address this issue: [PR URL]"</command>
+       <command>gh issue comment [issue-number] --repo [owner]/[repo] --body "PR #[pr-number] has been created to address this issue"</command>
        </execute_command>
     2. Inform user of successful creation
     3. Provide next steps and tracking info


### PR DESCRIPTION
Github will linkify the first reference to the PR by number
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes duplicate PR URL in issue fixer workflow comments by updating XML files to rely on GitHub's automatic linkification of PR numbers.
> 
>   - **Behavior**:
>     - Removes duplicate PR URL in comments by updating the command in `.roo/rules-issue-fixer-orchestrator/5_pull_request_workflow.xml`, `.roo/rules-issue-fixer/1_Workflow.xml`, and `.roo/rules-issue-fixer/5_pull_request_workflow.xml`.
>     - Comments now only include "PR #[pr-number] has been created to address this issue".
>   - **Commands**:
>     - Updates `gh issue comment` command to exclude `[PR URL]` in the body.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 47ab6d5515ca2b5c5c1646d8084c8d7d0b0902df. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->