### PR TITLE
Log API-initiated tasks to a tmp directory

### DIFF
--- a/.changeset/late-rockets-talk.md
+++ b/.changeset/late-rockets-talk.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Log api-initiated tasks to a tmp directory

--- a/src/extension/api.ts
+++ b/src/extension/api.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "events"
 import * as vscode from "vscode"
 import fs from "fs/promises"
 import * as path from "path"
+import * as os from "os"
 
 import {
 	RooCodeAPI,
@@ -50,7 +51,7 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 				console.log(args)
 			}
 
-			this.logfile = path.join(getWorkspacePath(), "roo-code-messages.log")
+			this.logfile = path.join(os.tmpdir(), "roo-code-messages.log")
 		} else {
 			this.log = () => {}
 		}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change log file path for API-initiated tasks in `API` class to use temporary directory.
> 
>   - **Behavior**:
>     - Change log file path for API-initiated tasks in `API` class in `api.ts` to use `os.tmpdir()` instead of `getWorkspacePath()`.
>   - **Misc**:
>     - Add changeset file `late-rockets-talk.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 218af1d45dae95bcc33ffa2333737e1937cdafee. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->