### PR TITLE
fix: restore working settings link in command permissions tooltip

### DIFF
--- a/webview-ui/src/components/chat/CommandPatternSelector.tsx
+++ b/webview-ui/src/components/chat/CommandPatternSelector.tsx
@@ -31,6 +31,10 @@ export const CommandPatternSelector: React.FC<CommandPatternSelectorProps> = ({
 	const [isExpanded, setIsExpanded] = useState(false)
 	const [editingStates, setEditingStates] = useState<Record<string, { isEditing: boolean; value: string }>>({})
 
+	const handleOpenSettings = () => {
+		window.postMessage({ type: "action", action: "settingsButtonClicked", values: { section: "autoApprove" } })
+	}
+
 	// Create a combined list with full command first, then patterns
 	const allPatterns = useMemo(() => {
 		// Trim the command to ensure consistency with extracted patterns
@@ -90,7 +94,11 @@ export const CommandPatternSelector: React.FC<CommandPatternSelectorProps> = ({
 									components={{
 										settingsLink: (
 											<VSCodeLink
-												href="command:workbench.action.openSettings?%5B%22roo-code%22%5D"
+												href="#"
+												onClick={(e) => {
+													e.preventDefault()
+													handleOpenSettings()
+												}}
 												className="text-vscode-textLink-foreground hover:text-vscode-textLink-activeForeground"
 											/>
 										),


### PR DESCRIPTION
## Summary
Fixes the broken "View Settings" link in the command permissions tooltip that was introduced in PR #5798.

## Problem
- The settings link was using a command URI (`command:workbench.action.openSettings`) which doesn't work in VSCode's webview context
- Clicking the link did nothing

## Solution
- Replace command URI with onClick handler that posts message to extension
- Directs to autoApprove section where command permissions are configured

## Context
Bug was introduced in commit 77bc9e6f when updating translation keys.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes broken "View Settings" link in `CommandPatternSelector.tsx` by replacing command URI with an onClick handler to open 'autoApprove' settings.
> 
>   - **Behavior**:
>     - Fixes broken "View Settings" link in command permissions tooltip in `CommandPatternSelector.tsx`.
>     - Replaces `command:workbench.action.openSettings` URI with `onClick` handler.
>     - `onClick` posts message to extension to open 'autoApprove' settings section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 36a966a57c652ac855421c3936d2a5e65f6ae70d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->