### PR TITLE
feat: add gemini-embedding-001 model to code-index service

### DIFF
--- a/src/services/code-index/embedders/gemini.ts
+++ b/src/services/code-index/embedders/gemini.ts
@@ -7,33 +7,36 @@ import { TelemetryService } from "@roo-code/telemetry"
 
 /**
  * Gemini embedder implementation that wraps the OpenAI Compatible embedder
- * with fixed configuration for Google's Gemini embedding API.
+ * with configuration for Google's Gemini embedding API.
  *
- * Fixed values:
- * - Base URL: https://generativelanguage.googleapis.com/v1beta/openai/
- * - Model: text-embedding-004
- * - Dimension: 768
+ * Supported models:
+ * - text-embedding-004 (dimension: 768)
+ * - gemini-embedding-001 (dimension: 2048)
  */
 export class GeminiEmbedder implements IEmbedder {
 	private readonly openAICompatibleEmbedder: OpenAICompatibleEmbedder
 	private static readonly GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
-	private static readonly GEMINI_MODEL = "text-embedding-004"
-	private static readonly GEMINI_DIMENSION = 768
+	private static readonly DEFAULT_MODEL = "gemini-embedding-001"
+	private readonly modelId: string
 
 	/**
 	 * Creates a new Gemini embedder
 	 * @param apiKey The Gemini API key for authentication
+	 * @param modelId The model ID to use (defaults to text-embedding-004)
 	 */
-	constructor(apiKey: string) {
+	constructor(apiKey: string, modelId?: string) {
 		if (!apiKey) {
 			throw new Error(t("embeddings:validation.apiKeyRequired"))
 		}
 
-		// Create an OpenAI Compatible embedder with Gemini's fixed configuration
+		// Use provided model or default
+		this.modelId = modelId || GeminiEmbedder.DEFAULT_MODEL
+
+		// Create an OpenAI Compatible embedder with Gemini's configuration
 		this.openAICompatibleEmbedder = new OpenAICompatibleEmbedder(
 			GeminiEmbedder.GEMINI_BASE_URL,
 			apiKey,
-			GeminiEmbedder.GEMINI_MODEL,
+			this.modelId,
 			GEMINI_MAX_ITEM_TOKENS,
 		)
 	}
@@ -41,13 +44,14 @@ export class GeminiEmbedder implements IEmbedder {
 	/**
 	 * Creates embeddings for the given texts using Gemini's embedding API
 	 * @param texts Array of text strings to embed
-	 * @param model Optional model identifier (ignored - always uses text-embedding-004)
+	 * @param model Optional model identifier (uses constructor model if not provided)
 	 * @returns Promise resolving to embedding response
 	 */
 	async createEmbeddings(texts: string[], model?: string): Promise<EmbeddingResponse> {
 		try {
-			// Always use the fixed Gemini model, ignoring any passed model parameter
-			return await this.openAICompatibleEmbedder.createEmbeddings(texts, GeminiEmbedder.GEMINI_MODEL)
+			// Use the provided model or fall back to the instance's model
+			const modelToUse = model || this.modelId
+			return await this.openAICompatibleEmbedder.createEmbeddings(texts, modelToUse)
 		} catch (error) {
 			TelemetryService.instance.captureEvent(TelemetryEventName.CODE_INDEX_ERROR, {
 				error: error instanceof Error ? error.message : String(error),
@@ -84,12 +88,5 @@ export class GeminiEmbedder implements IEmbedder {
 		return {
 			name: "gemini",
 		}
-	}
-
-	/**
-	 * Gets the fixed dimension for Gemini embeddings
-	 */
-	static get dimension(): number {
-		return GeminiEmbedder.GEMINI_DIMENSION
 	}
 }

--- a/src/services/code-index/embedders/gemini.ts
+++ b/src/services/code-index/embedders/gemini.ts
@@ -22,7 +22,7 @@ export class GeminiEmbedder implements IEmbedder {
 	/**
 	 * Creates a new Gemini embedder
 	 * @param apiKey The Gemini API key for authentication
-	 * @param modelId The model ID to use (defaults to text-embedding-004)
+	 * @param modelId The model ID to use (defaults to gemini-embedding-001)
 	 */
 	constructor(apiKey: string, modelId?: string) {
 		if (!apiKey) {

--- a/src/services/code-index/service-factory.ts
+++ b/src/services/code-index/service-factory.ts
@@ -63,7 +63,7 @@ export class CodeIndexServiceFactory {
 			if (!config.geminiOptions?.apiKey) {
 				throw new Error(t("embeddings:serviceFactory.geminiConfigMissing"))
 			}
-			return new GeminiEmbedder(config.geminiOptions.apiKey)
+			return new GeminiEmbedder(config.geminiOptions.apiKey, config.modelId)
 		}
 
 		throw new Error(
@@ -111,9 +111,6 @@ export class CodeIndexServiceFactory {
 		// First check if a manual dimension is provided (works for all providers)
 		if (config.modelDimension && config.modelDimension > 0) {
 			vectorSize = config.modelDimension
-		} else if (provider === "gemini") {
-			// Gemini's text-embedding-004 has a fixed dimension of 768
-			vectorSize = 768
 		} else {
 			// Fall back to model-specific dimension from profiles
 			vectorSize = getModelDimension(provider, modelId)

--- a/src/shared/embeddingModels.ts
+++ b/src/shared/embeddingModels.ts
@@ -48,6 +48,7 @@ export const EMBEDDING_MODEL_PROFILES: EmbeddingModelProfiles = {
 	},
 	gemini: {
 		"text-embedding-004": { dimension: 768 },
+		"gemini-embedding-001": { dimension: 3072, scoreThreshold: 0.4 },
 	},
 }
 
@@ -134,7 +135,7 @@ export function getDefaultModelId(provider: EmbedderProvider): string {
 		}
 
 		case "gemini":
-			return "text-embedding-004"
+			return "gemini-embedding-001"
 
 		default:
 			// Fallback for unknown providers


### PR DESCRIPTION
## Description

This PR adds support for Google's new gemini-embedding-001 model to the code-index service. This model provides state-of-the-art performance across English, multilingual, and code tasks, unifying previously specialized models.

## Changes Made

- Added gemini-embedding-001 to embedding model profiles with correct output dimension of 3072
- Updated GeminiEmbedder class to support multiple models via constructor parameter instead of being hardcoded
- Set gemini-embedding-001 as the default Gemini embedding model
- Updated service-factory to pass the modelId parameter to GeminiEmbedder
- Removed hardcoded dimension logic for Gemini provider in service-factory
- Updated all tests to support the new model parameter and correct dimensions

## Model Specifications

- Model Name: gemini-embedding-001
- Output Dimensions: 3072
- Max Sequence Length: 2048 tokens
- Description: State-of-the-art performance across English, multilingual and code tasks

## Testing

- All unit tests pass for GeminiEmbedder
- All unit tests pass for service-factory
- Linting and type checking pass

## UI Support

The existing CodeIndexPopover component already supports displaying Gemini models in a dropdown, so users will automatically see both available models:
- text-embedding-004 (768 dimensions)
- gemini-embedding-001 (3072 dimensions)

## Breaking Changes

None. The changes are backward compatible - existing configurations using text-embedding-004 will continue to work.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for `gemini-embedding-001` model to code-index service, updating `GeminiEmbedder` and tests for multiple model handling.
> 
>   - **Behavior**:
>     - Add `gemini-embedding-001` model to `embeddingModels.ts` with dimension 3072.
>     - Set `gemini-embedding-001` as default model in `getDefaultModelId()`.
>     - Update `GeminiEmbedder` to accept model ID via constructor, defaulting to `gemini-embedding-001`.
>     - Update `createEmbeddings()` in `GeminiEmbedder` to use instance or provided model.
>   - **Service Factory**:
>     - Update `createEmbedder()` in `service-factory.ts` to pass model ID to `GeminiEmbedder`.
>     - Remove hardcoded dimension logic for Gemini in `createVectorStore()`.
>   - **Testing**:
>     - Update tests in `service-factory.spec.ts` and `gemini.spec.ts` to handle new model parameter and dimensions.
>     - Ensure all tests pass with new model configurations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for fe877f9f3a645071d324ab91d46e58042bb57880. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->