### PR TITLE
Fix codebase indexing .gitignore/.rooignore handling

### DIFF
--- a/src/core/prompts/__tests__/responses-rooignore.spec.ts
+++ b/src/core/prompts/__tests__/responses-rooignore.spec.ts
@@ -231,18 +231,23 @@ describe("RooIgnore Response Formatting", () => {
 		})
 
 		/**
-		 * Tests null/undefined case
+		 * Tests default patterns case
 		 */
-		it("should return undefined when no .rooignore exists", async () => {
-			// Set up no .rooignore
+		it("should return default instructions when no .rooignore exists", async () => {
+			// Set up no .rooignore or .gitignore
 			mockFileExists.mockResolvedValue(false)
 
 			// Create controller without .rooignore
 			const controller = new RooIgnoreController(TEST_CWD)
 			await controller.initialize()
 
-			// Should return undefined
-			expect(controller.getInstructions()).toBeUndefined()
+			// Should return default instructions
+			const instructions = controller.getInstructions()
+			expect(instructions).toContain("# Default ignore patterns")
+			expect(instructions).toContain("node_modules/")
+			expect(instructions).toContain(".git/")
+			expect(instructions).toContain("dist/")
+			expect(instructions).toContain("build/")
 		})
 	})
 })

--- a/src/services/code-index/manager.ts
+++ b/src/services/code-index/manager.ts
@@ -236,7 +236,6 @@ export class CodeIndexManager {
 			this._cacheManager!,
 		)
 
