### PR TITLE
fix(diagnostics): differentiate linter warnings from fatal errors

### DIFF
--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -1,0 +1,38 @@
+export const DiagnosticSeverity = {
+	Error: 0,
+	Warning: 1,
+	Information: 2,
+	Hint: 3,
+}
+
+export class Range {
+	start: { line: number; character: number }
+	end: { line: number; character: number }
+
+	constructor(
+		public startLine: number,
+		public startChar: number,
+		public endLine: number,
+		public endChar: number,
+	) {
+		this.start = { line: startLine, character: startChar }
+		this.end = { line: endLine, character: endChar }
+	}
+}
+
+export class Diagnostic {
+	constructor(
+		public range: Range,
+		public message: string,
+		public severity: number,
+		public source?: string,
+	) {}
+}
+
+export const Uri = {
+	file: (path: string) => ({
+		path,
+		fsPath: path,
+		toString: () => path,
+	}),
+}

--- a/src/integrations/diagnostics/__tests__/index.test.ts
+++ b/src/integrations/diagnostics/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode"
 import { getNewDiagnostics } from ".."
 
 vi.mock("vscode", async () => {
-	const originalModule = await vi.importActual("vscode")
+	const originalModule = await vi.importActual("vscode");
 	const mock = {
 		...originalModule,
 		DiagnosticSeverity: {
@@ -12,26 +12,16 @@ vi.mock("vscode", async () => {
 			Hint: 3,
 		},
 		Range: class {
-			start: { line: number; character: number }
-			end: { line: number; character: number }
+			start: { line: number; character: number };
+			end: { line: number; character: number };
 
-			constructor(
-				public startLine: number,
-				public startChar: number,
-				public endLine: number,
-				public endChar: number,
-			) {
-				this.start = { line: startLine, character: startChar }
-				this.end = { line: endLine, character: endChar }
+			constructor(public startLine: number, public startChar: number, public endLine: number, public endChar: number) {
+				this.start = { line: startLine, character: startChar };
+				this.end = { line: endLine, character: endChar };
 			}
 		},
 		Diagnostic: class {
-			constructor(
-				public range: any,
-				public message: string,
-				public severity: number,
-				public source?: string,
-			) {}
+			constructor(public range: any, public message: string, public severity: number, public source?: string) {}
 		},
 		Uri: {
 			file: (path: string) => ({
@@ -40,112 +30,69 @@ vi.mock("vscode", async () => {
 				toString: () => path,
 			}),
 		},
-	}
-	return mock
-})
+	};
+	return mock;
+});
 
 describe("getNewDiagnostics", () => {
 	it("should return an empty list if there are no new diagnostics", () => {
 		const oldDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [
-			[
-				vscode.Uri.file("/path/to/file1.ts"),
-				[
-					new vscode.Diagnostic(
-						new vscode.Range(0, 0, 0, 10),
-						"Old error in file1",
-						vscode.DiagnosticSeverity.Error,
-					),
-				],
-			],
-		]
+			[vscode.Uri.file("/path/to/file1.ts"), [
+				new vscode.Diagnostic(new vscode.Range(0, 0, 0, 10), "Old error in file1", vscode.DiagnosticSeverity.Error)
+			]],
+		];
 		const newDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [
-			[
-				vscode.Uri.file("/path/to/file1.ts"),
-				[
-					new vscode.Diagnostic(
-						new vscode.Range(0, 0, 0, 10),
-						"Old error in file1",
-						vscode.DiagnosticSeverity.Error,
-					),
-				],
-			],
-		]
+			[vscode.Uri.file("/path/to/file1.ts"), [
+				new vscode.Diagnostic(new vscode.Range(0, 0, 0, 10), "Old error in file1", vscode.DiagnosticSeverity.Error)
+			]],
+		];
 
-		const { problems, warnings } = getNewDiagnostics(oldDiagnostics, newDiagnostics)
-		expect(problems).toEqual([])
-		expect(warnings).toEqual([])
-	})
+		const { problems, warnings } = getNewDiagnostics(oldDiagnostics, newDiagnostics);
+		expect(problems).toEqual([]);
+		expect(warnings).toEqual([]);
+	});
 
 	it("should identify new fatal errors", () => {
-		const oldDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = []
+		const oldDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [];
 		const newDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [
-			[
-				vscode.Uri.file("/path/to/file1.ts"),
-				[
-					new vscode.Diagnostic(
-						new vscode.Range(0, 0, 0, 10),
-						"New fatal error",
-						vscode.DiagnosticSeverity.Error,
-						"typescript",
-					),
-				],
-			],
-		]
+			[vscode.Uri.file("/path/to/file1.ts"), [
+				new vscode.Diagnostic(new vscode.Range(0, 0, 0, 10), "New fatal error", vscode.DiagnosticSeverity.Error, "typescript")
+			]],
+		];
 
-		const { problems, warnings } = getNewDiagnostics(oldDiagnostics, newDiagnostics)
-		expect(problems).toHaveLength(1)
-		expect(warnings).toHaveLength(0)
-		expect(problems[0][1][0].message).toBe("New fatal error")
-	})
+		const { problems, warnings } = getNewDiagnostics(oldDiagnostics, newDiagnostics);
+		expect(problems).toHaveLength(1);
+		expect(warnings).toHaveLength(0);
+		expect(problems[0][1][0].message).toBe("New fatal error");
+	});
 
 	it("should identify new linter warnings", () => {
-		const oldDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = []
+		const oldDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [];
 		const newDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [
-			[
-				vscode.Uri.file("/path/to/file1.ts"),
-				[
-					new vscode.Diagnostic(
-						new vscode.Range(0, 0, 0, 10),
-						"New linter warning",
-						vscode.DiagnosticSeverity.Error,
-						"pylance",
-					),
-				],
-			],
-		]
+			[vscode.Uri.file("/path/to/file1.ts"), [
+				new vscode.Diagnostic(new vscode.Range(0, 0, 0, 10), "New linter warning", vscode.DiagnosticSeverity.Error, "pylance")
+			]],
+		];
 
-		const { problems, warnings } = getNewDiagnostics(oldDiagnostics, newDiagnostics)
-		expect(problems).toHaveLength(0)
-		expect(warnings).toHaveLength(1)
-		expect(warnings[0][1][0].message).toBe("New linter warning")
-	})
+		const { problems, warnings } = getNewDiagnostics(oldDiagnostics, newDiagnostics);
+		expect(problems).toHaveLength(0);
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0][1][0].message).toBe("New linter warning");
+	});
 
 	it("should correctly categorize a mix of new diagnostics", () => {
-		const oldDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = []
+		const oldDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [];
 		const newDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [
-			[
-				vscode.Uri.file("/path/to/file1.ts"),
-				[
-					new vscode.Diagnostic(
-						new vscode.Range(0, 0, 0, 10),
-						"New fatal error",
-						vscode.DiagnosticSeverity.Error,
-						"typescript",
-					),
-					new vscode.Diagnostic(
-						new vscode.Range(1, 0, 1, 10),
-						"New linter warning",
-						vscode.DiagnosticSeverity.Error,
-						"eslint",
-					),
-				],
-			],
-		]
+			[vscode.Uri.file("/path/to/file1.ts"), [
+				new vscode.Diagnostic(new vscode.Range(0, 0, 0, 10), "New fatal error", vscode.DiagnosticSeverity.Error, "typescript"),
+				new vscode.Diagnostic(new vscode.Range(1, 0, 1, 10), "New linter warning", vscode.DiagnosticSeverity.Error, "eslint")
+			]],
+		];
 
-		const { problems, warnings } = getNewDiagnostics(oldDiagnostics, newDiagnostics)
-		expect(problems).toHaveLength(1)
-		expect(warnings).toHaveLength(1)
-		expect(problems[0][1][0].message).toBe("New fatal error")
-		expect(warnings[0][1][0].message).toBe("New linter warning")
-	})
-})
+		const { problems, warnings } = getNewDiagnostics(oldDiagnostics, newDiagnostics);
+		expect(problems).toHaveLength(1);
+		expect(warnings).toHaveLength(1);
+		expect(problems[0][1][0].message).toBe("New fatal error");
+		expect(warnings[0][1][0].message).toBe("New linter warning");
+	});
+});

