### PR TITLE
feat: diagnose nightly freeze by disabling contributes

### DIFF
--- a/apps/vscode-nightly/package.nightly.json
+++ b/apps/vscode-nightly/package.nightly.json
@@ -2,5 +2,6 @@
 	"name": "roo-code-nightly",
 	"version": "0.0.1",
 	"icon": "assets/icons/icon-nightly.png",
-	"scripts": {}
+	"scripts": {},
+	"contributes": {}
 }


### PR DESCRIPTION
This PR disables the 'contributes' section in the nightly build to diagnose a UI freeze in the VS Code marketplace.