### PR TITLE
fix(environment): Filter out non-text tab inputs

### DIFF
--- a/.changeset/lemon-grapes-bake.md
+++ b/.changeset/lemon-grapes-bake.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix 'failure to apply changes to files' when Git diff views are open

--- a/.changeset/lemon-grapes-bake.md
+++ b/.changeset/lemon-grapes-bake.md
@@ -1,5 +1,0 @@
----
-"kilo-code": patch
----
-
-Fix 'failure to apply changes to files' when Git diff views are open

--- a/src/core/environment/getEnvironmentDetails.ts
+++ b/src/core/environment/getEnvironmentDetails.ts
@@ -58,7 +58,8 @@ export async function getEnvironmentDetails(cline: Task, includeFileDetails: boo
 	const maxTabs = maxOpenTabsContext ?? 20
 	const openTabPaths = vscode.window.tabGroups.all
 		.flatMap((group) => group.tabs)
-		.map((tab) => (tab.input as vscode.TabInputText)?.uri?.fsPath)
+		.filter((tab) => tab.input instanceof vscode.TabInputText)
+		.map((tab) => (tab.input as vscode.TabInputText).uri.fsPath)
 		.filter(Boolean)
 		.map((absolutePath) => path.relative(cline.cwd, absolutePath).toPosix())
 		.slice(0, maxTabs)


### PR DESCRIPTION
## Bug Description

Multi-file edit operations (`apply_diff` tool) would fail consistently when Git diff views were open in VSCode. The failure occurred before reaching the diff view opening code, indicating the issue was not with tab management as initially suspected.

## Root Cause

The bug was caused by **environment context contamination** in `src/core/environment/getEnvironmentDetails.ts`. When Git diff views are open, the environment details gathering code was incorrectly processing non-text tabs:

1. **Improper type casting**: Line 68 used `(tab.input as vscode.TabInputText)?.uri?.fsPath` without filtering, casting all tab inputs as `TabInputText` regardless of their actual type
2. **Processing incompatible tab types**: Git diff tabs have input types like `TabInputTextDiff`, not `TabInputText`
3. **Malformed environment data**: This resulted in unexpected/malformed data being included in the environment context sent to the AI
4. **AI parsing interference**: The contaminated context affected how the AI parsed multi-file `apply_diff` requests, causing them to fail

## Fix

Added proper tab type filtering before processing:

```typescript
// Before (BROKEN)
.map((tab) => (tab.input as vscode.TabInputText)?.uri?.fsPath)

// After (FIXED)
.filter((tab) => tab.input instanceof vscode.TabInputText)
.map((tab) => (tab.input as vscode.TabInputText).uri.fsPath)
```

This matches the correct pattern already used in other parts of the codebase like `DiffViewProvider.ts` and `WorkspaceTracker.ts`.

## Impact

- Multi-file edits now work reliably when Git diff views are open
- Environment context data is properly filtered and type-safe
- Consistent tab processing across the codebase

Fixes: https://github.com/Kilo-Org/kilocode/issues/712

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes environment context contamination in `getEnvironmentDetails.ts` by filtering non-text tab inputs, ensuring reliable multi-file edits with Git diff views open.
> 
>   - **Bug Fix**:
>     - Fixes environment context contamination in `getEnvironmentDetails.ts` by filtering non-text tab inputs.
>     - Ensures only `vscode.TabInputText` instances are processed, preventing malformed data.
>   - **Code Changes**:
>     - Adds `.filter((tab) => tab.input instanceof vscode.TabInputText)` before mapping tab inputs in `getEnvironmentDetails.ts`.
>   - **Impact**:
>     - Multi-file edits work reliably with Git diff views open.
>     - Consistent and type-safe environment context data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for aa85bc8e3c6a6bb843d79e42aa23142b3ba3eb1c. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->