### PR TITLE
fix: add run parameter to vitest command in rules

### DIFF
--- a/.roo/rules/rules.md
+++ b/.roo/rules/rules.md
@@ -6,12 +6,12 @@
     - Ensure all tests pass before submitting changes
     - The vitest framework is used for testing; the `describe`, `test`, `it`, etc functions are defined by default in `tsconfig.json` and therefore don't need to be imported
     - Tests must be run from the same directory as the `package.json` file that specifies `vitest` in `devDependencies`
-    - Run tests with: `npx vitest <relative-path-from-workspace-root>`
+    - Run tests with: `npx vitest run <relative-path-from-workspace-root>`
     - Do NOT run tests from project root - this causes "vitest: command not found" error
     - Tests must be run from inside the correct workspace:
-        - Backend tests: `cd src && npx vitest path/to/test-file` (don't include `src/` in path)
-        - UI tests: `cd webview-ui && npx vitest src/path/to/test-file`
-    - Example: For `src/tests/user.test.ts`, run `cd src && npx vitest tests/user.test.ts` NOT `npx vitest src/tests/user.test.ts`
+        - Backend tests: `cd src && npx vitest run path/to/test-file` (don't include `src/` in path)
+        - UI tests: `cd webview-ui && npx vitest run src/path/to/test-file`
+    - Example: For `src/tests/user.test.ts`, run `cd src && npx vitest run tests/user.test.ts` NOT `npx vitest run src/tests/user.test.ts`
 
 2. Lint Rules:
 


### PR DESCRIPTION
## Context

When running vitest without the run parameter, it enters watch mode and waits for user input (like pressing q to quit), causing tests to hang in the terminal.

## Implementation

This PR updates the documentation in `.roo/rules/rules.md` to specify using `npx vitest run` instead of just `npx vitest` to ensure tests run to completion without requiring user interaction.

Fixes: #5992

## How to Test

1. Check the updated documentation in `.roo/rules/rules.md`
2. Verify that the command now includes the `run` parameter: `npx vitest run <relative-path-from-workspace-root>`
3. Try running a test with and without the `run` parameter to observe the difference in behavior:
   - With `run`: Test runs and completes automatically
   - Without `run`: Test enters watch mode and waits for user input

## Get in Touch

Discord: KJ7LNW