### PR TITLE
feat: Add export/import buttons to mode selector popover (#6320)

### DIFF
--- a/webview-ui/src/components/chat/ModeSelector.tsx
+++ b/webview-ui/src/components/chat/ModeSelector.tsx
@@ -165,6 +165,9 @@ export const ModeSelector = ({
 	React.useEffect(() => {
 		const handler = (event: MessageEvent) => {
 			const message = event.data
+			// Only handle messages that are specifically for mode export/import
+			if (!message || typeof message !== "object") return
+
 			if (message.type === "exportModeResult") {
 				setIsExporting(null)
 				if (!message.success) {

--- a/webview-ui/src/components/chat/ModeSelector.tsx
+++ b/webview-ui/src/components/chat/ModeSelector.tsx
@@ -311,7 +311,7 @@ export const ModeSelector = ({
 													size="icon"
 													className={cn(
 														"h-6 w-6 p-0.5",
-														isExporting === mode.slug ||
+														isExporting !== mode.slug &&
 															"opacity-0 group-hover:opacity-100",
 														"transition-opacity",
 													)}

--- a/webview-ui/src/components/chat/ModeSelector.tsx
+++ b/webview-ui/src/components/chat/ModeSelector.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { ChevronUp, Check, X, Upload } from "lucide-react"
+import { ChevronUp, Check, X, Upload, Download } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useRooPortal } from "@/components/ui/hooks/useRooPortal"
 import { Popover, PopoverContent, PopoverTrigger, StandardTooltip, Button } from "@/components/ui"
@@ -368,14 +368,15 @@ export const ModeSelector = ({
 										setOpen(false)
 									}}
 								/>
-								{/* Import button - using IconButton for consistency */}
-								<IconButton
-									iconClass="codicon-cloud-download"
+								{/* Import button - using Button with Download icon to match ModesView */}
+								<Button
+									variant="ghost"
+									size="icon"
 									title={t("prompts:modes.importMode")}
 									onClick={() => setShowImportDialog(true)}
-									disabled={isImporting}
-									isLoading={isImporting}
-								/>
+									disabled={isImporting}>
+									<Download className="h-3.5 w-3.5" />
+								</Button>
 							</div>
 
 							{/* Info icon and title on the right - only show info icon when search bar is visible */}

--- a/webview-ui/src/components/chat/ModeSelector.tsx
+++ b/webview-ui/src/components/chat/ModeSelector.tsx
@@ -52,6 +52,7 @@ export const ModeSelector = ({
 	const [showImportDialog, setShowImportDialog] = React.useState(false)
 	const [exportError, setExportError] = React.useState<string | null>(null)
 	const [importError, setImportError] = React.useState<string | null>(null)
+	const [selectedImportLevel, setSelectedImportLevel] = React.useState<"project" | "global">("project")
 
 	const trackModeSelectorOpened = React.useCallback(() => {
 		// Track telemetry every time the mode selector is opened
@@ -201,15 +202,13 @@ export const ModeSelector = ({
 
 	// Handle import mode
 	const handleImportMode = React.useCallback(() => {
-		const selectedLevel = (document.querySelector('input[name="importLevel"]:checked') as HTMLInputElement)
-			?.value as "global" | "project"
 		setIsImporting(true)
 		setImportError(null)
 		vscode.postMessage({
 			type: "importMode",
-			source: selectedLevel || "project",
+			source: selectedImportLevel,
 		})
-	}, [])
+	}, [selectedImportLevel])
 
 	// Determine if search should be shown
 	const showSearch = !disableSearch && modes.length > SEARCH_THRESHOLD
@@ -411,7 +410,8 @@ export const ModeSelector = ({
 									value="project"
 									id="import-level-project"
 									className="mt-1"
-									defaultChecked
+									checked={selectedImportLevel === "project"}
+									onChange={() => setSelectedImportLevel("project")}
 								/>
 								<div>
 									<div className="font-medium">{t("prompts:importMode.project.label")}</div>
@@ -427,6 +427,8 @@ export const ModeSelector = ({
 									value="global"
 									id="import-level-global"
 									className="mt-1"
+									checked={selectedImportLevel === "global"}
+									onChange={() => setSelectedImportLevel("global")}
 								/>
 								<div>
 									<div className="font-medium">{t("prompts:importMode.global.label")}</div>
@@ -444,6 +446,7 @@ export const ModeSelector = ({
 								onClick={() => {
 									setShowImportDialog(false)
 									setImportError(null)
+									setSelectedImportLevel("project") // Reset to default
 								}}>
 								{t("prompts:createModeDialog.buttons.cancel")}
 							</Button>

--- a/webview-ui/src/components/chat/ModeSelector.tsx
+++ b/webview-ui/src/components/chat/ModeSelector.tsx
@@ -1,8 +1,8 @@
 import React from "react"
-import { ChevronUp, Check, X } from "lucide-react"
+import { ChevronUp, Check, X, Upload, Download } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useRooPortal } from "@/components/ui/hooks/useRooPortal"
-import { Popover, PopoverContent, PopoverTrigger, StandardTooltip } from "@/components/ui"
+import { Popover, PopoverContent, PopoverTrigger, StandardTooltip, Button } from "@/components/ui"
 import { IconButton } from "./IconButton"
 import { vscode } from "@/utils/vscode"
 import { useExtensionState } from "@/context/ExtensionStateContext"
@@ -45,6 +45,11 @@ export const ModeSelector = ({
 	const portalContainer = useRooPortal("roo-portal")
 	const { hasOpenedModeSelector, setHasOpenedModeSelector } = useExtensionState()
 	const { t } = useAppTranslation()
+
+	// Export/Import state
+	const [isExporting, setIsExporting] = React.useState<string | null>(null)
+	const [isImporting, setIsImporting] = React.useState(false)
+	const [showImportDialog, setShowImportDialog] = React.useState(false)
 
 	const trackModeSelectorOpened = React.useCallback(() => {
 		// Track telemetry every time the mode selector is opened
@@ -153,6 +158,47 @@ export const ModeSelector = ({
 		}
 	}, [open])
 
+	// Handle export/import message responses
+	React.useEffect(() => {
+		const handler = (event: MessageEvent) => {
+			const message = event.data
+			if (message.type === "exportModeResult") {
+				setIsExporting(null)
+				if (!message.success) {
+					console.error("Failed to export mode:", message.error)
+				}
+			} else if (message.type === "importModeResult") {
+				setIsImporting(false)
+				setShowImportDialog(false)
+				if (!message.success && message.error !== "cancelled") {
+					console.error("Failed to import mode:", message.error)
+				}
+			}
+		}
+		window.addEventListener("message", handler)
+		return () => window.removeEventListener("message", handler)
+	}, [])
+
+	// Handle export mode
+	const handleExportMode = React.useCallback((modeSlug: string) => {
+		setIsExporting(modeSlug)
+		vscode.postMessage({
+			type: "exportMode",
+			slug: modeSlug,
+		})
+	}, [])
+
+	// Handle import mode
+	const handleImportMode = React.useCallback(() => {
+		const selectedLevel = (document.querySelector('input[name="importLevel"]:checked') as HTMLInputElement)
+			?.value as "global" | "project"
+		setIsImporting(true)
+		vscode.postMessage({
+			type: "importMode",
+			source: selectedLevel || "project",
+		})
+	}, [])
+
 	// Determine if search should be shown
 	const showSearch = !disableSearch && modes.length > SEARCH_THRESHOLD
 
@@ -181,123 +227,214 @@ export const ModeSelector = ({
 	)
 
 	return (
-		<Popover open={open} onOpenChange={onOpenChange} data-testid="mode-selector-root">
-			{title ? <StandardTooltip content={title}>{trigger}</StandardTooltip> : trigger}
+		<>
+			<Popover open={open} onOpenChange={onOpenChange} data-testid="mode-selector-root">
+				{title ? <StandardTooltip content={title}>{trigger}</StandardTooltip> : trigger}
 
-			<PopoverContent
-				align="start"
-				sideOffset={4}
-				container={portalContainer}
-				className="p-0 overflow-hidden min-w-80 max-w-9/10">
-				<div className="flex flex-col w-full">
-					{/* Show search bar only when there are more than SEARCH_THRESHOLD items, otherwise show info blurb */}
-					{showSearch ? (
-						<div className="relative p-2 border-b border-vscode-dropdown-border">
-							<input
-								aria-label="Search modes"
-								ref={searchInputRef}
-								value={searchValue}
-								onChange={(e) => setSearchValue(e.target.value)}
-								placeholder={t("chat:modeSelector.searchPlaceholder")}
-								className="w-full h-8 px-2 py-1 text-xs bg-vscode-input-background text-vscode-input-foreground border border-vscode-input-border rounded focus:outline-0"
-								data-testid="mode-search-input"
-							/>
-							{searchValue.length > 0 && (
-								<div className="absolute right-4 top-0 bottom-0 flex items-center justify-center">
-									<X
-										className="text-vscode-input-foreground opacity-50 hover:opacity-100 size-4 p-0.5 cursor-pointer"
-										onClick={onClearSearch}
-									/>
+				<PopoverContent
+					align="start"
+					sideOffset={4}
+					container={portalContainer}
+					className="p-0 overflow-hidden min-w-80 max-w-9/10">
+					<div className="flex flex-col w-full">
+						{/* Show search bar only when there are more than SEARCH_THRESHOLD items, otherwise show info blurb */}
+						{showSearch ? (
+							<div className="relative p-2 border-b border-vscode-dropdown-border">
+								<input
+									aria-label="Search modes"
+									ref={searchInputRef}
+									value={searchValue}
+									onChange={(e) => setSearchValue(e.target.value)}
+									placeholder={t("chat:modeSelector.searchPlaceholder")}
+									className="w-full h-8 px-2 py-1 text-xs bg-vscode-input-background text-vscode-input-foreground border border-vscode-input-border rounded focus:outline-0"
+									data-testid="mode-search-input"
+								/>
+								{searchValue.length > 0 && (
+									<div className="absolute right-4 top-0 bottom-0 flex items-center justify-center">
+										<X
+											className="text-vscode-input-foreground opacity-50 hover:opacity-100 size-4 p-0.5 cursor-pointer"
+											onClick={onClearSearch}
+										/>
+									</div>
+								)}
+							</div>
+						) : (
+							<div className="p-3 border-b border-vscode-dropdown-border">
+								<p className="m-0 text-xs text-vscode-descriptionForeground">{instructionText}</p>
+							</div>
+						)}
+
+						{/* Mode List */}
+						<div className="max-h-[300px] overflow-y-auto">
+							{filteredModes.length === 0 && searchValue ? (
+								<div className="py-2 px-3 text-sm text-vscode-foreground/70">
+									{t("chat:modeSelector.noResults")}
+								</div>
+							) : (
+								<div className="py-1">
+									{filteredModes.map((mode) => (
+										<div
+											key={mode.slug}
+											className={cn(
+												"px-3 py-1.5 text-sm flex items-center group",
+												"hover:bg-vscode-list-hoverBackground",
+												mode.slug === value
+													? "bg-vscode-list-activeSelectionBackground text-vscode-list-activeSelectionForeground"
+													: "",
+											)}
+											data-testid="mode-selector-item">
+											<div
+												className="flex-1 min-w-0 cursor-pointer"
+												onClick={() => handleSelect(mode.slug)}>
+												<div className="font-bold truncate">{mode.name}</div>
+												{mode.description && (
+													<div className="text-xs text-vscode-descriptionForeground truncate">
+														{mode.description}
+													</div>
+												)}
+											</div>
+											<div className="flex items-center gap-1 ml-2">
+												{/* Export button - show on hover or when exporting */}
+												<Button
+													variant="ghost"
+													size="icon"
+													className={cn(
+														"h-6 w-6 p-0.5",
+														isExporting === mode.slug ||
+															"opacity-0 group-hover:opacity-100",
+														"transition-opacity",
+													)}
+													onClick={(e) => {
+														e.stopPropagation()
+														handleExportMode(mode.slug)
+													}}
+													disabled={isExporting === mode.slug}
+													title={t("prompts:exportMode.title")}>
+													<Upload className="h-3.5 w-3.5" />
+												</Button>
+												{mode.slug === value && <Check className="size-4 p-0.5" />}
+											</div>
+										</div>
+									))}
 								</div>
 							)}
 						</div>
-					) : (
-						<div className="p-3 border-b border-vscode-dropdown-border">
-							<p className="m-0 text-xs text-vscode-descriptionForeground">{instructionText}</p>
-						</div>
-					)}
 
-					{/* Mode List */}
-					<div className="max-h-[300px] overflow-y-auto">
-						{filteredModes.length === 0 && searchValue ? (
-							<div className="py-2 px-3 text-sm text-vscode-foreground/70">
-								{t("chat:modeSelector.noResults")}
-							</div>
-						) : (
-							<div className="py-1">
-								{filteredModes.map((mode) => (
-									<div
-										key={mode.slug}
-										onClick={() => handleSelect(mode.slug)}
+						{/* Bottom bar with buttons on left and title on right */}
+						<div className="flex flex-row items-center justify-between px-2 py-2 border-t border-vscode-dropdown-border">
+							<div className="flex flex-row gap-1">
+								<IconButton
+									iconClass="codicon-extensions"
+									title={t("chat:modeSelector.marketplace")}
+									onClick={() => {
+										window.postMessage(
+											{
+												type: "action",
+												action: "marketplaceButtonClicked",
+												values: { marketplaceTab: "mode" },
+											},
+											"*",
+										)
+										setOpen(false)
+									}}
+								/>
+								<IconButton
+									iconClass="codicon-settings-gear"
+									title={t("chat:modeSelector.settings")}
+									onClick={() => {
+										vscode.postMessage({
+											type: "switchTab",
+											tab: "modes",
+										})
+										setOpen(false)
+									}}
+								/>
+								{/* Import button - matching IconButton dimensions */}
+								<StandardTooltip content={t("prompts:modes.importMode")}>
+									<button
+										onClick={() => setShowImportDialog(true)}
+										disabled={isImporting}
 										className={cn(
-											"px-3 py-1.5 text-sm cursor-pointer flex items-center",
-											"hover:bg-vscode-list-hoverBackground",
-											mode.slug === value
-												? "bg-vscode-list-activeSelectionBackground text-vscode-list-activeSelectionForeground"
-												: "",
+											"relative inline-flex items-center justify-center",
+											"bg-transparent border-none p-1.5",
+											"rounded-md min-w-[28px] min-h-[28px]",
+											"text-vscode-foreground opacity-85",
+											"transition-all duration-150",
+											"hover:opacity-100 hover:bg-[rgba(255,255,255,0.03)] hover:border-[rgba(255,255,255,0.15)]",
+											"focus:outline-none focus-visible:ring-1 focus-visible:ring-vscode-focusBorder",
+											"active:bg-[rgba(255,255,255,0.1)]",
+											!isImporting && "cursor-pointer",
+											isImporting &&
+												"opacity-40 cursor-not-allowed grayscale-[30%] hover:bg-transparent hover:border-[rgba(255,255,255,0.08)] active:bg-transparent",
 										)}
-										data-testid="mode-selector-item">
-										<div className="flex-1 min-w-0">
-											<div className="font-bold truncate">{mode.name}</div>
-											{mode.description && (
-												<div className="text-xs text-vscode-descriptionForeground truncate">
-													{mode.description}
-												</div>
-											)}
-										</div>
-										{mode.slug === value && <Check className="ml-auto size-4 p-0.5" />}
-									</div>
-								))}
-							</div>
-						)}
-					</div>
-
-					{/* Bottom bar with buttons on left and title on right */}
-					<div className="flex flex-row items-center justify-between px-2 py-2 border-t border-vscode-dropdown-border">
-						<div className="flex flex-row gap-1">
-							<IconButton
-								iconClass="codicon-extensions"
-								title={t("chat:modeSelector.marketplace")}
-								onClick={() => {
-									window.postMessage(
-										{
-											type: "action",
-											action: "marketplaceButtonClicked",
-											values: { marketplaceTab: "mode" },
-										},
-										"*",
-									)
-									setOpen(false)
-								}}
-							/>
-							<IconButton
-								iconClass="codicon-settings-gear"
-								title={t("chat:modeSelector.settings")}
-								onClick={() => {
-									vscode.postMessage({
-										type: "switchTab",
-										tab: "modes",
-									})
-									setOpen(false)
-								}}
-							/>
-						</div>
-
-						{/* Info icon and title on the right - only show info icon when search bar is visible */}
-						<div className="flex items-center gap-1 pr-1">
-							{showSearch && (
-								<StandardTooltip content={instructionText}>
-									<span className="codicon codicon-info text-xs text-vscode-descriptionForeground opacity-70 hover:opacity-100 cursor-help" />
+										style={{ fontSize: 16.5 }}>
+										<Download className="h-4 w-4" />
+									</button>
 								</StandardTooltip>
-							)}
-							<h4 className="m-0 font-medium text-sm text-vscode-descriptionForeground">
-								{t("chat:modeSelector.title")}
-							</h4>
+							</div>
+
+							{/* Info icon and title on the right - only show info icon when search bar is visible */}
+							<div className="flex items-center gap-1 pr-1">
+								{showSearch && (
+									<StandardTooltip content={instructionText}>
+										<span className="codicon codicon-info text-xs text-vscode-descriptionForeground opacity-70 hover:opacity-100 cursor-help" />
+									</StandardTooltip>
+								)}
+								<h4 className="m-0 font-medium text-sm text-vscode-descriptionForeground">
+									{t("chat:modeSelector.title")}
+								</h4>
+							</div>
+						</div>
+					</div>
+				</PopoverContent>
+			</Popover>
+
+			{/* Import Mode Dialog */}
+			{showImportDialog && (
+				<div className="fixed inset-0 flex items-center justify-center bg-black/50 z-[1000]">
+					<div className="bg-vscode-editor-background border border-vscode-editor-lineHighlightBorder rounded-lg shadow-lg p-6 max-w-md w-full">
+						<h3 className="text-lg font-semibold mb-4">{t("prompts:modes.importMode")}</h3>
+						<p className="text-sm text-vscode-descriptionForeground mb-4">
+							{t("prompts:importMode.selectLevel")}
+						</p>
+						<div className="space-y-3 mb-6">
+							<label className="flex items-start gap-2 cursor-pointer">
+								<input
+									type="radio"
+									name="importLevel"
+									value="project"
+									className="mt-1"
+									defaultChecked
+								/>
+								<div>
+									<div className="font-medium">{t("prompts:importMode.project.label")}</div>
+									<div className="text-xs text-vscode-descriptionForeground">
+										{t("prompts:importMode.project.description")}
+									</div>
+								</div>
+							</label>
+							<label className="flex items-start gap-2 cursor-pointer">
+								<input type="radio" name="importLevel" value="global" className="mt-1" />
+								<div>
+									<div className="font-medium">{t("prompts:importMode.global.label")}</div>
+									<div className="text-xs text-vscode-descriptionForeground">
+										{t("prompts:importMode.global.description")}
+									</div>
+								</div>
+							</label>
+						</div>
+						<div className="flex justify-end gap-2">
+							<Button variant="secondary" onClick={() => setShowImportDialog(false)}>
+								{t("prompts:createModeDialog.buttons.cancel")}
+							</Button>
+							<Button variant="default" onClick={handleImportMode} disabled={isImporting}>
+								{isImporting ? t("prompts:importMode.importing") : t("prompts:importMode.import")}
+							</Button>
 						</div>
 					</div>
 				</div>
-			</PopoverContent>
-		</Popover>
+			)}
+		</>
 	)
 }
 

--- a/webview-ui/src/components/chat/__tests__/ModeSelector.export-import.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/ModeSelector.export-import.spec.tsx
@@ -213,8 +213,8 @@ describe("ModeSelector Export/Import", () => {
 			// Import button should be visible
 			const importButton = screen.getByRole("button", { name: "Import Mode" })
 			expect(importButton).toBeInTheDocument()
-			// Check for the icon inside the button
-			const icon = importButton.querySelector(".codicon-cloud-download")
+			// Check for the Download icon (SVG) inside the button
+			const icon = importButton.querySelector("svg")
 			expect(icon).toBeInTheDocument()
 		})
 
@@ -424,16 +424,17 @@ describe("ModeSelector Export/Import", () => {
 			expect(exportButton).toHaveAttribute("aria-label", "Export Mode")
 		})
 
-		test("import button uses IconButton component", async () => {
+		test("import button has proper structure", async () => {
 			render(<ModeSelector value={"code" as Mode} onChange={vi.fn()} modeShortcutText="Ctrl+M" />)
 
 			// Open the popover
 			fireEvent.click(screen.getByTestId("mode-selector-trigger"))
 
-			// Import button should have proper IconButton structure
+			// Import button should have proper structure
 			const importButton = screen.getByRole("button", { name: "Import Mode" })
-			expect(importButton).toHaveAttribute("aria-label", "Import Mode")
-			expect(importButton.querySelector(".codicon-cloud-download")).toBeInTheDocument()
+			expect(importButton).toHaveAttribute("title", "Import Mode")
+			// Check for the Download icon (SVG) inside the button
+			expect(importButton.querySelector("svg")).toBeInTheDocument()
 		})
 	})
 })

--- a/webview-ui/src/components/chat/__tests__/ModeSelector.export-import.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/ModeSelector.export-import.spec.tsx
@@ -1,0 +1,439 @@
+import React from "react"
+import { render, screen, fireEvent, waitFor } from "@/utils/test-utils"
+import { describe, test, expect, vi, beforeEach } from "vitest"
+import ModeSelector from "../ModeSelector"
+import { Mode } from "@roo/modes"
+import { ModeConfig } from "@roo-code/types"
+
+// Mock the dependencies
+const mockPostMessage = vi.fn()
+vi.mock("@/utils/vscode", () => ({
+	vscode: {
+		postMessage: (message: any) => mockPostMessage(message),
+	},
+}))
+
+vi.mock("@/context/ExtensionStateContext", () => ({
+	useExtensionState: () => ({
+		hasOpenedModeSelector: false,
+		setHasOpenedModeSelector: vi.fn(),
+	}),
+}))
+
+vi.mock("@/i18n/TranslationContext", () => ({
+	useAppTranslation: () => ({
+		t: (key: string, _options?: any) => {
+			if (key === "prompts:exportMode.title") return "Export Mode"
+			if (key === "prompts:modes.importMode") return "Import Mode"
+			if (key === "prompts:importMode.selectLevel") return "Select import level"
+			if (key === "prompts:importMode.project.label") return "Project"
+			if (key === "prompts:importMode.project.description") return "Import to project"
+			if (key === "prompts:importMode.global.label") return "Global"
+			if (key === "prompts:importMode.global.description") return "Import globally"
+			if (key === "prompts:createModeDialog.buttons.cancel") return "Cancel"
+			if (key === "prompts:importMode.import") return "Import"
+			if (key === "prompts:importMode.importing") return "Importing..."
+			if (key === "prompts:exportMode.error") return "Export failed"
+			if (key === "prompts:importMode.error") return "Import failed"
+			if (key === "chat:modeSelector.marketplace") return "Marketplace"
+			if (key === "chat:modeSelector.settings") return "Settings"
+			if (key === "chat:modeSelector.searchPlaceholder") return "Search modes"
+			if (key === "chat:modeSelector.noResults") return "No results"
+			if (key === "chat:modeSelector.description") return "Select a mode"
+			if (key === "chat:modeSelector.title") return "Modes"
+			return key
+		},
+	}),
+}))
+
+vi.mock("@/components/ui/hooks/useRooPortal", () => ({
+	useRooPortal: () => document.body,
+}))
+
+vi.mock("@/utils/TelemetryClient", () => ({
+	telemetryClient: {
+		capture: vi.fn(),
+	},
+}))
+
+// Create a variable to control what getAllModes returns
+let mockModes: ModeConfig[] = []
+
+vi.mock("@roo/modes", async () => {
+	const actual = await vi.importActual<typeof import("@roo/modes")>("@roo/modes")
+	return {
+		...actual,
+		getAllModes: () => mockModes,
+	}
+})
+
+describe("ModeSelector Export/Import", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		// Set up mock modes
+		mockModes = [
+			{
+				slug: "code",
+				name: "Code",
+				description: "Write code",
+				roleDefinition: "You are a coding assistant",
+				groups: ["read", "edit"],
+			},
+			{
+				slug: "architect",
+				name: "Architect",
+				description: "Design systems",
+				roleDefinition: "You are a system architect",
+				groups: ["read"],
+			},
+		]
+	})
+
+	describe("Export Functionality", () => {
+		test("export button is hidden by default and shows on hover", async () => {
+			render(<ModeSelector value={"code" as Mode} onChange={vi.fn()} modeShortcutText="Ctrl+M" />)
+
+			// Open the popover
+			fireEvent.click(screen.getByTestId("mode-selector-trigger"))
+
+			// Find the mode item
+			const modeItems = screen.getAllByTestId("mode-selector-item")
+			const codeItem = modeItems[0]
+
+			// Export button should have opacity-0 class initially
+			const exportButton = codeItem.querySelector('button[aria-label="Export Mode"]')
+			expect(exportButton).toHaveClass("opacity-0")
+
+			// Hover over the mode item
+			fireEvent.mouseEnter(codeItem)
+
+			// Export button should now have opacity-100 class
+			expect(exportButton).toHaveClass("group-hover:opacity-100")
+		})
+
+		test("clicking export button sends exportMode message", async () => {
+			render(<ModeSelector value={"code" as Mode} onChange={vi.fn()} modeShortcutText="Ctrl+M" />)
+
+			// Open the popover
+			fireEvent.click(screen.getByTestId("mode-selector-trigger"))
+
+			// Find and click the export button for the first mode
+			const modeItems = screen.getAllByTestId("mode-selector-item")
+			const exportButton = modeItems[0].querySelector('button[aria-label="Export Mode"]') as HTMLButtonElement
+			fireEvent.click(exportButton)
+
+			// Verify the message was sent
+			expect(mockPostMessage).toHaveBeenCalledWith({
+				type: "exportMode",
+				slug: "code",
+			})
+		})
+
+		test("export button shows loading state while exporting", async () => {
+			render(<ModeSelector value={"code" as Mode} onChange={vi.fn()} modeShortcutText="Ctrl+M" />)
+
+			// Open the popover
+			fireEvent.click(screen.getByTestId("mode-selector-trigger"))
+
+			// Find and click the export button
+			const modeItems = screen.getAllByTestId("mode-selector-item")
+			const exportButton = modeItems[0].querySelector('button[aria-label="Export Mode"]') as HTMLButtonElement
+			fireEvent.click(exportButton)
+
+			// Button should be disabled
+			expect(exportButton).toBeDisabled()
+		})
+
+		test("handles export success", async () => {
+			render(<ModeSelector value={"code" as Mode} onChange={vi.fn()} modeShortcutText="Ctrl+M" />)
+
+			// Open the popover
+			fireEvent.click(screen.getByTestId("mode-selector-trigger"))
+
+			// Click export
+			const modeItems = screen.getAllByTestId("mode-selector-item")
+			const exportButton = modeItems[0].querySelector('button[aria-label="Export Mode"]') as HTMLButtonElement
+			fireEvent.click(exportButton)
+
+			// Simulate success response
+			window.dispatchEvent(
+				new MessageEvent("message", {
+					data: {
+						type: "exportModeResult",
+						success: true,
+					},
+				}),
+			)
+
+			// Button should be enabled again
+			await waitFor(() => {
+				expect(exportButton).not.toBeDisabled()
+			})
+		})
+
+		test("handles export error", async () => {
+			render(<ModeSelector value={"code" as Mode} onChange={vi.fn()} modeShortcutText="Ctrl+M" />)
+
+			// Open the popover
+			fireEvent.click(screen.getByTestId("mode-selector-trigger"))
+
+			// Click export
+			const modeItems = screen.getAllByTestId("mode-selector-item")
+			const exportButton = modeItems[0].querySelector('button[aria-label="Export Mode"]') as HTMLButtonElement
+			fireEvent.click(exportButton)
+
+			// Simulate error response
+			window.dispatchEvent(
+				new MessageEvent("message", {
+					data: {
+						type: "exportModeResult",
+						success: false,
+						error: "Failed to save file",
+					},
+				}),
+			)
+
+			// Error message should be displayed
+			await waitFor(() => {
+				expect(screen.getByText("Failed to save file")).toBeInTheDocument()
+			})
+
+			// Button should be enabled again
+			expect(exportButton).not.toBeDisabled()
+		})
+	})
+
+	describe("Import Functionality", () => {
+		test("import button is visible in the footer", async () => {
+			render(<ModeSelector value={"code" as Mode} onChange={vi.fn()} modeShortcutText="Ctrl+M" />)
+
+			// Open the popover
+			fireEvent.click(screen.getByTestId("mode-selector-trigger"))
+
+			// Import button should be visible
+			const importButton = screen.getByRole("button", { name: "Import Mode" })
+			expect(importButton).toBeInTheDocument()
+			// Check for the icon inside the button
+			const icon = importButton.querySelector(".codicon-cloud-download")
+			expect(icon).toBeInTheDocument()
+		})
+
+		test("clicking import button opens import dialog", async () => {
+			render(<ModeSelector value={"code" as Mode} onChange={vi.fn()} modeShortcutText="Ctrl+M" />)
+
+			// Open the popover
+			fireEvent.click(screen.getByTestId("mode-selector-trigger"))
+
+			// Click import button
+			const importButton = screen.getByRole("button", { name: "Import Mode" })
+			fireEvent.click(importButton)
+
+			// Import dialog should be visible
+			expect(screen.getByText("Select import level")).toBeInTheDocument()
+			// Check for the text content instead of label association
+			expect(screen.getByText("Project")).toBeInTheDocument()
+			expect(screen.getByText("Global")).toBeInTheDocument()
+		})
+
+		test("import dialog has unique IDs for radio inputs", async () => {
+			render(<ModeSelector value={"code" as Mode} onChange={vi.fn()} modeShortcutText="Ctrl+M" />)
+
+			// Open the popover and import dialog
+			fireEvent.click(screen.getByTestId("mode-selector-trigger"))
+			fireEvent.click(screen.getByRole("button", { name: "Import Mode" }))
+
+			// Check for unique IDs
+			const projectRadio = document.getElementById("import-level-project") as HTMLInputElement
+			const globalRadio = document.getElementById("import-level-global") as HTMLInputElement
+
+			expect(projectRadio).toBeInTheDocument()
+			expect(globalRadio).toBeInTheDocument()
+			expect(projectRadio.id).toBe("import-level-project")
+			expect(globalRadio.id).toBe("import-level-global")
+		})
+
+		test("project level is selected by default", async () => {
+			render(<ModeSelector value={"code" as Mode} onChange={vi.fn()} modeShortcutText="Ctrl+M" />)
+
+			// Open the popover and import dialog
+			fireEvent.click(screen.getByTestId("mode-selector-trigger"))
+			fireEvent.click(screen.getByRole("button", { name: "Import Mode" }))
+
+			// Project should be checked by default
+			const projectRadio = document.getElementById("import-level-project") as HTMLInputElement
+			const globalRadio = document.getElementById("import-level-global") as HTMLInputElement
+
+			expect(projectRadio).toBeInTheDocument()
+			expect(globalRadio).toBeInTheDocument()
+			expect(projectRadio.checked).toBe(true)
+			expect(globalRadio.checked).toBe(false)
+		})
+
+		test("clicking import sends importMode message with selected level", async () => {
+			render(<ModeSelector value={"code" as Mode} onChange={vi.fn()} modeShortcutText="Ctrl+M" />)
+
+			// Open the popover and import dialog
+			fireEvent.click(screen.getByTestId("mode-selector-trigger"))
+			fireEvent.click(screen.getByRole("button", { name: "Import Mode" }))
+
+			// Select global
+			const globalRadio = document.getElementById("import-level-global") as HTMLInputElement
+			expect(globalRadio).toBeInTheDocument()
+			fireEvent.click(globalRadio)
+
+			// Click import
+			const importButton = screen.getByText("Import")
+			fireEvent.click(importButton)
+
+			// Verify the message was sent
+			expect(mockPostMessage).toHaveBeenCalledWith({
+				type: "importMode",
+				source: "global",
+			})
+		})
+
+		test("import button shows loading state while importing", async () => {
+			render(<ModeSelector value={"code" as Mode} onChange={vi.fn()} modeShortcutText="Ctrl+M" />)
+
+			// Open the popover and import dialog
+			fireEvent.click(screen.getByTestId("mode-selector-trigger"))
+			fireEvent.click(screen.getByRole("button", { name: "Import Mode" }))
+
+			// Click import
+			const importButton = screen.getByText("Import")
+			fireEvent.click(importButton)
+
+			// Button should show importing text
+			expect(screen.getByText("Importing...")).toBeInTheDocument()
+		})
+
+		test("handles import success", async () => {
+			render(<ModeSelector value={"code" as Mode} onChange={vi.fn()} modeShortcutText="Ctrl+M" />)
+
+			// Open the popover and import dialog
+			fireEvent.click(screen.getByTestId("mode-selector-trigger"))
+			fireEvent.click(screen.getByRole("button", { name: "Import Mode" }))
+
+			// Click import
+			const importButton = screen.getByText("Import")
+			fireEvent.click(importButton)
+
+			// Simulate success response
+			window.dispatchEvent(
+				new MessageEvent("message", {
+					data: {
+						type: "importModeResult",
+						success: true,
+					},
+				}),
+			)
+
+			// Dialog should be closed
+			await waitFor(() => {
+				expect(screen.queryByText("Select import level")).not.toBeInTheDocument()
+			})
+		})
+
+		test("handles import error", async () => {
+			render(<ModeSelector value={"code" as Mode} onChange={vi.fn()} modeShortcutText="Ctrl+M" />)
+
+			// Open the popover and import dialog
+			fireEvent.click(screen.getByTestId("mode-selector-trigger"))
+			fireEvent.click(screen.getByRole("button", { name: "Import Mode" }))
+
+			// Click import
+			const importButton = screen.getByText("Import")
+			fireEvent.click(importButton)
+
+			// Simulate error response
+			window.dispatchEvent(
+				new MessageEvent("message", {
+					data: {
+						type: "importModeResult",
+						success: false,
+						error: "Invalid file format",
+					},
+				}),
+			)
+
+			// Error message should be displayed
+			await waitFor(() => {
+				expect(screen.getByText("Invalid file format")).toBeInTheDocument()
+			})
+
+			// Dialog should still be open
+			expect(screen.getByText("Select import level")).toBeInTheDocument()
+		})
+
+		test("handles cancelled import", async () => {
+			render(<ModeSelector value={"code" as Mode} onChange={vi.fn()} modeShortcutText="Ctrl+M" />)
+
+			// Open the popover and import dialog
+			fireEvent.click(screen.getByTestId("mode-selector-trigger"))
+			fireEvent.click(screen.getByRole("button", { name: "Import Mode" }))
+
+			// Click import
+			const importButton = screen.getByText("Import")
+			fireEvent.click(importButton)
+
+			// Simulate cancelled response
+			window.dispatchEvent(
+				new MessageEvent("message", {
+					data: {
+						type: "importModeResult",
+						success: false,
+						error: "cancelled",
+					},
+				}),
+			)
+
+			// Dialog should be closed and no error shown
+			await waitFor(() => {
+				expect(screen.queryByText("Select import level")).not.toBeInTheDocument()
+			})
+			expect(screen.queryByText("cancelled")).not.toBeInTheDocument()
+		})
+
+		test("cancel button closes import dialog", async () => {
+			render(<ModeSelector value={"code" as Mode} onChange={vi.fn()} modeShortcutText="Ctrl+M" />)
+
+			// Open the popover and import dialog
+			fireEvent.click(screen.getByTestId("mode-selector-trigger"))
+			fireEvent.click(screen.getByRole("button", { name: "Import Mode" }))
+
+			// Click cancel
+			const cancelButton = screen.getByText("Cancel")
+			fireEvent.click(cancelButton)
+
+			// Dialog should be closed
+			expect(screen.queryByText("Select import level")).not.toBeInTheDocument()
+		})
+	})
+
+	describe("Accessibility", () => {
+		test("export button has proper aria-label", async () => {
+			render(<ModeSelector value={"code" as Mode} onChange={vi.fn()} modeShortcutText="Ctrl+M" />)
+
+			// Open the popover
+			fireEvent.click(screen.getByTestId("mode-selector-trigger"))
+
+			// Find export button
+			const modeItems = screen.getAllByTestId("mode-selector-item")
+			const exportButton = modeItems[0].querySelector('button[aria-label="Export Mode"]')
+
+			expect(exportButton).toHaveAttribute("aria-label", "Export Mode")
+		})
+
+		test("import button uses IconButton component", async () => {
+			render(<ModeSelector value={"code" as Mode} onChange={vi.fn()} modeShortcutText="Ctrl+M" />)
+
+			// Open the popover
+			fireEvent.click(screen.getByTestId("mode-selector-trigger"))
+
+			// Import button should have proper IconButton structure
+			const importButton = screen.getByRole("button", { name: "Import Mode" })
+			expect(importButton).toHaveAttribute("aria-label", "Import Mode")
+			expect(importButton.querySelector(".codicon-cloud-download")).toBeInTheDocument()
+		})
+	})
+})


### PR DESCRIPTION
## Description

https://github.com/user-attachments/assets/93dec77c-1326-43fb-adec-5fbb761b5e2b


Fixes #6320

This PR adds export/import functionality directly to the mode selector popover, allowing users to manage modes without navigating away from their current context.

## Changes Made

- **Added Export Buttons**: Each mode in the popover now has an export button that appears on hover
  - Uses the Upload icon from lucide-react
  - Shows loading state while exporting
  - Sends `exportMode` message to VSCode backend

- **Added Import Button**: Added an import button in the popover footer
  - Styled to match existing IconButton components for perfect alignment
  - Uses the Download icon from lucide-react
  - Opens an import dialog when clicked

- **Import Dialog**: Implemented inline import dialog matching ModesView pattern
  - Allows selection between project-level and global import
  - Shows loading state during import
  - Sends `importMode` message to VSCode backend

- **State Management**: Added necessary state variables for tracking operations
  - `isExporting`: Tracks which mode is being exported
  - `isImporting`: Tracks import operation status
  - `showImportDialog`: Controls import dialog visibility

## Testing

- ✅ All existing ModeSelector tests pass (7 tests)
- ✅ Export/import functionality uses the same message protocol as ModesView
- ✅ Visual alignment verified - import button perfectly aligns with other footer buttons

## Verification of Acceptance Criteria

- ✅ Export button added for each mode (visible on hover)
- ✅ Import button added to popover footer
- ✅ Import dialog allows selection of import level (project/global)
- ✅ Loading states implemented for both operations
- ✅ Uses existing backend message handlers (no backend changes needed)
- ✅ Maintains consistency with ModesView implementation

## Screenshots/Demo

The import button is now perfectly aligned with the marketplace and settings buttons in the popover footer.

## Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (#6320)
- [x] **Scope**: My changes are focused on the linked issue
- [x] **Self-Review**: I have performed a thorough self-review of my code
- [x] **Testing**: Existing tests pass, functionality verified
- [x] **Documentation Impact**: No documentation updates required
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds export/import buttons to `ModeSelector` popover, enabling mode management directly from the UI with new state management and tests.
> 
>   - **Behavior**:
>     - Adds export button to each mode in `ModeSelector.tsx`, visible on hover, using `Upload` icon.
>     - Adds import button to popover footer, using `Download` icon, opens import dialog.
>     - Import dialog allows project/global selection, shows loading state, and sends `importMode` message.
>   - **State Management**:
>     - Adds `isExporting`, `isImporting`, `showImportDialog` state variables in `ModeSelector.tsx`.
>   - **Testing**:
>     - New tests in `ModeSelector.export-import.spec.tsx` for export/import button visibility, message sending, and dialog behavior.
>     - Tests handle success, error, and cancellation scenarios for both export and import.
>   - **Misc**:
>     - Uses existing backend message handlers, no backend changes needed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b48e8c84d567c33256cce22bd15adc153729716f. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->