### PR TITLE
Update the max_tokens fallback logic in the sliding window

### DIFF
--- a/src/core/sliding-window/__tests__/sliding-window.spec.ts
+++ b/src/core/sliding-window/__tests__/sliding-window.spec.ts
@@ -1103,9 +1103,9 @@ describe("Sliding Window", () => {
 			expect(result2.prevContextTokens).toBe(50001)
 		})
 
-		it("should use 20% of context window as buffer when maxTokens is undefined", async () => {
+		it("should use ANTHROPIC_DEFAULT_MAX_TOKENS as buffer when maxTokens is undefined", async () => {
 			const modelInfo = createModelInfo(100000, undefined)
-			// Max tokens = 100000 - (100000 * 0.2) = 80000
+			// Max tokens = 100000 - ANTHROPIC_DEFAULT_MAX_TOKENS = 100000 - 8192 = 91808
 
 			// Create messages with very small content in the last one to avoid token overflow
 			const messagesWithSmallContent = [
@@ -1117,7 +1117,7 @@ describe("Sliding Window", () => {
 			// Below max tokens and buffer - no truncation
 			const result1 = await truncateConversationIfNeeded({
 				messages: messagesWithSmallContent,
-				totalTokens: 69999, // Well below threshold + dynamic buffer
+				totalTokens: 81807, // Well below threshold + dynamic buffer (91808 - 10000 = 81808)
 				contextWindow: modelInfo.contextWindow,
 				maxTokens: modelInfo.maxTokens,
 				apiHandler: mockApiHandler,
@@ -1132,13 +1132,13 @@ describe("Sliding Window", () => {
 				messages: messagesWithSmallContent,
 				summary: "",
 				cost: 0,
-				prevContextTokens: 69999,
+				prevContextTokens: 81807,
 			})
 
 			// Above max tokens - truncate
 			const result2 = await truncateConversationIfNeeded({
 				messages: messagesWithSmallContent,
-				totalTokens: 80001, // Above threshold
+				totalTokens: 81809, // Above threshold (81808)
 				contextWindow: modelInfo.contextWindow,
 				maxTokens: modelInfo.maxTokens,
 				apiHandler: mockApiHandler,
@@ -1153,7 +1153,7 @@ describe("Sliding Window", () => {
 			expect(result2.messages.length).toBe(3) // Truncated with 0.5 fraction
 			expect(result2.summary).toBe("")
 			expect(result2.cost).toBe(0)
-			expect(result2.prevContextTokens).toBe(80001)
+			expect(result2.prevContextTokens).toBe(81809)
 		})
 
 		it("should handle small context windows appropriately", async () => {

--- a/src/core/sliding-window/index.ts
+++ b/src/core/sliding-window/index.ts
@@ -5,6 +5,7 @@ import { TelemetryService } from "@roo-code/telemetry"
 import { ApiHandler } from "../../api"
 import { MAX_CONDENSE_THRESHOLD, MIN_CONDENSE_THRESHOLD, summarizeConversation, SummarizeResponse } from "../condense"
 import { ApiMessage } from "../task-persistence/apiMessages"
+import { ANTHROPIC_DEFAULT_MAX_TOKENS } from "@roo-code/types"
 
 /**
  * Default percentage of the context window to use as a buffer when deciding when to truncate
@@ -105,7 +106,7 @@ export async function truncateConversationIfNeeded({
 	let error: string | undefined
 	let cost = 0
 	// Calculate the maximum tokens reserved for response
-	const reservedTokens = maxTokens || contextWindow * 0.2
+	const reservedTokens = maxTokens || ANTHROPIC_DEFAULT_MAX_TOKENS
 
 	// Estimate tokens for the last message (which is always a user message)
 	const lastMessage = messages[messages.length - 1]


### PR DESCRIPTION
I'm not sure it's actually possible to hit this in practice, but we got rid of all the 20% of context window logic and replaced it with falling back on 8192 tokens.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces 20% context window logic with a fixed fallback of 8192 tokens in sliding window logic and updates tests accordingly.
> 
>   - **Behavior**:
>     - Replaces 20% context window logic with `ANTHROPIC_DEFAULT_MAX_TOKENS` (8192) as fallback in `truncateConversationIfNeeded()` in `index.ts`.
>     - Updates test `should use ANTHROPIC_DEFAULT_MAX_TOKENS as buffer when maxTokens is undefined` in `sliding-window.spec.ts` to reflect new fallback logic.
>   - **Misc**:
>     - Updates comments in `sliding-window.spec.ts` to reflect new token calculation logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 2a24f80bb4cb3ade8f97f5b8f0bd39b4bd981f72. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->