### PR TITLE
feat: make PR reviewer rules generic

### DIFF
--- a/.roo/rules-pr-reviewer/1_workflow.xml
+++ b/.roo/rules-pr-reviewer/1_workflow.xml
@@ -26,8 +26,6 @@
   <step number="2">
     <name>Fetch Pull Request Information</name>
     <instructions>
-      By default, review pull requests from the https://github.com/RooCodeInc/Roo-Code repository.
-      
       If the user provides a PR number or URL, extract the necessary information:
       - Repository owner and name
       - Pull request number
@@ -283,7 +281,7 @@
       - Avoid including internal evaluation terminology (e.g., scores or internal tags) in public comments.
       
       When linking to specific lines or files, use full GitHub URLs relative to the repository, e.g.
-      `https://github.com/RooCodeInc/Roo-Code/blob/main/src/api/providers/human-relay.ts#L50`.
+      `https://github.com/[owner]/[repo]/blob/[branch]/[path/to/file]#L[line-number]`.
       
       Present your findings as a numbered list organized by priority:
       


### PR DESCRIPTION
## Description

This PR removes hardcoded repository references from the PR reviewer mode rules to make them generic and reusable for any GitHub repository.

## Changes Made

- Removed the default repository reference from  (line 29)
- Replaced the specific example URL with a generic pattern using placeholders
- No changes needed for  and  as they were already generic

## Before
- Default repo: `https://github.com/RooCodeInc/Roo-Code repository`
- Example URL: `https://github.com/RooCodeInc/Roo-Code/blob/main/src/api/providers/human-relay.ts#L50`

## After
- No default repo specified
- Generic URL pattern: `https://github.com/[owner]/[repo]/blob/[branch]/[path/to/file]#L[line-number]`

## Impact

The PR reviewer mode can now be used for reviewing pull requests in any GitHub repository without modification.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This PR makes PR reviewer rules generic by removing hardcoded repository references and using a generic URL pattern in `1_workflow.xml`.
> 
>   - **Behavior**:
>     - Removed hardcoded repository reference from `1_workflow.xml` to make PR reviewer rules generic.
>     - Replaced specific example URL with a generic pattern using placeholders in `1_workflow.xml`.
>   - **Impact**:
>     - PR reviewer mode is now reusable for any GitHub repository without modification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 306f29d3ad04d586ba10112e80ede2a0c775eb0a. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->