### PR TITLE
Fix MCP section logic

### DIFF
--- a/src/core/prompts/sections/capabilities.ts
+++ b/src/core/prompts/sections/capabilities.ts
@@ -33,7 +33,7 @@ CAPABILITIES
 			? "\n- You can use the browser_action tool to interact with websites (including html files and locally running development servers) through a Puppeteer-controlled browser when you feel it is necessary in accomplishing the user's task. This tool is particularly useful for web development tasks as it allows you to launch a browser, navigate to pages, interact with elements through clicks and keyboard input, and capture the results through screenshots and console logs. This tool may be useful at key stages of web development tasks-such as after implementing new features, making substantial changes, when troubleshooting issues, or to verify the result of your work. You can analyze the provided screenshots to ensure correct rendering or identify errors, and review console logs for runtime issues.\n  - For example, if asked to add a component to a react website, you might create the necessary files, use execute_command to run the site locally, then use browser_action to launch the browser, navigate to the local server, and verify the component renders & functions correctly before closing the browser."
 			: ""
 	}${
-		mcpHub && mcpHub.getAllServers().length > 0
+		mcpHub && (mcpHub.getAllServers()?.length ?? 0) > 0
 			? `
 - You have access to MCP servers that may provide additional tools and resources. Each server may provide different capabilities that you can use to accomplish tasks more effectively.
 `

--- a/src/core/prompts/sections/capabilities.ts
+++ b/src/core/prompts/sections/capabilities.ts
@@ -33,7 +33,7 @@ CAPABILITIES
 			? "\n- You can use the browser_action tool to interact with websites (including html files and locally running development servers) through a Puppeteer-controlled browser when you feel it is necessary in accomplishing the user's task. This tool is particularly useful for web development tasks as it allows you to launch a browser, navigate to pages, interact with elements through clicks and keyboard input, and capture the results through screenshots and console logs. This tool may be useful at key stages of web development tasks-such as after implementing new features, making substantial changes, when troubleshooting issues, or to verify the result of your work. You can analyze the provided screenshots to ensure correct rendering or identify errors, and review console logs for runtime issues.\n  - For example, if asked to add a component to a react website, you might create the necessary files, use execute_command to run the site locally, then use browser_action to launch the browser, navigate to the local server, and verify the component renders & functions correctly before closing the browser."
 			: ""
 	}${
-		mcpHub
+		mcpHub && mcpHub.getAllServers().length > 0
 			? `
 - You have access to MCP servers that may provide additional tools and resources. Each server may provide different capabilities that you can use to accomplish tasks more effectively.
 `

--- a/src/core/prompts/sections/mcp-servers.ts
+++ b/src/core/prompts/sections/mcp-servers.ts
@@ -6,7 +6,7 @@ export async function getMcpServersSection(
 	diffStrategy?: DiffStrategy,
 	enableMcpServerCreation?: boolean,
 ): Promise<string> {
-	if (!mcpHub) {
+	if (!mcpHub || mcpHub.getAllServers().length === 0) {
 		return ""
 	}
 

--- a/src/core/prompts/sections/mcp-servers.ts
+++ b/src/core/prompts/sections/mcp-servers.ts
@@ -6,7 +6,7 @@ export async function getMcpServersSection(
 	diffStrategy?: DiffStrategy,
 	enableMcpServerCreation?: boolean,
 ): Promise<string> {
-	if (!mcpHub || mcpHub.getAllServers().length === 0) {
+	if (!mcpHub || (mcpHub.getAllServers()?.length ?? 0) === 0) {
 		return ""
 	}
 

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1608,7 +1608,7 @@ export class Task extends EventEmitter<ClineEvents> {
 			})
 		}
 
-		const hasMcpServers = (mcpHub?.getAllServers().length ?? 0) > 0
+		const hasMcpServers = mcpHub && (mcpHub.getAllServers().length ?? 0) > 0
 
 		const rooIgnoreInstructions = this.rooIgnoreController?.getInstructions()
 

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1608,6 +1608,8 @@ export class Task extends EventEmitter<ClineEvents> {
 			})
 		}
 
+		const hasMcpServers = (mcpHub?.getAllServers().length ?? 0) > 0
+
 		const rooIgnoreInstructions = this.rooIgnoreController?.getInstructions()
 
 		const state = await this.providerRef.deref()?.getState()
@@ -1637,7 +1639,7 @@ export class Task extends EventEmitter<ClineEvents> {
 				provider.context,
 				this.cwd,
 				(this.api.getModel().info.supportsComputerUse ?? false) && (browserToolEnabled ?? true),
-				mcpHub,
+				hasMcpServers ? mcpHub : undefined,
 				this.diffStrategy,
 				browserViewportSize,
 				mode,

--- a/src/core/webview/generateSystemPrompt.ts
+++ b/src/core/webview/generateSystemPrompt.ts
@@ -63,11 +63,14 @@ export const generateSystemPrompt = async (provider: ClineProvider, message: Web
 	// and browser tools are enabled in settings
 	const canUseBrowserTool = modelSupportsComputerUse && modeSupportsBrowser && (browserToolEnabled ?? true)
 
+	const mcpHub = provider.getMcpHub()
+	const hasMcpServers = (mcpHub?.getAllServers().length ?? 0) > 0
+
 	const systemPrompt = await SYSTEM_PROMPT(
 		provider.context,
 		cwd,
 		canUseBrowserTool,
-		mcpEnabled ? provider.getMcpHub() : undefined,
+		mcpEnabled && hasMcpServers ? mcpHub : undefined,
 		diffStrategy,
 		browserViewportSize ?? "900x600",
 		mode,

--- a/src/core/webview/generateSystemPrompt.ts
+++ b/src/core/webview/generateSystemPrompt.ts
@@ -64,7 +64,7 @@ export const generateSystemPrompt = async (provider: ClineProvider, message: Web
 	const canUseBrowserTool = modelSupportsComputerUse && modeSupportsBrowser && (browserToolEnabled ?? true)
 
 	const mcpHub = provider.getMcpHub()
-	const hasMcpServers = (mcpHub?.getAllServers().length ?? 0) > 0
+	const hasMcpServers = mcpHub && (mcpHub.getAllServers().length ?? 0) > 0
 
 	const systemPrompt = await SYSTEM_PROMPT(
 		provider.context,


### PR DESCRIPTION
## Summary
- avoid referencing MCP when no servers are defined
- drop MCP section from capabilities
- guard MCP servers section if server list empty

## Testing
- `pnpm lint`
- `pnpm test` *(fails: command exited with error)*

------
https://chatgpt.com/codex/tasks/task_e_687a59b26e108330b7e0a7c0fccd96b7