### PR TITLE
feat: add batch limiting to code indexer

### DIFF
--- a/src/services/code-index/constants/index.ts
+++ b/src/services/code-index/constants/index.ts
@@ -20,6 +20,7 @@ export const BATCH_SEGMENT_THRESHOLD = 60 // Number of code segments to batch fo
 export const MAX_BATCH_RETRIES = 3
 export const INITIAL_RETRY_DELAY_MS = 500
 export const PARSING_CONCURRENCY = 10
+export const MAX_PENDING_BATCHES = 20 // Maximum number of batches to accumulate before waiting
 
 /**OpenAI Embedder */
 export const MAX_BATCH_TOKENS = 100000


### PR DESCRIPTION
## Summary

Adds batch limiting to the code indexer to control memory usage during large codebase scanning.

## Changes

- Added `MAX_PENDING_BATCHES = 20` constant to limit concurrent batch processing
- Implemented backpressure mechanism that pauses file parsing when the pending batch limit is reached
- Prevents memory overflow by ensuring only a bounded number of batches are in memory at once

## Technical Details

- Maximum blocks in memory: ~1,200 (20 batches × 60 blocks per batch)
- File parsing waits when limit is reached using `Promise.race()` for efficient resumption
- Maintains high throughput while preventing unbounded memory growth

## Testing

All existing tests pass. The implementation maintains the same functionality while adding memory safety.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds batch limiting to the code indexer to control memory usage during large codebase scanning by pausing file parsing when pending batches reach a limit.
> 
>   - **Behavior**:
>     - Adds `MAX_PENDING_BATCHES = 20` to limit concurrent batch processing in `constants/index.ts`.
>     - Implements backpressure in `DirectoryScanner` in `scanner.ts` to pause file parsing when pending batches reach the limit.
>     - Uses `Promise.race()` for efficient resumption of file parsing.
>   - **Technical Details**:
>     - Maximum blocks in memory: ~1,200 (20 batches × 60 blocks per batch).
>     - Ensures bounded memory usage while maintaining high throughput.
>   - **Testing**:
>     - All existing tests pass, confirming no change in functionality except added memory safety.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c34e51f9a8b535e94c7431bbab64615497b0a435. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->