### PR TITLE
Smarter auto-deny

### DIFF
--- a/webview-ui/src/utils/command-validation.ts
+++ b/webview-ui/src/utils/command-validation.ts
@@ -376,56 +376,6 @@ export function isAutoDeniedSingleCommand(
 }
 
 /**
- * Check if a command string should be auto-approved.
- * Only blocks subshell attempts if there's a denylist configured.
- * Requires all sub-commands to be auto-approved.
- */
-export function isAutoApprovedCommand(command: string, allowedCommands: string[], deniedCommands?: string[]): boolean {
-	if (!command?.trim()) return true
-
-	// Only block subshell execution attempts if there's a denylist configured
-	if ((command.includes("$(") || command.includes("`")) && deniedCommands?.length) {
-		return false
-	}
-
-	// Parse into sub-commands (split by &&, ||, ;, |)
-	const subCommands = parseCommand(command)
-
-	// Ensure every sub-command is auto-approved
-	return subCommands.every((cmd) => {
-		// Remove simple PowerShell-like redirections (e.g. 2>&1) before checking
-		const cmdWithoutRedirection = cmd.replace(/\d*>&\d*/, "").trim()
-
-		return isAutoApprovedSingleCommand(cmdWithoutRedirection, allowedCommands, deniedCommands)
-	})
-}
-
-/**
- * Check if a command string should be auto-denied.
- * Only blocks subshell attempts if there's a denylist configured.
- * Auto-denies if any sub-command is auto-denied.
- */
-export function isAutoDeniedCommand(command: string, allowedCommands: string[], deniedCommands?: string[]): boolean {
-	if (!command?.trim()) return false
-
-	// Only block subshell execution attempts if there's a denylist configured
-	if ((command.includes("$(") || command.includes("`")) && deniedCommands?.length) {
-		return true
-	}
-
-	// Parse into sub-commands (split by &&, ||, ;, |)
-	const subCommands = parseCommand(command)
-
-	// Auto-deny if any sub-command is auto-denied
-	return subCommands.some((cmd) => {
-		// Remove simple PowerShell-like redirections (e.g. 2>&1) before checking
-		const cmdWithoutRedirection = cmd.replace(/\d*>&\d*/, "").trim()
-
-		return isAutoDeniedSingleCommand(cmdWithoutRedirection, allowedCommands, deniedCommands)
-	})
-}
-
-/**
  * Command approval decision types
  */
 export type CommandDecision = "auto_approve" | "auto_deny" | "ask_user"

--- a/webview-ui/src/utils/command-validation.ts
+++ b/webview-ui/src/utils/command-validation.ts
@@ -432,42 +432,6 @@ export function getCommandDecision(
 
 	// Check if subshells contain denied prefixes
 	if ((command.includes("$(") || command.includes("`")) && deniedCommands?.length) {
-		// Extract subshell content and check if it contains denied prefixes
-		let match: RegExpExecArray | null
-
-		// Check $() subshells
-		const dollarRegex = /\$\((.*?)\)/g
-		while ((match = dollarRegex.exec(command)) !== null) {
-			const subshellContent = match[1].trim()
-			// Check if the subshell content matches any denied prefix
-			if (
-				deniedCommands.some((denied) => {
-					const lowerDenied = denied.toLowerCase()
-					const lowerContent = subshellContent.toLowerCase()
-					return lowerContent.startsWith(lowerDenied)
-				})
-			) {
-				return "auto_deny"
-			}
-		}
-
-		// Check `` subshells
-		const backtickRegex = /`(.*?)`/g
-		while ((match = backtickRegex.exec(command)) !== null) {
-			const subshellContent = match[1].trim()
-			// Check if the subshell content matches any denied prefix
-			if (
-				deniedCommands.some((denied) => {
-					const lowerDenied = denied.toLowerCase()
-					const lowerContent = subshellContent.toLowerCase()
-					return lowerContent.startsWith(lowerDenied)
-				})
-			) {
-				return "auto_deny"
-			}
-		}
-
-		// Also check if the main command contains denied prefixes
 		const mainCommandLower = command.toLowerCase()
 		if (deniedCommands.some((denied) => mainCommandLower.includes(denied.toLowerCase()))) {
 			return "auto_deny"


### PR DESCRIPTION
This changes the logic to only auto-deny commands with subshells if the command contains a denied prefix.

I also removed some code that was no longer used.

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refines command validation by removing legacy functions and enhancing subshell handling, focusing on prefix matching and decision logic.
> 
>   - **Behavior**:
>     - Refines `getCommandDecision()` in `command-validation.ts` to auto-deny subshells only if they contain denied prefixes.
>     - Removes `isAutoApprovedCommand()` and `isAutoDeniedCommand()` functions, consolidating logic into `getCommandDecision()`.
>   - **Tests**:
>     - Removes tests for `isAutoApprovedCommand()` and `isAutoDeniedCommand()` in `command-validation.spec.ts`.
>     - Updates tests to reflect new subshell handling logic, ensuring subshells are only denied if they contain denied prefixes.
>     - Adds tests for complex subshell scenarios and longest prefix match logic.
>   - **Misc**:
>     - Minor updates to comments and descriptions for clarity in `command-validation.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7a01a39c42d132cba7e5b11f17e814fd97b72b36. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->