### PR TITLE
fix: allow text content after update_todo_list tool (#5847)

### DIFF
--- a/src/core/assistant-message/presentAssistantMessage.ts
+++ b/src/core/assistant-message/presentAssistantMessage.ts
@@ -256,8 +256,11 @@ export async function presentAssistantMessage(cline: Task) {
 
 				// Once a tool result has been collected, ignore all other tool
 				// uses since we should only ever present one tool result per
-				// message.
-				cline.didAlreadyUseTool = true
+				// message. Exception: update_todo_list is allowed to be followed
+				// by text content.
+				if (block.name !== "update_todo_list") {
+					cline.didAlreadyUseTool = true
+				}
 			}
 
 			const askApproval = async (


### PR DESCRIPTION
## Description

This PR fixes issue #5847 by allowing text content to be displayed after the `update_todo_list` tool is used.

## Problem

Currently, when any tool is used (including `update_todo_list`), the `didAlreadyUseTool` flag is set to true, which causes all subsequent text content to be skipped. This prevents the assistant from providing context or explanations after updating the todo list.

## Solution

The `update_todo_list` tool is a special case that doesn't produce actionable output or require user interaction beyond confirmation. Unlike other tools that perform file operations or system commands, `update_todo_list` simply updates the UI's todo list display.

This change exempts `update_todo_list` from setting the `didAlreadyUseTool` flag, which allows subsequent text content to be rendered. This enables the assistant to provide context or explanations after updating the todo list, improving the user experience.

## Implementation Details

- Modified the `pushToolResult` function in `presentAssistantMessage.ts` to check if the current tool is `update_todo_list`
- If it is `update_todo_list`, the `didAlreadyUseTool` flag is not set
- The one-tool-per-message restriction remains in effect for all other tools to prevent multiple potentially conflicting operations in a single message

## Testing

The fix has been implemented and is ready for testing. The change is minimal and focused on the specific issue.

Fixes #5847