### PR TITLE
fix: add bedrock to ANTHROPIC_STYLE_PROVIDERS and restore vertex Claude model checking

### DIFF
--- a/packages/types/src/__tests__/provider-settings.test.ts
+++ b/packages/types/src/__tests__/provider-settings.test.ts
@@ -5,75 +5,33 @@ describe("getApiProtocol", () => {
 	describe("Anthropic-style providers", () => {
 		it("should return 'anthropic' for anthropic provider", () => {
 			expect(getApiProtocol("anthropic")).toBe("anthropic")
-			expect(getApiProtocol("anthropic", "gpt-4")).toBe("anthropic")
 		})
 
 		it("should return 'anthropic' for claude-code provider", () => {
 			expect(getApiProtocol("claude-code")).toBe("anthropic")
-			expect(getApiProtocol("claude-code", "some-model")).toBe("anthropic")
 		})
 	})
 
-	describe("Vertex provider with Claude models", () => {
-		it("should return 'anthropic' for vertex provider with claude models", () => {
-			expect(getApiProtocol("vertex", "claude-3-opus")).toBe("anthropic")
-			expect(getApiProtocol("vertex", "Claude-3-Sonnet")).toBe("anthropic")
-			expect(getApiProtocol("vertex", "CLAUDE-instant")).toBe("anthropic")
-			expect(getApiProtocol("vertex", "anthropic/claude-3-haiku")).toBe("anthropic")
+	describe("Non-Anthropic providers", () => {
+		it("should return 'openai' for vertex provider", () => {
+			expect(getApiProtocol("vertex")).toBe("openai")
 		})
 
-		it("should return 'openai' for vertex provider with non-claude models", () => {
-			expect(getApiProtocol("vertex", "gpt-4")).toBe("openai")
-			expect(getApiProtocol("vertex", "gemini-pro")).toBe("openai")
-			expect(getApiProtocol("vertex", "llama-2")).toBe("openai")
-		})
-	})
-
-	describe("Bedrock provider with Claude models", () => {
-		it("should return 'anthropic' for bedrock provider with claude models", () => {
-			expect(getApiProtocol("bedrock", "claude-3-opus")).toBe("anthropic")
-			expect(getApiProtocol("bedrock", "Claude-3-Sonnet")).toBe("anthropic")
-			expect(getApiProtocol("bedrock", "CLAUDE-instant")).toBe("anthropic")
-			expect(getApiProtocol("bedrock", "anthropic.claude-v2")).toBe("anthropic")
+		it("should return 'openai' for bedrock provider", () => {
+			expect(getApiProtocol("bedrock")).toBe("openai")
 		})
 
-		it("should return 'openai' for bedrock provider with non-claude models", () => {
-			expect(getApiProtocol("bedrock", "gpt-4")).toBe("openai")
-			expect(getApiProtocol("bedrock", "titan-text")).toBe("openai")
-			expect(getApiProtocol("bedrock", "llama-2")).toBe("openai")
-		})
-	})
-
-	describe("Other providers with Claude models", () => {
-		it("should return 'openai' for non-vertex/bedrock providers with claude models", () => {
-			expect(getApiProtocol("openrouter", "claude-3-opus")).toBe("openai")
-			expect(getApiProtocol("openai", "claude-3-sonnet")).toBe("openai")
-			expect(getApiProtocol("litellm", "claude-instant")).toBe("openai")
-			expect(getApiProtocol("ollama", "claude-model")).toBe("openai")
+		it("should return 'openai' for other providers", () => {
+			expect(getApiProtocol("openrouter")).toBe("openai")
+			expect(getApiProtocol("openai")).toBe("openai")
+			expect(getApiProtocol("litellm")).toBe("openai")
+			expect(getApiProtocol("ollama")).toBe("openai")
 		})
 	})
 
 	describe("Edge cases", () => {
 		it("should return 'openai' when provider is undefined", () => {
 			expect(getApiProtocol(undefined)).toBe("openai")
-			expect(getApiProtocol(undefined, "claude-3-opus")).toBe("openai")
-		})
-
-		it("should return 'openai' when model is undefined", () => {
-			expect(getApiProtocol("openai")).toBe("openai")
-			expect(getApiProtocol("vertex")).toBe("openai")
-			expect(getApiProtocol("bedrock")).toBe("openai")
-		})
-
-		it("should handle empty strings", () => {
-			expect(getApiProtocol("vertex", "")).toBe("openai")
-			expect(getApiProtocol("bedrock", "")).toBe("openai")
-		})
-
-		it("should be case-insensitive for claude detection", () => {
-			expect(getApiProtocol("vertex", "CLAUDE-3-OPUS")).toBe("anthropic")
-			expect(getApiProtocol("bedrock", "claude-3-opus")).toBe("anthropic")
-			expect(getApiProtocol("vertex", "ClAuDe-InStAnT")).toBe("anthropic")
 		})
 	})
 })

--- a/packages/types/src/__tests__/provider-settings.test.ts
+++ b/packages/types/src/__tests__/provider-settings.test.ts
@@ -5,33 +5,63 @@ describe("getApiProtocol", () => {
 	describe("Anthropic-style providers", () => {
 		it("should return 'anthropic' for anthropic provider", () => {
 			expect(getApiProtocol("anthropic")).toBe("anthropic")
+			expect(getApiProtocol("anthropic", "gpt-4")).toBe("anthropic")
 		})
 
 		it("should return 'anthropic' for claude-code provider", () => {
 			expect(getApiProtocol("claude-code")).toBe("anthropic")
+			expect(getApiProtocol("claude-code", "some-model")).toBe("anthropic")
+		})
+
+		it("should return 'anthropic' for bedrock provider", () => {
+			expect(getApiProtocol("bedrock")).toBe("anthropic")
+			expect(getApiProtocol("bedrock", "gpt-4")).toBe("anthropic")
+			expect(getApiProtocol("bedrock", "claude-3-opus")).toBe("anthropic")
 		})
 	})
 
-	describe("Non-Anthropic providers", () => {
-		it("should return 'openai' for vertex provider", () => {
+	describe("Vertex provider with Claude models", () => {
+		it("should return 'anthropic' for vertex provider with claude models", () => {
+			expect(getApiProtocol("vertex", "claude-3-opus")).toBe("anthropic")
+			expect(getApiProtocol("vertex", "Claude-3-Sonnet")).toBe("anthropic")
+			expect(getApiProtocol("vertex", "CLAUDE-instant")).toBe("anthropic")
+			expect(getApiProtocol("vertex", "anthropic/claude-3-haiku")).toBe("anthropic")
+		})
+
+		it("should return 'openai' for vertex provider with non-claude models", () => {
+			expect(getApiProtocol("vertex", "gpt-4")).toBe("openai")
+			expect(getApiProtocol("vertex", "gemini-pro")).toBe("openai")
+			expect(getApiProtocol("vertex", "llama-2")).toBe("openai")
+		})
+
+		it("should return 'openai' for vertex provider without model", () => {
 			expect(getApiProtocol("vertex")).toBe("openai")
 		})
+	})
 
-		it("should return 'openai' for bedrock provider", () => {
-			expect(getApiProtocol("bedrock")).toBe("openai")
-		})
-
-		it("should return 'openai' for other providers", () => {
-			expect(getApiProtocol("openrouter")).toBe("openai")
-			expect(getApiProtocol("openai")).toBe("openai")
-			expect(getApiProtocol("litellm")).toBe("openai")
-			expect(getApiProtocol("ollama")).toBe("openai")
+	describe("Other providers", () => {
+		it("should return 'openai' for non-anthropic providers regardless of model", () => {
+			expect(getApiProtocol("openrouter", "claude-3-opus")).toBe("openai")
+			expect(getApiProtocol("openai", "claude-3-sonnet")).toBe("openai")
+			expect(getApiProtocol("litellm", "claude-instant")).toBe("openai")
+			expect(getApiProtocol("ollama", "claude-model")).toBe("openai")
 		})
 	})
 
 	describe("Edge cases", () => {
 		it("should return 'openai' when provider is undefined", () => {
 			expect(getApiProtocol(undefined)).toBe("openai")
+			expect(getApiProtocol(undefined, "claude-3-opus")).toBe("openai")
+		})
+
+		it("should handle empty strings", () => {
+			expect(getApiProtocol("vertex", "")).toBe("openai")
+		})
+
+		it("should be case-insensitive for claude detection", () => {
+			expect(getApiProtocol("vertex", "CLAUDE-3-OPUS")).toBe("anthropic")
+			expect(getApiProtocol("vertex", "claude-3-opus")).toBe("anthropic")
+			expect(getApiProtocol("vertex", "ClAuDe-InStAnT")).toBe("anthropic")
 		})
 	})
 })

--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -301,7 +301,7 @@ export const getModelId = (settings: ProviderSettings): string | undefined => {
 }
 
 // Providers that use Anthropic-style API protocol
-export const ANTHROPIC_STYLE_PROVIDERS: ProviderName[] = ["anthropic", "claude-code"]
+export const ANTHROPIC_STYLE_PROVIDERS: ProviderName[] = ["anthropic", "claude-code", "bedrock"]
 
 // Helper function to determine API protocol for a provider
 export const getApiProtocol = (provider: ProviderName | undefined): "anthropic" | "openai" => {

--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -303,7 +303,18 @@ export const getModelId = (settings: ProviderSettings): string | undefined => {
 // Providers that use Anthropic-style API protocol
 export const ANTHROPIC_STYLE_PROVIDERS: ProviderName[] = ["anthropic", "claude-code", "bedrock"]
 
-// Helper function to determine API protocol for a provider
-export const getApiProtocol = (provider: ProviderName | undefined): "anthropic" | "openai" => {
-	return provider && ANTHROPIC_STYLE_PROVIDERS.includes(provider) ? "anthropic" : "openai"
+// Helper function to determine API protocol for a provider and model
+export const getApiProtocol = (provider: ProviderName | undefined, modelId?: string): "anthropic" | "openai" => {
+	// First check if the provider is an Anthropic-style provider
+	if (provider && ANTHROPIC_STYLE_PROVIDERS.includes(provider)) {
+		return "anthropic"
+	}
+
+	// For vertex provider, check if the model ID contains "claude" (case-insensitive)
+	if (provider && provider === "vertex" && modelId && modelId.toLowerCase().includes("claude")) {
+		return "anthropic"
+	}
+
+	// Default to OpenAI protocol
+	return "openai"
 }

--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -303,23 +303,7 @@ export const getModelId = (settings: ProviderSettings): string | undefined => {
 // Providers that use Anthropic-style API protocol
 export const ANTHROPIC_STYLE_PROVIDERS: ProviderName[] = ["anthropic", "claude-code"]
 
-// Helper function to determine API protocol for a provider and model
-export const getApiProtocol = (provider: ProviderName | undefined, modelId?: string): "anthropic" | "openai" => {
-	// First check if the provider is an Anthropic-style provider
-	if (provider && ANTHROPIC_STYLE_PROVIDERS.includes(provider)) {
-		return "anthropic"
-	}
-
-	// For vertex and bedrock providers, check if the model ID contains "claude" (case-insensitive)
-	if (
-		provider &&
-		(provider === "vertex" || provider === "bedrock") &&
-		modelId &&
-		modelId.toLowerCase().includes("claude")
-	) {
-		return "anthropic"
-	}
-
-	// Default to OpenAI protocol
-	return "openai"
+// Helper function to determine API protocol for a provider
+export const getApiProtocol = (provider: ProviderName | undefined): "anthropic" | "openai" => {
+	return provider && ANTHROPIC_STYLE_PROVIDERS.includes(provider) ? "anthropic" : "openai"
 }

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1214,7 +1214,7 @@ export class Task extends EventEmitter<ClineEvents> {
 
 		// Determine API protocol based on provider and model
 		const modelId = getModelId(this.apiConfiguration)
-		const apiProtocol = getApiProtocol(this.apiConfiguration.apiProvider, modelId)
+		const apiProtocol = getApiProtocol(this.apiConfiguration.apiProvider)
 
 		await this.say(
 			"api_req_started",

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1214,7 +1214,7 @@ export class Task extends EventEmitter<ClineEvents> {
 
 		// Determine API protocol based on provider and model
 		const modelId = getModelId(this.apiConfiguration)
-		const apiProtocol = getApiProtocol(this.apiConfiguration.apiProvider)
+		const apiProtocol = getApiProtocol(this.apiConfiguration.apiProvider, modelId)
 
 		await this.say(
 			"api_req_started",


### PR DESCRIPTION
This PR updates the API protocol handling to properly support bedrock provider while maintaining special handling for vertex provider with Claude models.

## Changes Made

1. **Added 'bedrock' to ANTHROPIC_STYLE_PROVIDERS**: Bedrock provider now uses Anthropic-style API protocol by default
2. **Restored Claude model checking for vertex provider**: The vertex provider continues to check if the model contains 'claude' (case-insensitive) to determine API protocol
3. **Updated tests**: Added comprehensive tests for the updated functionality
4. **Updated Task.ts**: Restored the modelId parameter passing to getApiProtocol

Fixes: #6004