-		const ignoreInstance = ignore()
 		const workspacePath = getWorkspacePath()
 
 		if (!workspacePath) {
@@ -244,26 +243,10 @@ export class CodeIndexManager {
 			return
 		}
 
-		const ignorePath = path.join(workspacePath, ".gitignore")
-		try {
-			const content = await fs.readFile(ignorePath, "utf8")
-			ignoreInstance.add(content)
-			ignoreInstance.add(".gitignore")
-		} catch (error) {
-			// Should never happen: reading file failed even though it exists
-			console.error("Unexpected error loading .gitignore:", error)
-			TelemetryService.instance.captureEvent(TelemetryEventName.CODE_INDEX_ERROR, {
-				error: error instanceof Error ? error.message : String(error),
-				stack: error instanceof Error ? error.stack : undefined,
-				location: "_recreateServices",
-			})
-		}
-
-		// (Re)Create shared service instances
+		// (Re)Create shared service instances - ignore patterns are now handled by RooIgnoreController
 		const { embedder, vectorStore, scanner, fileWatcher } = this._serviceFactory.createServices(
 			this.context,
 			this._cacheManager!,
-			ignoreInstance,
 		)
 
 		// Validate embedder configuration before proceeding

--- a/src/services/code-index/processors/__tests__/file-watcher.spec.ts
+++ b/src/services/code-index/processors/__tests__/file-watcher.spec.ts
@@ -18,9 +18,15 @@ vi.mock("../../cache-manager")
 vi.mock("../../../core/ignore/RooIgnoreController", () => ({
 	RooIgnoreController: vi.fn().mockImplementation(() => ({
 		validateAccess: vi.fn().mockReturnValue(true),
+		initialize: vi.fn().mockResolvedValue(undefined),
 	})),
 }))
-vi.mock("ignore")
+vi.mock("ignore", () => ({
+	default: vi.fn(() => ({
+		add: vi.fn(),
+		ignores: vi.fn().mockReturnValue(false),
+	})),
+}))
 vi.mock("../parser", () => ({
 	codeParser: {
 		parseFile: vi.fn().mockResolvedValue([]),
@@ -124,14 +130,7 @@ describe("FileWatcher", () => {
 			ignores: vi.fn().mockReturnValue(false),
 		}
 
-		fileWatcher = new FileWatcher(
-			"/mock/workspace",
-			mockContext,
-			mockCacheManager,
-			mockEmbedder,
-			mockVectorStore,
-			mockIgnoreInstance,
-		)
+		fileWatcher = new FileWatcher("/mock/workspace", mockContext, mockCacheManager, mockEmbedder, mockVectorStore)
 	})
 
 	describe("file filtering", () => {

--- a/src/services/code-index/processors/__tests__/scanner.spec.ts
+++ b/src/services/code-index/processors/__tests__/scanner.spec.ts
@@ -104,13 +104,7 @@ describe("DirectoryScanner", () => {
 			ignores: vi.fn().mockReturnValue(false),
 		}
 
-		scanner = new DirectoryScanner(
-			mockEmbedder,
-			mockVectorStore,
-			mockCodeParser,
-			mockCacheManager,
-			mockIgnoreInstance,
-		)
+		scanner = new DirectoryScanner(mockEmbedder, mockVectorStore, mockCodeParser, mockCacheManager)
 
 		// Mock default implementations - create proper Stats object
 		mockStats = {

--- a/src/services/code-index/processors/scanner.ts
+++ b/src/services/code-index/processors/scanner.ts
@@ -35,7 +35,6 @@ export class DirectoryScanner implements IDirectoryScanner {
 		private readonly qdrantClient: IVectorStore,
 		private readonly codeParser: ICodeParser,
 		private readonly cacheManager: CacheManager,
-		private readonly ignoreInstance: Ignore,
 	) {}
 
 	/**
@@ -70,17 +69,16 @@ export class DirectoryScanner implements IDirectoryScanner {
 		// Filter paths using .rooignore
 		const allowedPaths = ignoreController.filterPaths(filePaths)
 
-		// Filter by supported extensions, ignore patterns, and excluded directories
+		// Filter by supported extensions and excluded directories
 		const supportedPaths = allowedPaths.filter((filePath) => {
 			const ext = path.extname(filePath).toLowerCase()
-			const relativeFilePath = generateRelativeFilePath(filePath, scanWorkspace)
 
 			// Check if file is in an ignored directory using the shared helper
 			if (isPathInIgnoredDirectory(filePath)) {
 				return false
 			}
 
-			return scannerExtensions.includes(ext) && !this.ignoreInstance.ignores(relativeFilePath)
+			return scannerExtensions.includes(ext)
 		})
 
 		// Initialize tracking variables

--- a/src/services/code-index/service-factory.ts
+++ b/src/services/code-index/service-factory.ts
@@ -144,9 +144,8 @@ export class CodeIndexServiceFactory {
 		embedder: IEmbedder,
 		vectorStore: IVectorStore,
 		parser: ICodeParser,
-		ignoreInstance: Ignore,
 	): DirectoryScanner {
-		return new DirectoryScanner(embedder, vectorStore, parser, this.cacheManager, ignoreInstance)
+		return new DirectoryScanner(embedder, vectorStore, parser, this.cacheManager)
 	}
 
 	/**
@@ -157,9 +156,8 @@ export class CodeIndexServiceFactory {
 		embedder: IEmbedder,
 		vectorStore: IVectorStore,
 		cacheManager: CacheManager,
-		ignoreInstance: Ignore,
 	): IFileWatcher {
-		return new FileWatcher(this.workspacePath, context, cacheManager, embedder, vectorStore, ignoreInstance)
+		return new FileWatcher(this.workspacePath, context, cacheManager, embedder, vectorStore)
 	}
 
 	/**
@@ -169,7 +167,6 @@ export class CodeIndexServiceFactory {
 	public createServices(
 		context: vscode.ExtensionContext,
 		cacheManager: CacheManager,
-		ignoreInstance: Ignore,
 	): {
 		embedder: IEmbedder
 		vectorStore: IVectorStore
@@ -184,8 +181,8 @@ export class CodeIndexServiceFactory {
 		const embedder = this.createEmbedder()
 		const vectorStore = this.createVectorStore()
 		const parser = codeParser
-		const scanner = this.createDirectoryScanner(embedder, vectorStore, parser, ignoreInstance)
-		const fileWatcher = this.createFileWatcher(context, embedder, vectorStore, cacheManager, ignoreInstance)
+		const scanner = this.createDirectoryScanner(embedder, vectorStore, parser)
+		const fileWatcher = this.createFileWatcher(context, embedder, vectorStore, cacheManager)
 
 		return {
 			embedder,

--- a/src/services/mcp/__tests__/McpHub.spec.ts
+++ b/src/services/mcp/__tests__/McpHub.spec.ts
@@ -62,6 +62,22 @@ vi.mock("vscode", () => ({
 			dispose: vi.fn(),
 		}),
 	},
+	Uri: {
+		file: vi.fn((path: string) => ({
+			scheme: "file",
+			authority: "",
+			path: path,
+			query: "",
+			fragment: "",
+			fsPath: path,
+			with: vi.fn(),
+			toJSON: vi.fn(),
+		})),
+	},
+	RelativePattern: vi.fn().mockImplementation((base: string, pattern: string) => ({
+		base,
+		pattern,
+	})),
 	Disposable: {
 		from: vi.fn(),
 	},
@@ -92,7 +108,6 @@ describe("McpHub", () => {
 
 		// Mock console.error to suppress error messages during tests
 		console.error = vi.fn()
-
 
 		const mockUri: Uri = {
 			scheme: "file",


### PR DESCRIPTION
## Summary

This PR fixes the codebase indexing issues described in #5655 by implementing a unified ignore pattern handling system that makes .gitignore act as a fallback when .rooignore is missing or empty.

## Problem

The current indexing system had several critical issues:
1. **No Fallback Mechanism**: When .rooignore doesn't exist, the system doesn't fall back to .gitignore
2. **Inconsistent Application**: Different components apply ignore patterns differently  
3. **Dual Filtering Confusion**: Some components apply both .rooignore AND .gitignore, causing conflicts
4. **Missing Integration**: The two ignore systems don't communicate

## Solution

### Enhanced RooIgnoreController
- **Priority System**: .rooignore (if exists and non-empty) → .gitignore (fallback) → default patterns
- **File Watchers**: Added watchers for both .rooignore and .gitignore files to detect changes
- **State Tracking**: Added `currentIgnoreSource` property to track which ignore file is being used
- **Unified Interface**: Single source of truth for all ignore pattern validation

### Removed Dual Filtering
- **DirectoryScanner**: Removed separate .gitignore filtering, now relies solely on RooIgnoreController
- **FileWatcher**: Removed duplicate ignore instance checks
- **Service Factory**: Removed redundant ignore instance parameter from service creation

### Updated Architecture
- **Manager**: Updated to use unified ignore system without separate ignore instances
- **Tests**: Updated constructor signatures to reflect new architecture

## Behavior Changes

### Before
- .rooignore and .gitignore were applied separately and inconsistently
- No fallback when .rooignore was missing
- Dual filtering caused unpredictable results

### After  
- **Scenario 1**: .rooignore exists with content → Use .rooignore only
- **Scenario 2**: .rooignore exists but is empty → Fall back to .gitignore
- **Scenario 3**: .rooignore missing, .gitignore exists → Use .gitignore  
- **Scenario 4**: Both files missing → Use default patterns

## Testing

- ✅ All existing tests pass
- ✅ TypeScript compilation successful
- ✅ Linting passes
- ✅ Updated test constructors to match new signatures

## Files Changed

- `src/core/ignore/RooIgnoreController.ts` - Enhanced with .gitignore fallback support
- `src/services/code-index/manager.ts` - Removed duplicate .gitignore handling  
- `src/services/code-index/service-factory.ts` - Updated service creation interface
- `src/services/code-index/processors/scanner.ts` - Removed dual filtering
- `src/services/code-index/processors/file-watcher.ts` - Unified ignore handling
- `src/services/code-index/processors/__tests__/scanner.spec.ts` - Updated test signatures

Fixes #5655
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Unified `.gitignore` and `.rooignore` handling in codebase indexing, with `.gitignore` as fallback, and updated related components and tests.
> 
>   - **Behavior**:
>     - `RooIgnoreController` now uses `.gitignore` as a fallback if `.rooignore` is missing or empty.
>     - Added file watchers for `.rooignore` and `.gitignore` to detect changes.
>     - Introduced `currentIgnoreSource` to track active ignore file.
>     - Unified ignore pattern validation across components.
>   - **Architecture**:
>     - Removed separate `.gitignore` handling in `DirectoryScanner` and `FileWatcher`.
>     - Updated `CodeIndexManager` to use unified ignore system.
>     - Updated `service-factory.ts` to remove redundant ignore instance parameters.
>   - **Testing**:
>     - Updated tests in `scanner.spec.ts` and `file-watcher.spec.ts` to align with new ignore handling.
>     - Mocked `RooIgnoreController` in tests to validate new behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ebcb23d32134da23fd58a41cc028b52ce478d271. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->