### PR TITLE
docs: clarify apply_diff tool descriptions to emphasize surgical edits

### DIFF
--- a/src/core/diff/strategies/multi-file-search-replace.ts
+++ b/src/core/diff/strategies/multi-file-search-replace.ts
@@ -93,7 +93,7 @@ export class MultiFileSearchReplaceDiffStrategy implements DiffStrategy {
 	getToolDescription(args: { cwd: string; toolOptions?: { [key: string]: string } }): string {
 		return `## apply_diff
 
-Description: Request to apply targeted modifications to one or more files by searching for specific sections of content and replacing them. This tool supports both single-file and multi-file operations, allowing you to make changes across multiple files in a single request.
+Description: Request to apply PRECISE, TARGETED modifications to one or more files by searching for specific sections of content and replacing them. This tool is for SURGICAL EDITS ONLY - specific changes to existing code. This tool supports both single-file and multi-file operations, allowing you to make changes across multiple files in a single request.
 
 **IMPORTANT: You MUST use multiple files in a single operation whenever possible to maximize efficiency and minimize back-and-forth.**
 

--- a/src/core/diff/strategies/multi-search-replace.ts
+++ b/src/core/diff/strategies/multi-search-replace.ts
@@ -92,7 +92,7 @@ export class MultiSearchReplaceDiffStrategy implements DiffStrategy {
 
 	getToolDescription(args: { cwd: string; toolOptions?: { [key: string]: string } }): string {
 		return `## apply_diff
-Description: Request to apply targeted modifications to an existing file by searching for specific sections of content and replacing them. This tool is ideal for precise, surgical edits when you know the exact content to change. It helps maintain proper indentation and formatting.
+Description: Request to apply PRECISE, TARGETED modifications to an existing file by searching for specific sections of content and replacing them. This tool is for SURGICAL EDITS ONLY - specific changes to existing code.
 You can perform multiple distinct search and replace operations within a single \`apply_diff\` call by providing multiple SEARCH/REPLACE blocks in the \`diff\` parameter. This is the preferred way to make several targeted changes efficiently.
 The SEARCH section must exactly match existing content including whitespace and indentation.
 If you're not confident in the exact content to search for, use the read_file tool first to get the exact content.

--- a/src/core/prompts/sections/rules.ts
+++ b/src/core/prompts/sections/rules.ts
@@ -8,7 +8,7 @@ function getEditingInstructions(diffStrategy?: DiffStrategy): string {
 	// Collect available editing tools
 	if (diffStrategy) {
 		availableTools.push(
-			"apply_diff (for replacing lines in existing files)",
+			"apply_diff (for surgical edits - targeted changes to specific lines or functions)",
 			"write_to_file (for creating new files or complete file rewrites)",
 		)
 	} else {


### PR DESCRIPTION
## Description

This PR clarifies the descriptions of the `apply_diff` tool across multiple strategy files to better communicate its intended use case.

## Changes Made

- **src/core/diff/strategies/multi-file-search-replace.ts**: Updated the tool description to emphasize "PRECISE, TARGETED modifications" and clarify that this tool is for "SURGICAL EDITS ONLY - specific changes to existing code"
  
- **src/core/diff/strategies/multi-search-replace.ts**: Applied similar clarification to maintain consistency across different diff strategies
  
- **src/core/prompts/sections/rules.ts**: Updated the brief description of apply_diff from "for replacing lines in existing files" to "for surgical edits - targeted changes to specific lines or functions"

## Motivation

These changes help users better understand that `apply_diff` is designed for precise, targeted modifications to existing code rather than broad rewrites. This distinction is important for:
- Guiding users to choose the right tool for their task
- Setting proper expectations about the tool's capabilities
- Encouraging best practices for code modifications

## Testing

These are documentation-only changes that don't affect functionality. All existing tests continue to pass.

## Checklist

- [x] Documentation changes only
- [x] No breaking changes
- [x] Consistent terminology across all modified files
- [x] Clear and concise descriptions