### PR TITLE
feat: add efficiency warning for single SEARCH/REPLACE blocks in apply_diff

### DIFF
--- a/src/core/tools/applyDiffTool.ts
+++ b/src/core/tools/applyDiffTool.ts
@@ -188,10 +188,17 @@ export async function applyDiffToolLegacy(
 			// Get the formatted response message
 			const message = await cline.diffViewProvider.pushToolWriteResult(cline, cline.cwd, !fileExists)
 
+			// Check for single SEARCH/REPLACE block warning
+			const searchBlocks = (diffContent.match(/<<<<<<< SEARCH/g) || []).length
+			const singleBlockWarning =
+				searchBlocks === 1
+					? "Making multiple related changes in a single apply_diff is more efficient for the LLM. If other changes are needed in this file, please include them as additional SEARCH/REPLACE blocks.\n\n"
+					: ""
+
 			if (partFailHint) {
 				pushToolResult(partFailHint + message)
 			} else {
-				pushToolResult(message)
+				pushToolResult(singleBlockWarning + message)
 			}
 
 			await cline.diffViewProvider.reset()

--- a/src/core/tools/applyDiffTool.ts
+++ b/src/core/tools/applyDiffTool.ts
@@ -190,15 +190,15 @@ export async function applyDiffToolLegacy(
 
 			// Check for single SEARCH/REPLACE block warning
 			const searchBlocks = (diffContent.match(/<<<<<<< SEARCH/g) || []).length
-			const singleBlockWarning =
+			const singleBlockNotice =
 				searchBlocks === 1
-					? "Making multiple related changes in a single apply_diff is more efficient for the LLM. If other changes are needed in this file, please include them as additional SEARCH/REPLACE blocks.\n\n"
+					? "\n<notice>Making multiple related changes in a single apply_diff is more efficient. If other changes are needed in this file, please include them as additional SEARCH/REPLACE blocks.</notice>"
 					: ""
 
 			if (partFailHint) {
-				pushToolResult(partFailHint + message)
+				pushToolResult(partFailHint + message + singleBlockNotice)
 			} else {
-				pushToolResult(singleBlockWarning + message)
+				pushToolResult(message + singleBlockNotice)
 			}
 
 			await cline.diffViewProvider.reset()

--- a/src/core/tools/multiApplyDiffTool.ts
+++ b/src/core/tools/multiApplyDiffTool.ts
@@ -596,8 +596,22 @@ ${errorDetails ? `\nTechnical details:\n${errorDetails}\n` : ""}
 			await cline.say("diff_error", allDiffErrors.join("\n"))
 		}
 
+		// Check for single SEARCH/REPLACE block warning
+		let totalSearchBlocks = 0
+		for (const operation of operations) {
+			for (const diffItem of operation.diff) {
+				const searchBlocks = (diffItem.content.match(/<<<<<<< SEARCH/g) || []).length
+				totalSearchBlocks += searchBlocks
+			}
+		}
+
+		const singleBlockNotice =
+			totalSearchBlocks === 1
+				? "\n<notice>Making multiple related changes in a single apply_diff is more efficient. If other changes are needed in this file, please include them as additional SEARCH/REPLACE blocks.</notice>"
+				: ""
+
 		// Push the final result combining all operation results
-		pushToolResult(results.join("\n\n"))
+		pushToolResult(results.join("\n\n") + singleBlockNotice)
 		return
 	} catch (error) {
 		await handleError("applying diff", error)


### PR DESCRIPTION
## Context

The apply_diff tool was missing efficiency guidance similar to what the read_file tool provides. When models use only one SEARCH/REPLACE block, they miss opportunities to batch multiple related changes in a single operation, leading to inefficient API usage patterns.

## Implementation

Added single block detection by counting `<<<<<<< SEARCH` occurrences in the diff content. When only one block is detected, the tool now includes a warning message encouraging models to batch multiple related changes for better efficiency.

The warning message is prepended to successful results: "Making multiple related changes in a single apply_diff is more efficient for the LLM. If other changes are needed in this file, please include them as additional SEARCH/REPLACE blocks."

This follows the same pattern established by the read_file tool, which warns models when only one file is read to encourage reading multiple files simultaneously for better LLM context efficiency.

## How to Test

1. Use apply_diff with only one SEARCH/REPLACE block
2. Verify that the warning message appears in the tool result
3. Use apply_diff with multiple SEARCH/REPLACE blocks  
4. Verify that no warning appears for multi-block usage

Discord: KJ7LNW
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a warning in `applyDiffToolLegacy` for single `SEARCH/REPLACE` blocks to encourage batching changes for efficiency.
> 
>   - **Behavior**:
>     - Adds a warning in `applyDiffToolLegacy` in `applyDiffTool.ts` for single `SEARCH/REPLACE` blocks.
>     - Encourages batching multiple related changes for efficiency.
>     - Warning message: "Making multiple related changes in a single apply_diff is more efficient for the LLM. If other changes are needed in this file, please include them as additional SEARCH/REPLACE blocks."
>   - **Implementation**:
>     - Counts `SEARCH` block occurrences in `diffContent` to detect single block usage.
>     - Prepends warning to results if only one block is detected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for dd7a9d352ef09e6883405769f65c5f34d512302c. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->