### PR TITLE
Hide Gemini checkboxes on the welcome view

### DIFF
--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -448,7 +448,11 @@ const ApiOptions = ({
 			)}
 
 			{selectedProvider === "gemini" && (
-				<Gemini apiConfiguration={apiConfiguration} setApiConfigurationField={setApiConfigurationField} />
+				<Gemini
+					apiConfiguration={apiConfiguration}
+					setApiConfigurationField={setApiConfigurationField}
+					fromWelcomeView={fromWelcomeView}
+				/>
 			)}
 
 			{selectedProvider === "openai" && (

--- a/webview-ui/src/components/settings/providers/Gemini.tsx
+++ b/webview-ui/src/components/settings/providers/Gemini.tsx
@@ -12,9 +12,10 @@ import { inputEventTransform } from "../transforms"
 type GeminiProps = {
 	apiConfiguration: ProviderSettings
 	setApiConfigurationField: (field: keyof ProviderSettings, value: ProviderSettings[keyof ProviderSettings]) => void
+	fromWelcomeView?: boolean
 }
 
-export const Gemini = ({ apiConfiguration, setApiConfigurationField }: GeminiProps) => {
+export const Gemini = ({ apiConfiguration, setApiConfigurationField, fromWelcomeView }: GeminiProps) => {
 	const { t } = useAppTranslation()
 
 	const [googleGeminiBaseUrlSelected, setGoogleGeminiBaseUrlSelected] = useState(
@@ -73,26 +74,30 @@ export const Gemini = ({ apiConfiguration, setApiConfigurationField }: GeminiPro
 					/>
 				)}
 
-				<Checkbox
-					className="mt-6"
-					data-testid="checkbox-url-context"
-					checked={!!apiConfiguration.enableUrlContext}
-					onChange={(checked: boolean) => setApiConfigurationField("enableUrlContext", checked)}>
-					{t("settings:providers.geminiParameters.urlContext.title")}
-				</Checkbox>
-				<div className="text-sm text-vscode-descriptionForeground mb-3 mt-1.5">
-					{t("settings:providers.geminiParameters.urlContext.description")}
-				</div>
+				{!fromWelcomeView && (
+					<>
+						<Checkbox
+							className="mt-6"
+							data-testid="checkbox-url-context"
+							checked={!!apiConfiguration.enableUrlContext}
+							onChange={(checked: boolean) => setApiConfigurationField("enableUrlContext", checked)}>
+							{t("settings:providers.geminiParameters.urlContext.title")}
+						</Checkbox>
+						<div className="text-sm text-vscode-descriptionForeground mb-3 mt-1.5">
+							{t("settings:providers.geminiParameters.urlContext.description")}
+						</div>
 
-				<Checkbox
-					data-testid="checkbox-grounding-search"
-					checked={!!apiConfiguration.enableGrounding}
-					onChange={(checked: boolean) => setApiConfigurationField("enableGrounding", checked)}>
-					{t("settings:providers.geminiParameters.groundingSearch.title")}
-				</Checkbox>
-				<div className="text-sm text-vscode-descriptionForeground mb-3 mt-1.5">
-					{t("settings:providers.geminiParameters.groundingSearch.description")}
-				</div>
+						<Checkbox
+							data-testid="checkbox-grounding-search"
+							checked={!!apiConfiguration.enableGrounding}
+							onChange={(checked: boolean) => setApiConfigurationField("enableGrounding", checked)}>
+							{t("settings:providers.geminiParameters.groundingSearch.title")}
+						</Checkbox>
+						<div className="text-sm text-vscode-descriptionForeground mb-3 mt-1.5">
+							{t("settings:providers.geminiParameters.groundingSearch.description")}
+						</div>
+					</>
+				)}
 			</div>
 		</>
 	)

--- a/webview-ui/src/components/settings/providers/__tests__/Gemini.spec.tsx
+++ b/webview-ui/src/components/settings/providers/__tests__/Gemini.spec.tsx
@@ -127,4 +127,51 @@ describe("Gemini", () => {
 			expect(mockSetApiConfigurationField).toHaveBeenCalledWith("enableGrounding", true)
 		})
 	})
+
+	describe("fromWelcomeView prop", () => {
+		it("should hide URL context and grounding checkboxes when fromWelcomeView is true, but keep custom base URL", () => {
+			render(
+				<Gemini
+					apiConfiguration={defaultApiConfiguration}
+					setApiConfigurationField={mockSetApiConfigurationField}
+					fromWelcomeView={true}
+				/>,
+			)
+
+			// Should still render custom base URL checkbox
+			expect(screen.getByTestId("checkbox-custom-base-url")).toBeInTheDocument()
+			// Should not render URL context and grounding checkboxes
+			expect(screen.queryByTestId("checkbox-url-context")).not.toBeInTheDocument()
+			expect(screen.queryByTestId("checkbox-grounding-search")).not.toBeInTheDocument()
+		})
+
+		it("should show all checkboxes when fromWelcomeView is false", () => {
+			render(
+				<Gemini
+					apiConfiguration={defaultApiConfiguration}
+					setApiConfigurationField={mockSetApiConfigurationField}
+					fromWelcomeView={false}
+				/>,
+			)
+
+			// Should render all checkboxes
+			expect(screen.getByTestId("checkbox-custom-base-url")).toBeInTheDocument()
+			expect(screen.getByTestId("checkbox-url-context")).toBeInTheDocument()
+			expect(screen.getByTestId("checkbox-grounding-search")).toBeInTheDocument()
+		})
+
+		it("should show all checkboxes when fromWelcomeView is undefined (default behavior)", () => {
+			render(
+				<Gemini
+					apiConfiguration={defaultApiConfiguration}
+					setApiConfigurationField={mockSetApiConfigurationField}
+				/>,
+			)
+
+			// Should render all checkboxes (default behavior)
+			expect(screen.getByTestId("checkbox-custom-base-url")).toBeInTheDocument()
+			expect(screen.getByTestId("checkbox-url-context")).toBeInTheDocument()
+			expect(screen.getByTestId("checkbox-grounding-search")).toBeInTheDocument()
+		})
+	})
 })


### PR DESCRIPTION
The new checkboxes for url fetch and grounding are too much for the welcome view imo
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `Gemini` component now conditionally hides certain checkboxes based on `fromWelcomeView` prop, with tests verifying this behavior.
> 
>   - **Behavior**:
>     - `Gemini` component now hides URL context and grounding checkboxes when `fromWelcomeView` is true, but retains the custom base URL checkbox.
>     - `ApiOptions` passes `fromWelcomeView` prop to `Gemini`.
>   - **Tests**:
>     - Added tests in `Gemini.spec.tsx` to verify checkbox visibility based on `fromWelcomeView` prop.
>     - Tests ensure all checkboxes are visible when `fromWelcomeView` is false or undefined.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c7654403a288e248e1c1cdebb147625779809287. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->