### PR TITLE
Tweaks to command timeout error

### DIFF
--- a/src/core/tools/executeCommandTool.ts
+++ b/src/core/tools/executeCommandTool.ts
@@ -252,7 +252,10 @@ export async function executeCommand(
 				clineProvider?.postMessageToWebview({ type: "commandExecutionStatus", text: JSON.stringify(status) })
 
 				// Add visual feedback for timeout
-				await cline.say("text", t("common:command_timeout", { seconds: commandExecutionTimeoutSeconds }))
+				await cline.say(
+					"error",
+					t("common:errors:command_timeout", { seconds: commandExecutionTimeoutSeconds }),
+				)
 
 				cline.terminalProcess = undefined
 


### PR DESCRIPTION
Fix translation, make it red
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update translation key and visual feedback type for command timeout errors in `executeCommandTool.ts`.
> 
>   - **Behavior**:
>     - In `executeCommand` in `executeCommandTool.ts`, change translation key from `common:command_timeout` to `common:errors:command_timeout` for timeout messages.
>     - Change visual feedback type from `text` to `error` for command timeout messages in `executeCommand` in `executeCommandTool.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 9135c952d3a43ddcb02e03e748c2158a21f1390e. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->