### PR TITLE
Add type for allowing org members to view all tasks

### DIFF
--- a/packages/types/npm/package.json
+++ b/packages/types/npm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@roo-code/types",
-	"version": "1.37.0",
+	"version": "1.39.0",
 	"description": "TypeScript type definitions for Roo Code.",
 	"publishConfig": {
 		"access": "public",

--- a/packages/types/npm/package.json
+++ b/packages/types/npm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@roo-code/types",
-	"version": "1.37.0",
+	"version": "1.38.0",
 	"description": "TypeScript type definitions for Roo Code.",
 	"publishConfig": {
 		"access": "public",

--- a/packages/types/npm/package.json
+++ b/packages/types/npm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@roo-code/types",
-	"version": "1.36.0",
+	"version": "1.37.0",
 	"description": "TypeScript type definitions for Roo Code.",
 	"publishConfig": {
 		"access": "public",

--- a/packages/types/src/cloud.ts
+++ b/packages/types/src/cloud.ts
@@ -96,6 +96,7 @@ export const organizationCloudSettingsSchema = z.object({
 	recordTaskMessages: z.boolean().optional(),
 	enableTaskSharing: z.boolean().optional(),
 	taskShareExpirationDays: z.number().int().positive().optional(),
+	allowMembersViewAllTasks: z.boolean().optional(),
 })
 
 export type OrganizationCloudSettings = z.infer<typeof organizationCloudSettingsSchema>

--- a/packages/types/src/cloud.ts
+++ b/packages/types/src/cloud.ts
@@ -129,6 +129,7 @@ export const ORGANIZATION_DEFAULT: OrganizationSettings = {
 		recordTaskMessages: true,
 		enableTaskSharing: true,
 		taskShareExpirationDays: 30,
+		allowMembersViewAllTasks: true,
 	},
 	defaultSettings: {},
 	allowList: ORGANIZATION_ALLOW_ALL,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `allowMembersViewAllTasks` to `organizationCloudSettingsSchema` in `cloud.ts` and update version in `package.json`.
> 
>   - **Behavior**:
>     - Adds `allowMembersViewAllTasks` boolean to `organizationCloudSettingsSchema` in `cloud.ts` to allow org members to view all tasks.
>     - Updates `ORGANIZATION_DEFAULT` in `cloud.ts` to set `allowMembersViewAllTasks` to `true` by default.
>   - **Versioning**:
>     - Updates version in `package.json` from `1.37.0` to `1.39.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5e5b783b340f883d78d9e3e6aaf8ff78106f28d3. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->