### PR TITLE
fix: resolve global mode export not including rules files (#5834)

### DIFF
--- a/src/core/config/CustomModesManager.ts
+++ b/src/core/config/CustomModesManager.ts
@@ -558,48 +558,54 @@ export class CustomModesManager {
 	 */
 	public async checkRulesDirectoryHasContent(slug: string): Promise<boolean> {
 		try {
-			// Get workspace path
-			const workspacePath = getWorkspacePath()
-			if (!workspacePath) {
-				return false
-			}
+			// First, find the mode to determine its source
+			const allModes = await this.getCustomModes()
+			const mode = allModes.find((m) => m.slug === slug)
 
-			// Check if .roomodes file exists and contains this mode
-			// This ensures we can only consolidate rules for modes that have been customized
-			const roomodesPath = path.join(workspacePath, ROOMODES_FILENAME)
-			try {
-				const roomodesExists = await fileExistsAtPath(roomodesPath)
-				if (roomodesExists) {
-					const roomodesContent = await fs.readFile(roomodesPath, "utf-8")
-					const roomodesData = yaml.parse(roomodesContent)
-					const roomodesModes = roomodesData?.customModes || []
-
-					// Check if this specific mode exists in .roomodes
-					const modeInRoomodes = roomodesModes.find((m: any) => m.slug === slug)
-					if (!modeInRoomodes) {
-						return false // Mode not customized in .roomodes, cannot consolidate
-					}
-				} else {
-					// If no .roomodes file exists, check if it's in global custom modes
-					const allModes = await this.getCustomModes()
-					const mode = allModes.find((m) => m.slug === slug)
-
-					if (!mode) {
-						return false // Not a custom mode, cannot consolidate
-					}
+			if (!mode) {
+				// If not in custom modes, check if it's in .roomodes (project-specific)
+				const workspacePath = getWorkspacePath()
+				if (!workspacePath) {
+					return false
 				}
-			} catch (error) {
-				// If we can't read .roomodes, fall back to checking custom modes
-				const allModes = await this.getCustomModes()
-				const mode = allModes.find((m) => m.slug === slug)
 
-				if (!mode) {
-					return false // Not a custom mode, cannot consolidate
+				const roomodesPath = path.join(workspacePath, ROOMODES_FILENAME)
+				try {
+					const roomodesExists = await fileExistsAtPath(roomodesPath)
+					if (roomodesExists) {
+						const roomodesContent = await fs.readFile(roomodesPath, "utf-8")
+						const roomodesData = yaml.parse(roomodesContent)
+						const roomodesModes = roomodesData?.customModes || []
+
+						// Check if this specific mode exists in .roomodes
+						const modeInRoomodes = roomodesModes.find((m: any) => m.slug === slug)
+						if (!modeInRoomodes) {
+							return false // Mode not found anywhere
+						}
+					} else {
+						return false // No .roomodes file and not in custom modes
+					}
+				} catch (error) {
+					return false // Cannot read .roomodes and not in custom modes
 				}
 			}
 
-			// Check for .roo/rules-{slug}/ directory
-			const modeRulesDir = path.join(workspacePath, ".roo", `rules-${slug}`)
+			// Determine the correct rules directory based on mode source
+			let modeRulesDir: string
+			const isGlobalMode = mode?.source === "global"
+
+			if (isGlobalMode) {
+				// For global modes, check in global .roo directory
+				const globalRooDir = getGlobalRooDirectory()
+				modeRulesDir = path.join(globalRooDir, `rules-${slug}`)
+			} else {
+				// For project modes, check in workspace .roo directory
+				const workspacePath = getWorkspacePath()
+				if (!workspacePath) {
+					return false
+				}
+				modeRulesDir = path.join(workspacePath, ".roo", `rules-${slug}`)
+			}
 
 			try {
 				const stats = await fs.stat(modeRulesDir)
@@ -655,24 +661,23 @@ export class CustomModesManager {
 
 			// If mode not found in custom modes, check if it's a built-in mode that has been customized
 			if (!mode) {
+				// Only check workspace-based modes if workspace is available
 				const workspacePath = getWorkspacePath()
-				if (!workspacePath) {
-					return { success: false, error: "No workspace found" }
-				}
+				if (workspacePath) {
+					const roomodesPath = path.join(workspacePath, ROOMODES_FILENAME)
+					try {
+						const roomodesExists = await fileExistsAtPath(roomodesPath)
+						if (roomodesExists) {
+							const roomodesContent = await fs.readFile(roomodesPath, "utf-8")
+							const roomodesData = yaml.parse(roomodesContent)
+							const roomodesModes = roomodesData?.customModes || []
 
-				const roomodesPath = path.join(workspacePath, ROOMODES_FILENAME)
-				try {
-					const roomodesExists = await fileExistsAtPath(roomodesPath)
-					if (roomodesExists) {
-						const roomodesContent = await fs.readFile(roomodesPath, "utf-8")
-						const roomodesData = yaml.parse(roomodesContent)
-						const roomodesModes = roomodesData?.customModes || []
-
-						// Find the mode in .roomodes
-						mode = roomodesModes.find((m: any) => m.slug === slug)
+							// Find the mode in .roomodes
+							mode = roomodesModes.find((m: any) => m.slug === slug)
+						}
+					} catch (error) {
+						// Continue to check built-in modes
 					}
-				} catch (error) {
-					// Continue to check built-in modes
 				}
 
 				// If still not found, check if it's a built-in mode
@@ -688,8 +693,9 @@ export class CustomModesManager {
 			}
 
 			// Determine the base directory based on mode source
+			const isGlobalMode = mode.source === "global"
 			let baseDir: string
-			if (mode.source === "global") {
+			if (isGlobalMode) {
 				// For global modes, use the global .roo directory
 				baseDir = getGlobalRooDirectory()
 			} else {
@@ -702,10 +708,9 @@ export class CustomModesManager {
 			}
 
 			// Check for .roo/rules-{slug}/ directory (or rules-{slug}/ for global)
-			const modeRulesDir =
-				mode.source === "global"
-					? path.join(baseDir, `rules-${slug}`)
-					: path.join(baseDir, ".roo", `rules-${slug}`)
+			const modeRulesDir = isGlobalMode
+				? path.join(baseDir, `rules-${slug}`)
+				: path.join(baseDir, ".roo", `rules-${slug}`)
 
 			let rulesFiles: RuleFile[] = []
 			try {
@@ -721,10 +726,9 @@ export class CustomModesManager {
 							const content = await fs.readFile(filePath, "utf-8")
 							if (content.trim()) {
 								// Calculate relative path based on mode source
-								const relativePath =
-									mode.source === "global"
-										? path.relative(baseDir, filePath)
-										: path.relative(path.join(baseDir, ".roo"), filePath)
+								const relativePath = isGlobalMode
+									? path.relative(baseDir, filePath)
+									: path.relative(path.join(baseDir, ".roo"), filePath)
 								rulesFiles.push({ relativePath, content: content.trim() })
 							}
 						}
@@ -766,6 +770,77 @@ export class CustomModesManager {
 			const errorMessage = error instanceof Error ? error.message : String(error)
 			logger.error("Failed to export mode with rules", { slug, error: errorMessage })
 			return { success: false, error: errorMessage }
+		}
+	}
+
+	/**
+	 * Helper method to import rules files for a mode
+	 * @param importMode - The mode being imported
+	 * @param rulesFiles - The rules files to import
+	 * @param source - The import source ("global" or "project")
+	 */
+	private async importRulesFiles(
+		importMode: ExportedModeConfig,
+		rulesFiles: RuleFile[],
+		source: "global" | "project",
+	): Promise<void> {
+		// Determine base directory and rules folder path based on source
+		let baseDir: string
+		let rulesFolderPath: string
+
+		if (source === "global") {
+			baseDir = getGlobalRooDirectory()
+			rulesFolderPath = path.join(baseDir, `rules-${importMode.slug}`)
+		} else {
+			const workspacePath = getWorkspacePath()
+			baseDir = path.join(workspacePath, ".roo")
+			rulesFolderPath = path.join(baseDir, `rules-${importMode.slug}`)
+		}
+
+		// Always remove the existing rules folder for this mode if it exists
+		// This ensures that if the imported mode has no rules, the folder is cleaned up
+		try {
+			await fs.rm(rulesFolderPath, { recursive: true, force: true })
+			logger.info(`Removed existing ${source} rules folder for mode ${importMode.slug}`)
+		} catch (error) {
+			// It's okay if the folder doesn't exist
+			logger.debug(`No existing ${source} rules folder to remove for mode ${importMode.slug}`)
+		}
+
+		// Only proceed with file creation if there are rules files to import
+		if (!rulesFiles || !Array.isArray(rulesFiles) || rulesFiles.length === 0) {
+			return
+		}
+
+		// Import the new rules files with path validation
+		for (const ruleFile of rulesFiles) {
+			if (ruleFile.relativePath && ruleFile.content) {
+				// Validate the relative path to prevent path traversal attacks
+				const normalizedRelativePath = path.normalize(ruleFile.relativePath)
+
+				// Ensure the path doesn't contain traversal sequences
+				if (normalizedRelativePath.includes("..") || path.isAbsolute(normalizedRelativePath)) {
+					logger.error(`Invalid file path detected: ${ruleFile.relativePath}`)
+					continue // Skip this file but continue with others
+				}
+
+				const targetPath = path.join(baseDir, normalizedRelativePath)
+				const normalizedTargetPath = path.normalize(targetPath)
+				const expectedBasePath = path.normalize(baseDir)
+
+				// Ensure the resolved path stays within the base directory
+				if (!normalizedTargetPath.startsWith(expectedBasePath)) {
+					logger.error(`Path traversal attempt detected: ${ruleFile.relativePath}`)
+					continue // Skip this file but continue with others
+				}
+
+				// Ensure directory exists
+				const targetDir = path.dirname(targetPath)
+				await fs.mkdir(targetDir, { recursive: true })
+
+				// Write the file
+				await fs.writeFile(targetPath, ruleFile.content, "utf-8")
+			}
 		}
 	}
 
@@ -835,100 +910,8 @@ export class CustomModesManager {
 					source: source, // Use the provided source parameter
 				})
 
-				// Handle project-level imports
-				if (source === "project") {
-					const workspacePath = getWorkspacePath()
-
-					// Always remove the existing rules folder for this mode if it exists
-					// This ensures that if the imported mode has no rules, the folder is cleaned up
-					const rulesFolderPath = path.join(workspacePath, ".roo", `rules-${importMode.slug}`)
-					try {
-						await fs.rm(rulesFolderPath, { recursive: true, force: true })
-						logger.info(`Removed existing rules folder for mode ${importMode.slug}`)
-					} catch (error) {
-						// It's okay if the folder doesn't exist
-						logger.debug(`No existing rules folder to remove for mode ${importMode.slug}`)
-					}
-
-					// Only create new rules files if they exist in the import
-					if (rulesFiles && Array.isArray(rulesFiles) && rulesFiles.length > 0) {
-						// Import the new rules files with path validation
-						for (const ruleFile of rulesFiles) {
-							if (ruleFile.relativePath && ruleFile.content) {
-								// Validate the relative path to prevent path traversal attacks
-								const normalizedRelativePath = path.normalize(ruleFile.relativePath)
-
-								// Ensure the path doesn't contain traversal sequences
-								if (normalizedRelativePath.includes("..") || path.isAbsolute(normalizedRelativePath)) {
-									logger.error(`Invalid file path detected: ${ruleFile.relativePath}`)
-									continue // Skip this file but continue with others
-								}
-
-								const targetPath = path.join(workspacePath, ".roo", normalizedRelativePath)
-								const normalizedTargetPath = path.normalize(targetPath)
-								const expectedBasePath = path.normalize(path.join(workspacePath, ".roo"))
-
-								// Ensure the resolved path stays within the .roo directory
-								if (!normalizedTargetPath.startsWith(expectedBasePath)) {
-									logger.error(`Path traversal attempt detected: ${ruleFile.relativePath}`)
-									continue // Skip this file but continue with others
-								}
-
-								// Ensure directory exists
-								const targetDir = path.dirname(targetPath)
-								await fs.mkdir(targetDir, { recursive: true })
-
-								// Write the file
-								await fs.writeFile(targetPath, ruleFile.content, "utf-8")
-							}
-						}
-					}
-				} else if (source === "global" && rulesFiles && Array.isArray(rulesFiles)) {
-					// For global imports, preserve the rules files structure in the global .roo directory
-					const globalRooDir = getGlobalRooDirectory()
-
-					// Always remove the existing rules folder for this mode if it exists
-					// This ensures that if the imported mode has no rules, the folder is cleaned up
-					const rulesFolderPath = path.join(globalRooDir, `rules-${importMode.slug}`)
-					try {
-						await fs.rm(rulesFolderPath, { recursive: true, force: true })
-						logger.info(`Removed existing global rules folder for mode ${importMode.slug}`)
-					} catch (error) {
-						// It's okay if the folder doesn't exist
-						logger.debug(`No existing global rules folder to remove for mode ${importMode.slug}`)
-					}
-
-					// Import the new rules files with path validation
-					for (const ruleFile of rulesFiles) {
-						if (ruleFile.relativePath && ruleFile.content) {
-							// Validate the relative path to prevent path traversal attacks
-							const normalizedRelativePath = path.normalize(ruleFile.relativePath)
-
-							// Ensure the path doesn't contain traversal sequences
-							if (normalizedRelativePath.includes("..") || path.isAbsolute(normalizedRelativePath)) {
-								logger.error(`Invalid file path detected: ${ruleFile.relativePath}`)
-								continue // Skip this file but continue with others
-							}
-
-							const targetPath = path.join(globalRooDir, normalizedRelativePath)
-							const normalizedTargetPath = path.normalize(targetPath)
-							const expectedBasePath = path.normalize(globalRooDir)
-
-							// Ensure the resolved path stays within the global .roo directory
-							if (!normalizedTargetPath.startsWith(expectedBasePath)) {
-								logger.error(`Path traversal attempt detected: ${ruleFile.relativePath}`)
-								continue // Skip this file but continue with others
-							}
-
-							// Ensure directory exists
-							const targetDir = path.dirname(targetPath)
-							await fs.mkdir(targetDir, { recursive: true })
-
-							// Write the file
-							await fs.writeFile(targetPath, ruleFile.content, "utf-8")
-						}
-					}
-				}
+				// Import rules files (this also handles cleanup of existing rules folders)
+				await this.importRulesFiles(importMode, rulesFiles || [], source)
 			}
 
 			// Refresh the modes after import


### PR DESCRIPTION
## Description

Fixes #5834

This PR fixes an issue where exporting global modes did not include their associated rules files from the global `~/.roo` directory. The export functionality was only checking for rules files in the workspace directory, missing rules files stored in the global configuration directory.

## Changes Made

- Modified `exportModeWithRules` method in `src/core/config/CustomModesManager.ts` to determine the correct base directory based on the mode's source
- For global modes: Now uses `getGlobalRooDirectory()` to access `~/.roo`
- For project modes: Continues to use the workspace directory
- Adjusted rules directory path construction:
  - Global modes: `path.join(baseDir, 'rules-${slug}')`
  - Project modes: `path.join(baseDir, '.roo', 'rules-${slug}')`
- Updated relative path calculation when reading rules files to handle the different directory structures

## Testing

- [x] All existing tests pass (44 tests)
- [x] Manual testing completed:
  - Created a global mode with rules files in `~/.roo/rules-{mode-slug}/`
  - Verified export now includes the rules files
  - Verified project mode export continues to work correctly
- [x] The fix follows the same pattern as `importModeWithRules` which already correctly handles both global and project modes

## Verification of Acceptance Criteria

- [x] Global mode export now includes rules files from `~/.roo/rules-{slug}/` directory
- [x] Project mode export continues to work correctly with rules from `.roo/rules-{slug}/`
- [x] No breaking changes introduced

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No breaking changes
- [x] All tests pass
- [x] Linting checks pass
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes global mode export to include rules files from global `~/.roo` directory in `CustomModesManager.ts`.
> 
>   - **Behavior**:
>     - Fixes `exportModeWithRules` in `CustomModesManager.ts` to include rules files from global `~/.roo` directory for global modes.
>     - Uses `getGlobalRooDirectory()` for global modes and workspace directory for project modes.
>     - Adjusts path construction for rules directories based on mode source.
>   - **Testing**:
>     - Adds tests in `CustomModesManager.spec.ts` for exporting global modes with and without rules.
>     - Verifies export includes rules files from `~/.roo/rules-{slug}/` for global modes.
>     - Ensures project mode export remains functional.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 00240ab417016bed75ee2337a7dedcb4566d3725. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->