### PR TITLE
feat: add llama-4-maverick model to Vertex AI provider (#5808)

### DIFF
--- a/packages/types/src/providers/vertex.ts
+++ b/packages/types/src/providers/vertex.ts
@@ -278,8 +278,8 @@ export const vertexModels = {
 		contextWindow: 131072,
 		supportsImages: false,
 		supportsPromptCache: false,
-		inputPrice: 0.2,
-		outputPrice: 0.6,
+		inputPrice: 0.35,
+		outputPrice: 1.15,
 		description: "Meta Llama 4 Maverick 17B Instruct model, 128K context.",
 	},
 } as const satisfies Record<string, ModelInfo>

--- a/packages/types/src/providers/vertex.ts
+++ b/packages/types/src/providers/vertex.ts
@@ -273,6 +273,15 @@ export const vertexModels = {
 		maxThinkingTokens: 24_576,
 		supportsReasoningBudget: true,
 	},
+	"llama-4-maverick-17b-128e-instruct-maas": {
+		maxTokens: 8192,
+		contextWindow: 131072,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.2,
+		outputPrice: 0.6,
+		description: "Meta Llama 4 Maverick 17B Instruct model, 128K context.",
+	},
 } as const satisfies Record<string, ModelInfo>
 
 export const VERTEX_REGIONS = [


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #5808 <!-- Replace with the issue number, e.g., Closes: #123 -->

### Roo Code Task Context (Optional)

<!--
If you used Roo Code to help create this PR, you can share public task links here.
This helps reviewers understand your development process and provides additional context.
Example: https://app.roocode.com/share/task-id
-->

_No Roo Code task context for this PR_

### Description

<!--
Briefly summarize the changes in this PR and how they address the linked issue.
The issue should cover the "what" and "why"; this section should focus on:
- The "how": key implementation details, design choices, or trade-offs made.
- Anything specific reviewers should pay attention to in this PR.
-->

This PR adds the missing Llama 4 Maverick model (`llama-4-maverick-17b-128e-instruct-maas`) to the Vertex AI provider configuration, as requested in issue #5808.

The implementation follows the pattern established by Daniel (collaborator) in the issue comments and uses the same model configuration as found in the Groq provider for consistency.

### Test Procedure

<!--
Detail the steps to test your changes. This helps reviewers verify your work.
- How did you test this specific implementation? (e.g., unit tests, manual testing steps)
- How can reviewers reproduce your tests or verify the fix/feature?
- Include relevant testing environment details if applicable.
-->

1. **TypeScript Compilation**: Ran `npm run check-types` in the `packages/types` directory - all checks passed
2. **Unit Tests**: Ran `npm test` in the `packages/types` directory - all 22 tests passed
3. **Linting**: The pre-commit hooks ran successfully with no linting errors

To verify the fix:
1. Configure Roo Code to use Google Vertex AI as the provider
2. Select US-EAST5 as the region
3. The model dropdown should now include `llama-4-maverick-17b-128e-instruct-maas`

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->

_No UI changes in this PR_

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

- [x] No documentation updates are required.

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->

The model configuration values (maxTokens, contextWindow, pricing) were taken from the existing Groq provider configuration for the same model to ensure consistency across providers.

### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->

_Discord username not provided_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `llama-4-maverick-17b-128e-instruct-maas` model to Vertex AI provider with specific configuration in `vertex.ts`.
> 
>   - **Behavior**:
>     - Adds `llama-4-maverick-17b-128e-instruct-maas` model to `vertexModels` in `vertex.ts`.
>     - Model has `maxTokens` of 8192, `contextWindow` of 131072, and does not support images or prompt cache.
>     - Sets `inputPrice` to 0.2 and `outputPrice` to 0.6.
>     - Includes a description: "Meta Llama 4 Maverick 17B Instruct model, 128K context."
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a7704d7f1dbd92e4883fcc92db7106d04557b530. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->