### PR TITLE
fix: add manutic/nomic-embed-code model for Ollama compatibility

### DIFF
--- a/src/shared/embeddingModels.ts
+++ b/src/shared/embeddingModels.ts
@@ -31,6 +31,11 @@ export const EMBEDDING_MODEL_PROFILES: EmbeddingModelProfiles = {
 			scoreThreshold: 0.15,
 			queryPrefix: "Represent this query for searching relevant code: ",
 		},
+		"manutic/nomic-embed-code": {
+			dimension: 3584,
+			scoreThreshold: 0.15,
+			queryPrefix: "Represent this query for searching relevant code: ",
+		},
 		"mxbai-embed-large": { dimension: 1024, scoreThreshold: 0.4 },
 		"all-minilm": { dimension: 384, scoreThreshold: 0.4 },
 		// Add default Ollama model if applicable, e.g.:

--- a/src/shared/embeddingModels.ts
+++ b/src/shared/embeddingModels.ts
@@ -50,6 +50,11 @@ export const EMBEDDING_MODEL_PROFILES: EmbeddingModelProfiles = {
 			scoreThreshold: 0.15,
 			queryPrefix: "Represent this query for searching relevant code: ",
 		},
+		"manutic/nomic-embed-code": {
+			dimension: 3584,
+			scoreThreshold: 0.15,
+			queryPrefix: "Represent this query for searching relevant code: ",
+		},
 	},
 	gemini: {
 		"text-embedding-004": { dimension: 768 },


### PR DESCRIPTION
Fixes #5687

## Summary
This PR adds support for the `manutic/nomic-embed-code` model to resolve the issue where users cannot use `nomic-embed-code` with Ollama, since only the community version exists in Ollama's model repository.

## Changes
- Added `manutic/nomic-embed-code` to both Ollama and OpenAI Compatible embedding model profiles
- Configured with same properties as `nomic-embed-code`:
  - 3584 dimensions
  - 0.15 score threshold  
  - Code search query prefix

## Testing
- ✅ All existing config-manager tests pass
- ✅ All shared module tests pass
- ✅ Linting and type checking pass
- ✅ No breaking changes to existing functionality

## Impact
- Users can now select `manutic/nomic-embed-code` for Ollama-based code indexing
- Provides flexibility in embedding model selection
- Maintains backward compatibility with existing configurations

## Related Issue
Closes #5687 - [Codebase Indexing] Wrong Ollama Model reference
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `manutic/nomic-embed-code` model to Ollama and OpenAI-compatible profiles in `embeddingModels.ts` with specific configurations.
> 
>   - **Behavior**:
>     - Adds `manutic/nomic-embed-code` model to `EMBEDDING_MODEL_PROFILES` in `embeddingModels.ts` for both `ollama` and `openai-compatible` providers.
>     - Configures `manutic/nomic-embed-code` with 3584 dimensions, 0.15 score threshold, and a code search query prefix.
>   - **Testing**:
>     - All existing tests pass, including config-manager and shared module tests.
>     - Linting and type checking pass.
>   - **Impact**:
>     - Enables `manutic/nomic-embed-code` selection for Ollama-based code indexing.
>     - Maintains backward compatibility with existing configurations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for befcd2b5ef6435d38b71a7de85e55baa4d119252. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->