### PR TITLE
Allow command execution timeout to be set via IPC task execution

### DIFF
--- a/packages/types/npm/package.json
+++ b/packages/types/npm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@roo-code/types",
-	"version": "1.32.0",
+	"version": "1.34.0",
 	"description": "TypeScript type definitions for Roo Code.",
 	"publishConfig": {
 		"access": "public",

--- a/packages/types/src/global-settings.ts
+++ b/packages/types/src/global-settings.ts
@@ -50,6 +50,7 @@ export const globalSettingsSchema = z.object({
 	alwaysAllowUpdateTodoList: z.boolean().optional(),
 	allowedCommands: z.array(z.string()).optional(),
 	deniedCommands: z.array(z.string()).optional(),
+	commandExecutionTimeout: z.number().optional(),
 	allowedMaxRequests: z.number().nullish(),
 	autoCondenseContext: z.boolean().optional(),
 	autoCondenseContextPercent: z.number().optional(),
@@ -200,6 +201,7 @@ export const EVALS_SETTINGS: RooCodeSettings = {
 	alwaysAllowUpdateTodoList: true,
 	followupAutoApproveTimeoutMs: 0,
 	allowedCommands: ["*"],
+	commandExecutionTimeout: 30_000,
 
 	browserToolEnabled: false,
 	browserViewportSize: "900x600",

--- a/src/extension/api.ts
+++ b/src/extension/api.ts
@@ -125,6 +125,22 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 					.getConfiguration(Package.name)
 					.update("allowedCommands", configuration.allowedCommands, vscode.ConfigurationTarget.Global)
 			}
+
+			if (configuration.deniedCommands) {
+				await vscode.workspace
+					.getConfiguration(Package.name)
+					.update("deniedCommands", configuration.deniedCommands, vscode.ConfigurationTarget.Global)
+			}
+
+			if (configuration.commandExecutionTimeout) {
+				await vscode.workspace
+					.getConfiguration(Package.name)
+					.update(
+						"commandExecutionTimeout",
+						configuration.commandExecutionTimeout,
+						vscode.ConfigurationTarget.Global,
+					)
+			}
 		}
 
 		await provider.removeClineFromStack()
@@ -223,9 +239,11 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 
 			cline.on("taskCompleted", async (_, tokenUsage, toolUsage) => {
 				let isSubtask = false
+
 				if (cline.rootTask != undefined) {
 					isSubtask = true
 				}
+
 				this.emit(RooCodeEventName.TaskCompleted, cline.taskId, tokenUsage, toolUsage, { isSubtask: isSubtask })
 				this.taskMap.delete(cline.taskId)
 


### PR DESCRIPTION
Add `commandExecutionTimeout` to `GlobalSettings`, and if it is specified when starting a task via the API then persist the value in the VSCode settings.

Also bumped the version of `@roo-code/types`.