### PR TITLE
feat: Update Ollama UI to use text inputs

### DIFF
--- a/webview-ui/src/components/chat/CodeIndexPopover.tsx
+++ b/webview-ui/src/components/chat/CodeIndexPopover.tsx
@@ -741,7 +741,7 @@ export const CodeIndexPopover: React.FC<CodeIndexPopoverProps> = ({
 													}
 													onInput={(e: any) => {
 														const value = e.target.value
-															? parseInt(e.target.value)
+															? parseInt(e.target.value, 10) || undefined
 															: undefined
 														updateSetting("codebaseIndexEmbedderModelDimension", value)
 													}}
@@ -849,7 +849,7 @@ export const CodeIndexPopover: React.FC<CodeIndexPopoverProps> = ({
 													}
 													onInput={(e: any) => {
 														const value = e.target.value
-															? parseInt(e.target.value)
+															? parseInt(e.target.value, 10) || undefined
 															: undefined
 														updateSetting("codebaseIndexEmbedderModelDimension", value)
 													}}

--- a/webview-ui/src/components/chat/CodeIndexPopover.tsx
+++ b/webview-ui/src/components/chat/CodeIndexPopover.tsx
@@ -97,6 +97,10 @@ const createValidationSchema = (provider: EmbedderProvider, t: any) => {
 					.min(1, t("settings:codeIndex.validation.ollamaBaseUrlRequired"))
 					.url(t("settings:codeIndex.validation.invalidOllamaUrl")),
 				codebaseIndexEmbedderModelId: z.string().min(1, t("settings:codeIndex.validation.modelIdRequired")),
+				codebaseIndexEmbedderModelDimension: z
+					.number()
+					.min(1, t("settings:codeIndex.validation.modelDimensionRequired"))
+					.optional(),
 			})
 
 		case "openai-compatible":
@@ -709,37 +713,47 @@ export const CodeIndexPopover: React.FC<CodeIndexPopoverProps> = ({
 												<label className="text-sm font-medium">
 													{t("settings:codeIndex.modelLabel")}
 												</label>
-												<VSCodeDropdown
-													value={currentSettings.codebaseIndexEmbedderModelId}
-													onChange={(e: any) =>
+												<VSCodeTextField
+													value={currentSettings.codebaseIndexEmbedderModelId || ""}
+													onInput={(e: any) =>
 														updateSetting("codebaseIndexEmbedderModelId", e.target.value)
 													}
+													placeholder={t("settings:codeIndex.modelPlaceholder")}
 													className={cn("w-full", {
 														"border-red-500": formErrors.codebaseIndexEmbedderModelId,
-													})}>
-													<VSCodeOption value="" className="p-2">
-														{t("settings:codeIndex.selectModel")}
-													</VSCodeOption>
-													{getAvailableModels().map((modelId) => {
-														const model =
-															codebaseIndexModels?.[
-																currentSettings.codebaseIndexEmbedderProvider
-															]?.[modelId]
-														return (
-															<VSCodeOption key={modelId} value={modelId} className="p-2">
-																{modelId}{" "}
-																{model
-																	? t("settings:codeIndex.modelDimensions", {
-																			dimension: model.dimension,
-																		})
-																	: ""}
-															</VSCodeOption>
-														)
 													})}
-												</VSCodeDropdown>
+												/>
 												{formErrors.codebaseIndexEmbedderModelId && (
 													<p className="text-xs text-vscode-errorForeground mt-1 mb-0">
 														{formErrors.codebaseIndexEmbedderModelId}
+													</p>
+												)}
+											</div>
+
+											<div className="space-y-2">
+												<label className="text-sm font-medium">
+													{t("settings:codeIndex.modelDimensionLabel")}
+												</label>
+												<VSCodeTextField
+													value={
+														currentSettings.codebaseIndexEmbedderModelDimension?.toString() ||
+														""
+													}
+													onInput={(e: any) => {
+														const value = e.target.value
+															? parseInt(e.target.value)
+															: undefined
+														updateSetting("codebaseIndexEmbedderModelDimension", value)
+													}}
+													placeholder={t("settings:codeIndex.modelDimensionPlaceholder")}
+													className={cn("w-full", {
+														"border-red-500":
+															formErrors.codebaseIndexEmbedderModelDimension,
+													})}
+												/>
+												{formErrors.codebaseIndexEmbedderModelDimension && (
+													<p className="text-xs text-vscode-errorForeground mt-1 mb-0">
+														{formErrors.codebaseIndexEmbedderModelDimension}
 													</p>
 												)}
 											</div>


### PR DESCRIPTION
Updates Ollama embedder configuration to use text inputs for model and dimensions instead of dropdown. Makes it consistent with OpenAI-compatible provider.

<img width="397" height="705" alt="image" src="https://github.com/user-attachments/assets/1a644e7d-4b53-4eda-84b2-1292b4733082" />


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Updates Ollama embedder UI to use text inputs for model and dimensions, with validation adjustments in `CodeIndexPopover.tsx`.
> 
>   - **UI Update**:
>     - Replaces `VSCodeDropdown` with `VSCodeTextField` for `codebaseIndexEmbedderModelId` and `codebaseIndexEmbedderModelDimension` in `CodeIndexPopover.tsx`.
>     - Adds placeholder text for model and dimension fields.
>   - **Validation**:
>     - Updates `createValidationSchema` to validate `codebaseIndexEmbedderModelDimension` as an optional number for "ollama" provider.
>   - **Misc**:
>     - Adjusts input handling to parse dimension as integer in `CodeIndexPopover.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c306e78e5c003a8de896eabd28aa9accf0cefe8a. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->