--- a/src/integrations/diagnostics/__tests__/index.test.ts
+++ b/src/integrations/diagnostics/__tests__/index.test.ts
@@ -1,0 +1,151 @@
+import * as vscode from "vscode"
+import { getNewDiagnostics } from ".."
+
+vi.mock("vscode", async () => {
+	const originalModule = await vi.importActual("vscode")
+	const mock = {
+		...originalModule,
+		DiagnosticSeverity: {
+			Error: 0,
+			Warning: 1,
+			Information: 2,
+			Hint: 3,
+		},
+		Range: class {
+			start: { line: number; character: number }
+			end: { line: number; character: number }
+
+			constructor(
+				public startLine: number,
+				public startChar: number,
+				public endLine: number,
+				public endChar: number,
+			) {
+				this.start = { line: startLine, character: startChar }
+				this.end = { line: endLine, character: endChar }
+			}
+		},
+		Diagnostic: class {
+			constructor(
+				public range: any,
+				public message: string,
+				public severity: number,
+				public source?: string,
+			) {}
+		},
+		Uri: {
+			file: (path: string) => ({
+				path,
+				fsPath: path,
+				toString: () => path,
+			}),
+		},
+	}
+	return mock
+})
+
+describe("getNewDiagnostics", () => {
+	it("should return an empty list if there are no new diagnostics", () => {
+		const oldDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [
+			[
+				vscode.Uri.file("/path/to/file1.ts"),
+				[
+					new vscode.Diagnostic(
+						new vscode.Range(0, 0, 0, 10),
+						"Old error in file1",
+						vscode.DiagnosticSeverity.Error,
+					),
+				],
+			],
+		]
+		const newDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [
+			[
+				vscode.Uri.file("/path/to/file1.ts"),
+				[
+					new vscode.Diagnostic(
+						new vscode.Range(0, 0, 0, 10),
+						"Old error in file1",
+						vscode.DiagnosticSeverity.Error,
+					),
+				],
+			],
+		]
+
+		const { problems, warnings } = getNewDiagnostics(oldDiagnostics, newDiagnostics)
+		expect(problems).toEqual([])
+		expect(warnings).toEqual([])
+	})
+
+	it("should identify new fatal errors", () => {
+		const oldDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = []
+		const newDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [
+			[
+				vscode.Uri.file("/path/to/file1.ts"),
+				[
+					new vscode.Diagnostic(
+						new vscode.Range(0, 0, 0, 10),
+						"New fatal error",
+						vscode.DiagnosticSeverity.Error,
+						"typescript",
+					),
+				],
+			],
+		]
+
+		const { problems, warnings } = getNewDiagnostics(oldDiagnostics, newDiagnostics)
+		expect(problems).toHaveLength(1)
+		expect(warnings).toHaveLength(0)
+		expect(problems[0][1][0].message).toBe("New fatal error")
+	})
+
+	it("should identify new linter warnings", () => {
+		const oldDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = []
+		const newDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [
+			[
+				vscode.Uri.file("/path/to/file1.ts"),
+				[
+					new vscode.Diagnostic(
+						new vscode.Range(0, 0, 0, 10),
+						"New linter warning",
+						vscode.DiagnosticSeverity.Error,
+						"pylance",
+					),
+				],
+			],
+		]
+
+		const { problems, warnings } = getNewDiagnostics(oldDiagnostics, newDiagnostics)
+		expect(problems).toHaveLength(0)
+		expect(warnings).toHaveLength(1)
+		expect(warnings[0][1][0].message).toBe("New linter warning")
+	})
+
+	it("should correctly categorize a mix of new diagnostics", () => {
+		const oldDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = []
+		const newDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [
+			[
+				vscode.Uri.file("/path/to/file1.ts"),
+				[
+					new vscode.Diagnostic(
+						new vscode.Range(0, 0, 0, 10),
+						"New fatal error",
+						vscode.DiagnosticSeverity.Error,
+						"typescript",
+					),
+					new vscode.Diagnostic(
+						new vscode.Range(1, 0, 1, 10),
+						"New linter warning",
+						vscode.DiagnosticSeverity.Error,
+						"eslint",
+					),
+				],
+			],
+		]
+
+		const { problems, warnings } = getNewDiagnostics(oldDiagnostics, newDiagnostics)
+		expect(problems).toHaveLength(1)
+		expect(warnings).toHaveLength(1)
+		expect(problems[0][1][0].message).toBe("New fatal error")
+		expect(warnings[0][1][0].message).toBe("New linter warning")
+	})
+})

