### PR TITLE
fix: improve subshell detection to avoid false positives with markdown content

### DIFF
--- a/webview-ui/src/utils/command-validation.ts
+++ b/webview-ui/src/utils/command-validation.ts
@@ -307,7 +307,7 @@ function containsBlockableSubshell(command: string, deniedCommands?: string[]): 
 		if (!hasMarkdownIndicators) {
 			// Check if backticks are likely command substitution
 			// Look for patterns like: cmd `subcmd` or var=`cmd`
-			hasBacktickSubstitution = /[^\\]`[^`\n]+`/.test(command)
+			hasBacktickSubstitution = /(?:^|[^\\])`[^`\n]+`/.test(command)
 		}
 	}
 


### PR DESCRIPTION
Fixes issue where commands containing markdown with backticks were incorrectly denied.

Added intelligent subshell detection that:
- Exempts text output commands (echo, printf, etc)
- Detects markdown patterns to avoid false positives
- Only flags actual command substitution syntax

Solves #6028
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improved subshell detection in `command-validation.ts` to exempt markdown content from blocking, while still blocking actual command substitutions if denylist is present.
> 
>   - **Behavior**:
>     - Improved subshell detection in `command-validation.ts` to avoid false positives with markdown content.
>     - Commands like `echo`, `printf`, and `cat` with markdown are exempt from blocking.
>     - Actual command substitutions are still blocked if denylist is present.
>   - **Functions**:
>     - Added `containsBlockableSubshell()` to intelligently detect subshells.
>     - Updated `isAutoApprovedCommand()`, `isAutoDeniedCommand()`, and `getCommandDecision()` to use new detection logic.
>   - **Tests**:
>     - Added tests in `command-validation.spec.ts` to verify markdown handling and subshell detection.
>     - Tests cover cases with markdown content, actual command substitutions, and edge cases with backticks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for aebec8b75017144d9fb50a12a2143eb652ae65d4. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->