### PR TITLE
Bugfix: Cloud: be more specific about session error codes

### DIFF
--- a/packages/cloud/src/auth/WebAuthService.ts
+++ b/packages/cloud/src/auth/WebAuthService.ts
@@ -494,7 +494,7 @@ export class WebAuthService extends EventEmitter<AuthServiceEvents> implements A
 			signal: AbortSignal.timeout(10000),
 		})
 
-		if (response.status >= 400 && response.status < 500) {
+		if (response.status === 401 || response.status === 404) {
 			throw new InvalidClientTokenError()
 		} else if (!response.ok) {
 			throw new Error(`HTTP ${response.status}: ${response.statusText}`)


### PR DESCRIPTION
`InvalidClientTokenError` indicates an unrecoverable state for the session, so we need to be more exact about triggering it. A recent Clerk outage resulted in a lot of 429 responses which should really cause inactive-session, not a full clear to logged-out.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `WebAuthService.ts` to throw `InvalidClientTokenError` only for HTTP status 401 and 404, preventing unnecessary session logout on 429 responses.
> 
>   - **Behavior**:
>     - In `WebAuthService.ts`, modify condition to throw `InvalidClientTokenError` only for HTTP status 401 and 404.
>     - Prevents unnecessary session logout on 429 responses, aligning with intended session management behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1c9e2b69360d62a649f4d0dd7c4f340dedf0655a. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->