### PR TITLE
Fix: Remove invalid skip-checkout parameter from GitHub Actions workflows

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -31,8 +31,6 @@ jobs:
           ref: ${{ env.GIT_REF }}
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
-        with:
-          skip-checkout: 'true'
 
       # Check if there are any new changesets to process
       - name: Check for changesets

--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -25,8 +25,6 @@ jobs:
           ref: ${{ env.GIT_REF }}
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
-        with:
-          skip-checkout: 'true'
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
-          skip-checkout: 'true'
           install-args: '--frozen-lockfile'
       - name: Forge numeric Nightly version
         id: version


### PR DESCRIPTION
## Summary

This PR fixes the warnings in the `publish-nightly` workflow logs by removing the invalid `skip-checkout` parameter from three GitHub Actions workflow files.

## Problem

The `setup-node-pnpm` custom action only accepts these inputs:
- `node-version`
- `pnpm-version` 
- `skip-install`
- `install-args`

However, three workflow files were passing an invalid `skip-checkout` parameter, causing warnings in the workflow runs.

## Solution

Removed the `skip-checkout` parameter from:
- `.github/workflows/nightly-publish.yml`
- `.github/workflows/marketplace-publish.yml`
- `.github/workflows/changeset-release.yml`

Since all these workflows already have a separate checkout step before calling the setup action, the `skip-checkout` parameter was unnecessary.

## Testing

- ✅ All linting checks pass
- ✅ All type checks pass
- ✅ No `skip-checkout` parameters remain in workflow files

Fixes #5674
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove invalid `skip-checkout` parameter from GitHub Actions workflows to fix warnings.
> 
>   - **Behavior**:
>     - Removed invalid `skip-checkout` parameter from `setup-node-pnpm` in `.github/workflows/nightly-publish.yml`, `.github/workflows/marketplace-publish.yml`, and `.github/workflows/changeset-release.yml`.
>     - The parameter was unnecessary as a separate checkout step is already present in these workflows.
>   - **Testing**:
>     - Verified no `skip-checkout` parameters remain in workflow files.
>     - All linting and type checks pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 36f345325fc74bc68863c7d5135b4ead245503f1. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->