### PR TITLE
fix: prevent duplicate command patterns by trimming full command

### DIFF
--- a/webview-ui/src/components/chat/CommandPatternSelector.tsx
+++ b/webview-ui/src/components/chat/CommandPatternSelector.tsx
@@ -33,11 +33,13 @@ export const CommandPatternSelector: React.FC<CommandPatternSelectorProps> = ({
 
 	// Create a combined list with full command first, then patterns
 	const allPatterns = useMemo(() => {
-		const fullCommandPattern: CommandPattern = { pattern: command }
+		// Trim the command to ensure consistency with extracted patterns
+		const trimmedCommand = command.trim()
+		const fullCommandPattern: CommandPattern = { pattern: trimmedCommand }
 
 		// Create a set to track unique patterns we've already seen
 		const seenPatterns = new Set<string>()
-		seenPatterns.add(command) // Add the full command first
+		seenPatterns.add(trimmedCommand) // Add the trimmed full command first
 
 		// Filter out any patterns that are duplicates or are the same as the full command
 		const uniquePatterns = patterns.filter((p) => {


### PR DESCRIPTION
## Description

This PR fixes a bug introduced in PR #5798 where command patterns could be duplicated in the CommandPatternSelector UI when commands have trailing whitespace.

## The Issue

When a command like `"npm install "` (with trailing space) is processed:
1. The full command `"npm install "` is added as the first pattern in CommandPatternSelector
2. `extractPatternsFromCommand` extracts patterns and trims them, returning `"npm install"` (without trailing space)
3. Both `"npm install "` and `"npm install"` end up in the list, appearing as duplicates to the user

## The Fix

The fix is simple: trim the full command before adding it to the pattern list to ensure consistency with the extracted patterns which are already trimmed.

## Changes Made

- Modified `CommandPatternSelector.tsx` to trim the command before creating the full command pattern
- This ensures the full command pattern matches the trimmed patterns from `extractPatternsFromCommand`

## Testing

- The existing tests continue to pass
- Manual testing confirms no duplicate patterns appear in the UI
- The fix maintains backward compatibility

## Related Issues

- Fixes bug introduced in PR #5798
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes duplicate command patterns in `CommandPatternSelector.tsx` by trimming commands before adding to the pattern list.
> 
>   - **Behavior**:
>     - Fixes duplicate command patterns in `CommandPatternSelector.tsx` by trimming the command before adding it to the pattern list.
>     - Ensures the full command pattern matches trimmed patterns from `extractPatternsFromCommand`.
>   - **Testing**:
>     - Existing tests pass.
>     - Manual testing confirms no duplicate patterns in UI.
>     - Maintains backward compatibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d4ea48eee7132a1d784ac854ee84f29c5579338f. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->