### PR TITLE
fix: allow auto-approve checkbox to be toggled at any time

### DIFF
--- a/webview-ui/src/components/chat/AutoApproveMenu.tsx
+++ b/webview-ui/src/components/chat/AutoApproveMenu.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react"
+import { memo, useCallback, useMemo, useState } from "react"
 import { Trans } from "react-i18next"
 import { VSCodeCheckbox, VSCodeLink, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 
@@ -129,11 +129,6 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 		setIsExpanded((prev) => !prev)
 	}, [])
 
-	// Disable main checkbox while menu is open or no options selected
-	const isCheckboxDisabled = useMemo(() => {
-		return !hasEnabledOptions || isExpanded
-	}, [hasEnabledOptions, isExpanded])
-
 	const enabledActionsList = Object.entries(toggles)
 		.filter(([_key, value]) => !!value)
 		.map(([key]) => t(autoApproveSettingsConfig[key as AutoApproveSetting].labelKey))
@@ -178,19 +173,15 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 						content={!hasEnabledOptions ? t("chat:autoApprove.selectOptionsFirst") : undefined}>
 						<VSCodeCheckbox
 							checked={effectiveAutoApprovalEnabled}
-							disabled={isCheckboxDisabled}
 							aria-label={
 								hasEnabledOptions
 									? t("chat:autoApprove.toggleAriaLabel")
 									: t("chat:autoApprove.disabledAriaLabel")
 							}
 							onChange={() => {
-								if (hasEnabledOptions) {
-									const newValue = !(autoApprovalEnabled ?? false)
-									setAutoApprovalEnabled(newValue)
-									vscode.postMessage({ type: "autoApprovalEnabled", bool: newValue })
-								}
-								// If no options enabled, do nothing
+								const newValue = !(autoApprovalEnabled ?? false)
+								setAutoApprovalEnabled(newValue)
+								vscode.postMessage({ type: "autoApprovalEnabled", bool: newValue })
 							}}
 						/>
 					</StandardTooltip>
@@ -290,4 +281,4 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 	)
 }
 
-export default AutoApproveMenu
+export default memo(AutoApproveMenu)

--- a/webview-ui/src/components/chat/__tests__/AutoApproveMenu.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/AutoApproveMenu.spec.tsx
@@ -115,7 +115,7 @@ describe("AutoApproveMenu", () => {
 			expect(screen.getByText("Read-only operations")).toBeInTheDocument()
 		})
 
-		it("should not allow toggling master checkbox when no options are selected", () => {
+		it("should allow toggling master checkbox even when no options are selected", () => {
 			;(useExtensionState as ReturnType<typeof vi.fn>).mockReturnValue({
 				...defaultExtensionState,
 				autoApprovalEnabled: false,
@@ -128,8 +128,11 @@ describe("AutoApproveMenu", () => {
 			const masterCheckbox = screen.getByRole("checkbox")
 			fireEvent.click(masterCheckbox)
 
-			// Should not send any message since no options are selected
-			expect(mockPostMessage).not.toHaveBeenCalled()
+			// Should send message to toggle auto-approval even when no options are selected
+			expect(mockPostMessage).toHaveBeenCalledWith({
+				type: "autoApprovalEnabled",
+				bool: true,
+			})
 		})
 
 		it("should toggle master checkbox when options are selected", () => {


### PR DESCRIPTION
## Context

The auto-approve checkbox was becoming unresponsive and flickering during model responses, preventing users from disabling auto-approval when they realize the model is about to perform unintended actions. This created a critical safety issue where users could not stop unwanted auto-approvals in time-sensitive situations.

## Implementation

This fix removes the disabled state from the main auto-approve checkbox and ensures it can always be toggled:

1. **Remove checkbox disabled logic**: Eliminated `isCheckboxDisabled` state that prevented toggling when no options were selected or menu was open
2. **Simplify toggle behavior**: The checkbox now always responds to user clicks and sends toggle messages
3. **Add memoization**: Wrapped component in `React.memo` to reduce unnecessary re-renders that cause flickering
4. **Update test coverage**: Modified tests to reflect the new always-enabled behavior

## How to Test

1. Open Roo Code and start a conversation
2. Enable auto-approval for any operations  
3. During a model response, try to disable the auto-approve checkbox
4. Verify the checkbox responds immediately and toggles state
5. Test with no options selected - checkbox should still be toggleable
6. Verify no flickering occurs during normal usage

## Safety Impact

This fix ensures users can always disable auto-approval for safety, especially during time-critical situations when the model is actively responding and about to execute unwanted actions.

Fixes #6060