### PR TITLE
test: update list-files test for fixed hidden files bug

### DIFF
--- a/apps/vscode-e2e/src/suite/tools/list-files.test.ts
+++ b/apps/vscode-e2e/src/suite/tools/list-files.test.ts
@@ -242,8 +242,8 @@ This directory contains various files and subdirectories for testing the list_fi
 			// Verify the tool returned the expected files (non-recursive)
 			assert.ok(listResults, "Tool execution results should be captured")
 
-			// Check that expected root-level files are present (excluding hidden files due to current bug)
-			const expectedFiles = ["root-file-1.txt", "root-file-2.js", "config.yaml", "README.md"]
+			// Check that expected root-level files are present (including hidden files now that bug is fixed)
+			const expectedFiles = ["root-file-1.txt", "root-file-2.js", "config.yaml", "README.md", ".hidden-file"]
 			const expectedDirs = ["nested/"]
 
 			const results = listResults as string
@@ -255,13 +255,9 @@ This directory contains various files and subdirectories for testing the list_fi
 				assert.ok(results.includes(dir), `Tool results should include directory ${dir}`)
 			}
 
-			// BUG: Hidden files are currently excluded in non-recursive mode
-			// This should be fixed - hidden files should be included when using --hidden flag
-			console.log("BUG DETECTED: Hidden files are excluded in non-recursive mode")
-			assert.ok(
-				!results.includes(".hidden-file"),
-				"KNOWN BUG: Hidden files are currently excluded in non-recursive mode",
-			)
+			// Verify hidden files are now included (bug has been fixed)
+			console.log("Verifying hidden files are included in non-recursive mode")
+			assert.ok(results.includes(".hidden-file"), "Hidden files should be included in non-recursive mode")
 
 			// Verify nested files are NOT included (non-recursive)
 			const nestedFiles = ["nested-file-1.md", "nested-file-2.json", "deep-nested-file.ts"]


### PR DESCRIPTION
Updates the e2e test to reflect that hidden files are now correctly included in non-recursive directory listings.

## Changes
- Added `.hidden-file` to expected files list
- Changed assertion to verify hidden files are included
- Updated comments to reflect the fixed behavior