### PR TITLE
feat(ui): Make mode selection dropdowns responsive

### DIFF
--- a/webview-ui/src/components/modes/ModesView.tsx
+++ b/webview-ui/src/components/modes/ModesView.tsx
@@ -615,9 +615,9 @@ const ModesView = ({ onDone }: ModesViewProps) => {
 									variant="combobox"
 									role="combobox"
 									aria-expanded={open}
-									className="justify-between w-60"
+									className="justify-between w-full"
 									data-testid="mode-select-trigger">
-									<div>{getCurrentMode()?.name || t("prompts:modes.selectMode")}</div>
+									<div className="truncate">{getCurrentMode()?.name || t("prompts:modes.selectMode")}</div>
 									<ChevronDown className="opacity-50" />
 								</Button>
 							</PopoverTrigger>
@@ -716,7 +716,7 @@ const ModesView = ({ onDone }: ModesViewProps) => {
 										text: value,
 									})
 								}}>
-								<SelectTrigger className="w-60">
+								<SelectTrigger className="w-full">
 									<SelectValue placeholder={t("settings:common.select")} />
 								</SelectTrigger>
 								<SelectContent>


### PR DESCRIPTION
This PR makes the mode selection dropdowns responsive. It was difficult to select modes with long names and slugs, so this change improves the user experience by making the UI more flexible.

<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->


Closes: #6423 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make mode selection dropdowns responsive in `ModesView` by adjusting width and truncating long names.
> 
>   - **UI Changes**:
>     - In `ModesView`, change `Button` class from `w-60` to `w-full` for mode selection dropdowns.
>     - Add `truncate` class to mode name display in `ModesView` to handle long names.
>   - **Files Affected**:
>     - `ModesView.tsx`
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e200a4919ad00bc36aa6a9dbaa37990d9220e83f. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->