--- a/src/integrations/diagnostics/__tests__/index.test.ts
+++ b/src/integrations/diagnostics/__tests__/index.test.ts
@@ -21,7 +21,16 @@ vi.mock("vscode", async () => {
 			}
 		},
 		Diagnostic: class {
-			constructor(public range: any, public message: string, public severity: number, public source?: string) {}
+			range: any;
+			message: string;
+			severity: number;
+			source?: string;
+
+			constructor(range: any, message: string, severity: number) {
+				this.range = range;
+				this.message = message;
+				this.severity = severity;
+			}
 		},
 		Uri: {
 			file: (path: string) => ({
@@ -56,7 +65,7 @@ describe("getNewDiagnostics", () => {
 		const oldDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [];
 		const newDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [
 			[vscode.Uri.file("/path/to/file1.ts"), [
-				new vscode.Diagnostic(new vscode.Range(0, 0, 0, 10), "New fatal error", vscode.DiagnosticSeverity.Error, "typescript")
+				Object.assign(new vscode.Diagnostic(new vscode.Range(0, 0, 0, 10), "New fatal error", vscode.DiagnosticSeverity.Error), { source: "typescript" })
 			]],
 		];
 
@@ -70,7 +79,7 @@ describe("getNewDiagnostics", () => {
 		const oldDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [];
 		const newDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [
 			[vscode.Uri.file("/path/to/file1.ts"), [
-				new vscode.Diagnostic(new vscode.Range(0, 0, 0, 10), "New linter warning", vscode.DiagnosticSeverity.Error, "pylance")
+				Object.assign(new vscode.Diagnostic(new vscode.Range(0, 0, 0, 10), "New linter warning", vscode.DiagnosticSeverity.Error), { source: "pylance" })
 			]],
 		];
 
@@ -84,8 +93,8 @@ describe("getNewDiagnostics", () => {
 		const oldDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [];
 		const newDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [
 			[vscode.Uri.file("/path/to/file1.ts"), [
-				new vscode.Diagnostic(new vscode.Range(0, 0, 0, 10), "New fatal error", vscode.DiagnosticSeverity.Error, "typescript"),
-				new vscode.Diagnostic(new vscode.Range(1, 0, 1, 10), "New linter warning", vscode.DiagnosticSeverity.Error, "eslint")
+				Object.assign(new vscode.Diagnostic(new vscode.Range(0, 0, 0, 10), "New fatal error", vscode.DiagnosticSeverity.Error), { source: "typescript" }),
+				Object.assign(new vscode.Diagnostic(new vscode.Range(1, 0, 1, 10), "New linter warning", vscode.DiagnosticSeverity.Error), { source: "eslint" })
 			]],
 		];
 


### PR DESCRIPTION
This change addresses an issue where linter errors were treated as fatal, causing unnecessary retries and inefficient file writes. The getNewDiagnostics function has been updated to categorize diagnostics into problems (fatal errors) and warnings (linter errors). The DiffViewProvider has been updated to consume this new structure and present the information to the AI in a more structured way. Fixes #4622