### PR TITLE
Allow queueing images

### DIFF
--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1133,10 +1133,10 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 
 				{!inputValue && !isEditMode && (
 					<div
-						className="absolute left-2 z-30 pr-9 flex items-center h-8"
+						className="absolute left-2 z-30 pr-9 flex items-center h-8 font-vscode-font-family text-vscode-editor-font-size leading-vscode-editor-line-height"
 						style={{
 							bottom: "0.25rem",
-							color: "var(--vscode-tab-inactiveForeground)",
+							color: "color-mix(in oklab, var(--vscode-input-foreground) 50%, transparent)",
 							userSelect: "none",
 							pointerEvents: "none",
 						}}>

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -811,8 +811,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 
 	const selectImages = useCallback(() => vscode.postMessage({ type: "selectImages" }), [])
 
-	const shouldDisableImages =
-		!model?.supportsImages || sendingDisabled || selectedImages.length >= MAX_IMAGES_PER_MESSAGE
+	const shouldDisableImages = !model?.supportsImages || selectedImages.length >= MAX_IMAGES_PER_MESSAGE
 
 	const handleMessage = useCallback(
 		(e: MessageEvent) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enable image queueing in chat by updating `ChatView.tsx` and `ChatTextArea.tsx` to handle image selection, pasting, and dragging.
> 
>   - **Behavior**:
>     - Allow image queueing in `ChatView.tsx` by updating `handleSendMessage()` to handle images in the message queue.
>     - Update `shouldDisableImages` logic in `ChatView.tsx` to disable image selection based on model support and image count.
>   - **Functions**:
>     - Add `selectImages` function in `ChatView.tsx` to handle image selection messages.
>     - Update `handlePaste()` and `handleDrop()` in `ChatTextArea.tsx` to process pasted and dragged images, respectively.
>   - **UI**:
>     - Update `ChatTextArea.tsx` to adjust styles for image handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 9fcd3011196797998a8712936556fbc8abbf42dd. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->