### PR TITLE
fix(chat): Cancel auto-approve timer when editing follow-up suggestion

### DIFF
--- a/.changeset/kind-horses-sniff.md
+++ b/.changeset/kind-horses-sniff.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Cancel auto-approve timer when editing follow-up suggestion

--- a/webview-ui/src/components/chat/FollowUpSuggest.tsx
+++ b/webview-ui/src/components/chat/FollowUpSuggest.tsx
@@ -134,6 +134,9 @@ export const FollowUpSuggest = ({
 								className="absolute top-0 right-0 opacity-0 group-hover:opacity-100 transition-opacity"
 								onClick={(e) => {
 									e.stopPropagation()
+									// Cancel the auto-approve timer when edit button is clicked
+									setSuggestionSelected(true)
+									onCancelAutoApproval?.()
 									// Simulate shift-click by directly calling the handler with shiftKey=true.
 									onSuggestionClick?.(suggestion, { ...e, shiftKey: true })
 								}}>


### PR DESCRIPTION
So users don't have to race against the clock to type their message

Fixes: https://github.com/Kilo-Org/kilocode/issues/1262

![2025-07-25 15 14 15](https://github.com/user-attachments/assets/aa7fb2da-40f2-43d6-bb93-6deaef1e22fc)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Cancels auto-approve timer when editing follow-up suggestion in `FollowUpSuggest.tsx` to prevent user race conditions.
> 
>   - **Behavior**:
>     - Cancels auto-approve timer when editing follow-up suggestion in `FollowUpSuggest.tsx` by calling `onCancelAutoApproval` when edit button is clicked.
>     - Sets `suggestionSelected` to `true` to prevent auto-approval when editing.
>   - **Misc**:
>     - Adds changeset file `kind-horses-sniff.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c5666316f10f35eb39a91d981b99f273550a9cc8. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->