### PR TITLE
feat: add persistent retry queue for failed telemetry events (#4940)

### DIFF
--- a/packages/telemetry/src/BaseTelemetryClient.ts
+++ b/packages/telemetry/src/BaseTelemetryClient.ts
@@ -5,10 +5,12 @@ import {
 	TelemetryPropertiesProvider,
 	TelemetryEventSubscription,
 } from "@roo-code/types"
+import { TelemetryQueue } from "./TelemetryQueue"
 
 export abstract class BaseTelemetryClient implements TelemetryClient {
 	protected providerRef: WeakRef<TelemetryPropertiesProvider> | null = null
 	protected telemetryEnabled: boolean = false
+	protected queue?: TelemetryQueue
 
 	constructor(
 		public readonly subscription?: TelemetryEventSubscription,
@@ -58,6 +60,29 @@ export abstract class BaseTelemetryClient implements TelemetryClient {
 	}
 
 	public abstract capture(event: TelemetryEvent): Promise<void>
+
+	/**
+	 * Attempts to capture an event with retry capability
+	 * @param event The telemetry event to capture
+	 * @returns True if the event was successfully sent, false if it should be retried
+	 */
+	protected abstract captureWithRetry(event: TelemetryEvent): Promise<boolean>
+
+	/**
+	 * Gets the queue instance if available
+	 * @returns The TelemetryQueue instance or undefined
+	 */
+	protected getQueue(): TelemetryQueue | undefined {
+		return this.queue
+	}
+
+	/**
+	 * Sets the queue instance for this client
+	 * @param queue The TelemetryQueue instance
+	 */
+	public setQueue(queue: TelemetryQueue): void {
+		this.queue = queue
+	}
 
 	public setProvider(provider: TelemetryPropertiesProvider): void {
 		this.providerRef = new WeakRef(provider)

--- a/packages/telemetry/src/TelemetryQueue.ts
+++ b/packages/telemetry/src/TelemetryQueue.ts
@@ -1,0 +1,290 @@
+import * as vscode from "vscode"
+import { randomUUID } from "crypto"
+import { TelemetryEvent } from "@roo-code/types"
+
+/**
+ * Represents a telemetry event that has been queued for retry
+ */
+export interface QueuedTelemetryEvent {
+	/** Unique identifier for the queued event */
+	id: string
+	/** Timestamp when the event was first queued */
+	timestamp: number
+	/** The original telemetry event */
+	event: TelemetryEvent
+	/** The client type that should process this event */
+	clientType: "posthog" | "cloud"
+	/** Number of times this event has been retried */
+	retryCount: number
+	/** Timestamp of the last retry attempt */
+	lastAttempt?: number
+	/** Timestamp when the next retry should occur */
+	nextAttempt?: number
+}
+
+/**
+ * TelemetryQueue manages failed telemetry events with persistent storage and retry logic.
+ * It uses VSCode's globalState for persistence and implements exponential backoff for retries.
+ */
+export class TelemetryQueue {
+	private static readonly STORAGE_KEY = "telemetryQueue"
+	private static readonly MAX_QUEUE_SIZE = 1000
+	private static readonly MAX_RETRY_COUNT = 10
+	private static readonly SUCCESS_INTERVAL = 30000 // 30 seconds
+	private static readonly INITIAL_BACKOFF_MS = 1000 // 1 second
+	private static readonly MAX_BACKOFF_MS = 300000 // 5 minutes
+
+	private events: QueuedTelemetryEvent[] = []
+	private context: vscode.ExtensionContext
+	private isProcessing = false
+	private retryCallback?: (event: QueuedTelemetryEvent) => Promise<boolean>
+	private timerId: NodeJS.Timeout | null = null
+	private currentBackoffMs: number
+	private attemptCount: number = 0
+	private isRunning: boolean = false
+
+	constructor(context: vscode.ExtensionContext) {
+		this.context = context
+		this.currentBackoffMs = TelemetryQueue.INITIAL_BACKOFF_MS
+
+		// Load persisted queue on initialization
+		this.loadQueue()
+	}
+
+	/**
+	 * Sets the callback function that will be used to retry events
+	 * @param callback Function that attempts to send an event, returns true if successful
+	 */
+	public setRetryCallback(callback: (event: QueuedTelemetryEvent) => Promise<boolean>): void {
+		this.retryCallback = callback
+	}
+
+	/**
+	 * Adds a failed event to the queue for retry
+	 * @param event The telemetry event that failed to send
+	 * @param clientType The client type that should process this event
+	 */
+	public async addEvent(event: TelemetryEvent, clientType: "posthog" | "cloud"): Promise<void> {
+		const queuedEvent: QueuedTelemetryEvent = {
+			id: randomUUID(),
+			timestamp: Date.now(),
+			event,
+			clientType,
+			retryCount: 0,
+		}
+
+		// Add to queue
+		this.events.push(queuedEvent)
+
+		// Enforce queue size limit (FIFO eviction)
+		if (this.events.length > TelemetryQueue.MAX_QUEUE_SIZE) {
+			this.events = this.events.slice(-TelemetryQueue.MAX_QUEUE_SIZE)
+		}
+
+		// Persist the updated queue
+		await this.saveQueue()
+
+		// Start the timer if not already running
+		if (!this.isRunning) {
+			this.start()
+		}
+	}
+
+	/**
+	 * Processes the queue, attempting to send all pending events
+	 * @returns True if all events were processed successfully, false otherwise
+	 */
+	public async processQueue(): Promise<boolean> {
+		if (this.isProcessing || !this.retryCallback) {
+			return false
+		}
+
+		this.isProcessing = true
+		const now = Date.now()
+		let allSuccessful = true
+		const remainingEvents: QueuedTelemetryEvent[] = []
+
+		try {
+			// Process events that are ready for retry
+			for (const event of this.events) {
+				// Skip if not ready for retry yet
+				if (event.nextAttempt && event.nextAttempt > now) {
+					remainingEvents.push(event)
+					continue
+				}
+
+				// Skip if max retries exceeded
+				if (event.retryCount >= TelemetryQueue.MAX_RETRY_COUNT) {
+					// Silently drop events that have exceeded max retries
+					continue
+				}
+
+				try {
+					// Attempt to send the event
+					const success = await this.retryCallback(event)
+
+					if (!success) {
+						// Update retry metadata
+						event.retryCount++
+						event.lastAttempt = now
+						// Calculate next attempt with exponential backoff
+						const backoffMs = Math.min(1000 * Math.pow(2, event.retryCount), 300000) // Max 5 minutes
+						event.nextAttempt = now + backoffMs
+						remainingEvents.push(event)
+						allSuccessful = false
+					}
+					// If successful, don't add back to remainingEvents (effectively removing it)
+				} catch (_error) {
+					// Treat errors as failures - silently retry
+					event.retryCount++
+					event.lastAttempt = now
+					const backoffMs = Math.min(1000 * Math.pow(2, event.retryCount), 300000)
+					event.nextAttempt = now + backoffMs
+					remainingEvents.push(event)
+					allSuccessful = false
+				}
+			}
+
+			// Update the queue with remaining events
+			this.events = remainingEvents
+			await this.saveQueue()
+
+			// Schedule next attempt based on result
+			this.scheduleNextAttempt(allSuccessful)
+
+			return allSuccessful
+		} finally {
+			this.isProcessing = false
+		}
+	}
+
+	/**
+	 * Gracefully shuts down the queue, attempting to flush pending events
+	 * @param timeoutMs Maximum time to wait for queue processing
+	 */
+	public async shutdown(timeoutMs: number = 5000): Promise<void> {
+		// Stop the timer
+		this.stop()
+
+		// Try to process remaining events with timeout
+		const timeoutPromise = new Promise<void>((resolve) => setTimeout(resolve, timeoutMs))
+		const processPromise = this.processQueue()
+
+		await Promise.race([processPromise, timeoutPromise])
+
+		// Save any remaining events
+		await this.saveQueue()
+	}
+
+	/**
+	 * Gets the current size of the queue
+	 * @returns Number of events in the queue
+	 */
+	public getQueueSize(): number {
+		return this.events.length
+	}
+
+	/**
+	 * Clears all events from the queue
+	 */
+	public async clearQueue(): Promise<void> {
+		this.events = []
+		await this.saveQueue()
+	}
+
+	/**
+	 * Loads the queue from persistent storage
+	 */
+	private async loadQueue(): Promise<void> {
+		try {
+			const stored = this.context.globalState.get<QueuedTelemetryEvent[]>(TelemetryQueue.STORAGE_KEY)
+			if (stored && Array.isArray(stored)) {
+				this.events = stored
+			}
+		} catch (_error) {
+			// If loading fails, start with empty queue
+			this.events = []
+		}
+	}
+
+	/**
+	 * Saves the queue to persistent storage
+	 */
+	private async saveQueue(): Promise<void> {
+		try {
+			await this.context.globalState.update(TelemetryQueue.STORAGE_KEY, this.events)
+		} catch (_error) {
+			// Silently fail - queue will be lost but telemetry shouldn't break the app
+		}
+	}
+
+	/**
+	 * Schedules the next attempt based on the success/failure of the current attempt
+	 * @param wasSuccessful Whether the current attempt was successful
+	 */
+	private scheduleNextAttempt(wasSuccessful: boolean): void {
+		if (!this.isRunning) {
+			return
+		}
+
+		if (wasSuccessful) {
+			// Reset backoff on success
+			this.currentBackoffMs = TelemetryQueue.INITIAL_BACKOFF_MS
+			this.attemptCount = 0
+
+			this.timerId = setTimeout(() => this.executeCallback(), TelemetryQueue.SUCCESS_INTERVAL)
+		} else {
+			// Increment attempt count
+			this.attemptCount++
+
+			// Calculate backoff time with exponential increase
+			this.currentBackoffMs = Math.min(
+				TelemetryQueue.INITIAL_BACKOFF_MS * Math.pow(2, this.attemptCount - 1),
+				TelemetryQueue.MAX_BACKOFF_MS,
+			)
+
+			this.timerId = setTimeout(() => this.executeCallback(), this.currentBackoffMs)
+		}
+	}
+
+	/**
+	 * Executes the callback and handles the result
+	 */
+	private async executeCallback(): Promise<void> {
+		if (!this.isRunning) {
+			return
+		}
+
+		await this.processQueue()
+	}
+
+	/**
+	 * Starts the queue processing timer
+	 */
+	public start(): void {
+		if (this.isRunning) {
+			return
+		}
+
+		this.isRunning = true
+
+		// Execute the callback immediately
+		this.executeCallback()
+	}
+
+	/**
+	 * Stops the queue processing timer
+	 */
+	public stop(): void {
+		if (!this.isRunning) {
+			return
+		}
+
+		if (this.timerId) {
+			clearTimeout(this.timerId)
+			this.timerId = null
+		}
+
+		this.isRunning = false
+	}
+}

--- a/packages/telemetry/src/__tests__/TelemetryQueue.test.ts
+++ b/packages/telemetry/src/__tests__/TelemetryQueue.test.ts
@@ -1,0 +1,505 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import * as vscode from "vscode"
+import { TelemetryQueue, QueuedTelemetryEvent } from "../TelemetryQueue"
+import { TelemetryEvent, TelemetryEventName } from "@roo-code/types"
+
+// Mock vscode
+vi.mock("vscode", () => ({
+	ExtensionContext: vi.fn(),
+}))
+
+// Mock crypto
+vi.mock("crypto", () => ({
+	randomUUID: vi.fn(() => "test-uuid-" + Math.random()),
+}))
+
+describe("TelemetryQueue", () => {
+	let mockContext: vscode.ExtensionContext
+	let queue: TelemetryQueue
+	let mockGlobalState: Map<string, unknown>
+
+	beforeEach(() => {
+		vi.useFakeTimers()
+
+		// Create a mock global state
+		mockGlobalState = new Map()
+
+		// Mock extension context
+		mockContext = {
+			globalState: {
+				get: vi.fn((key: string) => mockGlobalState.get(key)),
+				update: vi.fn(async (key: string, value: unknown) => {
+					mockGlobalState.set(key, value)
+				}),
+			},
+		} as unknown as vscode.ExtensionContext
+
+		queue = new TelemetryQueue(mockContext)
+	})
+
+	afterEach(() => {
+		vi.clearAllTimers()
+		vi.restoreAllMocks()
+	})
+
+	describe("addEvent", () => {
+		it("should add an event to the queue", async () => {
+			const event: TelemetryEvent = {
+				event: TelemetryEventName.TASK_CREATED,
+				properties: { taskId: "test-123" },
+			}
+
+			await queue.addEvent(event, "posthog")
+
+			expect(queue.getQueueSize()).toBe(1)
+			expect(mockContext.globalState.update).toHaveBeenCalledWith(
+				"telemetryQueue",
+				expect.arrayContaining([
+					expect.objectContaining({
+						id: expect.stringContaining("test-uuid-"),
+						event,
+						clientType: "posthog",
+						retryCount: 0,
+						timestamp: expect.any(Number),
+					}),
+				]),
+			)
+		})
+
+		it("should enforce queue size limit with FIFO eviction", async () => {
+			// Add more than MAX_QUEUE_SIZE (1000) events
+			for (let i = 0; i < 1005; i++) {
+				await queue.addEvent(
+					{
+						event: TelemetryEventName.TASK_CREATED,
+						properties: { index: i },
+					},
+					"cloud",
+				)
+			}
+
+			expect(queue.getQueueSize()).toBe(1000)
+		})
+
+		it("should start the timer when adding first event", async () => {
+			const startSpy = vi.spyOn(queue, "start")
+
+			await queue.addEvent(
+				{
+					event: TelemetryEventName.TASK_CREATED,
+					properties: {},
+				},
+				"posthog",
+			)
+
+			expect(startSpy).toHaveBeenCalled()
+		})
+	})
+
+	describe("processQueue", () => {
+		it("should process events successfully", async () => {
+			const mockCallback = vi.fn().mockResolvedValue(true)
+			queue.setRetryCallback(mockCallback)
+
+			// Add some events
+			await queue.addEvent(
+				{
+					event: TelemetryEventName.TASK_CREATED,
+					properties: { id: 1 },
+				},
+				"posthog",
+			)
+			await queue.addEvent(
+				{
+					event: TelemetryEventName.TASK_COMPLETED,
+					properties: { id: 2 },
+				},
+				"cloud",
+			)
+
+			const result = await queue.processQueue()
+
+			expect(result).toBe(true)
+			expect(mockCallback).toHaveBeenCalledTimes(2)
+			expect(queue.getQueueSize()).toBe(0)
+		})
+
+		it("should handle failed events with retry", async () => {
+			const mockCallback = vi.fn().mockResolvedValue(false)
+			queue.setRetryCallback(mockCallback)
+
+			await queue.addEvent(
+				{
+					event: TelemetryEventName.TASK_CREATED,
+					properties: {},
+				},
+				"posthog",
+			)
+
+			const result = await queue.processQueue()
+
+			expect(result).toBe(false)
+			expect(queue.getQueueSize()).toBe(1)
+
+			// Check that retry metadata was updated
+			const queuedEvents = mockGlobalState.get("telemetryQueue") as QueuedTelemetryEvent[]
+			expect(queuedEvents[0].retryCount).toBe(1)
+			expect(queuedEvents[0].lastAttempt).toBeDefined()
+			expect(queuedEvents[0].nextAttempt).toBeDefined()
+		})
+
+		it("should skip events not ready for retry", async () => {
+			const mockCallback = vi.fn().mockResolvedValue(true)
+			queue.setRetryCallback(mockCallback)
+
+			// Add an event with future nextAttempt
+			const futureEvent: QueuedTelemetryEvent = {
+				id: "test-1",
+				timestamp: Date.now(),
+				event: {
+					event: TelemetryEventName.TASK_CREATED,
+					properties: {},
+				},
+				clientType: "posthog",
+				retryCount: 1,
+				nextAttempt: Date.now() + 10000, // 10 seconds in future
+			}
+
+			mockGlobalState.set("telemetryQueue", [futureEvent])
+			queue = new TelemetryQueue(mockContext) // Reload to pick up the event
+			queue.setRetryCallback(mockCallback)
+
+			await queue.processQueue()
+
+			expect(mockCallback).not.toHaveBeenCalled()
+			expect(queue.getQueueSize()).toBe(1)
+		})
+
+		it("should drop events after max retries", async () => {
+			const mockCallback = vi.fn().mockResolvedValue(false)
+			queue.setRetryCallback(mockCallback)
+
+			// Add an event that has already been retried max times
+			const maxRetriedEvent: QueuedTelemetryEvent = {
+				id: "test-1",
+				timestamp: Date.now(),
+				event: {
+					event: TelemetryEventName.TASK_CREATED,
+					properties: {},
+				},
+				clientType: "posthog",
+				retryCount: 10, // MAX_RETRY_COUNT
+			}
+
+			mockGlobalState.set("telemetryQueue", [maxRetriedEvent])
+			queue = new TelemetryQueue(mockContext)
+			queue.setRetryCallback(mockCallback)
+
+			await queue.processQueue()
+
+			expect(mockCallback).not.toHaveBeenCalled()
+			expect(queue.getQueueSize()).toBe(0)
+			// Event should be silently dropped
+		})
+
+		it("should handle callback errors as failures", async () => {
+			const mockCallback = vi.fn().mockRejectedValue(new Error("Network error"))
+			queue.setRetryCallback(mockCallback)
+
+			await queue.addEvent(
+				{
+					event: TelemetryEventName.TASK_CREATED,
+					properties: {},
+				},
+				"posthog",
+			)
+
+			const result = await queue.processQueue()
+
+			expect(result).toBe(false)
+			expect(queue.getQueueSize()).toBe(1)
+			// Error should be silently handled
+		})
+
+		it("should return false if no callback is set", async () => {
+			await queue.addEvent(
+				{
+					event: TelemetryEventName.TASK_CREATED,
+					properties: {},
+				},
+				"posthog",
+			)
+
+			const result = await queue.processQueue()
+
+			expect(result).toBe(false)
+		})
+	})
+
+	describe("shutdown", () => {
+		it("should stop timer and save queue", async () => {
+			const stopSpy = vi.spyOn(queue, "stop")
+
+			await queue.addEvent(
+				{
+					event: TelemetryEventName.TASK_CREATED,
+					properties: {},
+				},
+				"posthog",
+			)
+
+			await queue.shutdown()
+
+			expect(stopSpy).toHaveBeenCalled()
+			expect(mockContext.globalState.update).toHaveBeenCalled()
+		})
+
+		it("should attempt to process queue with timeout", async () => {
+			const mockCallback = vi
+				.fn()
+				.mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve(true), 10000)))
+			queue.setRetryCallback(mockCallback)
+
+			await queue.addEvent(
+				{
+					event: TelemetryEventName.TASK_CREATED,
+					properties: {},
+				},
+				"posthog",
+			)
+
+			const shutdownPromise = queue.shutdown(100) // 100ms timeout
+
+			// Fast forward time
+			await vi.advanceTimersByTimeAsync(100)
+
+			await shutdownPromise
+
+			// Callback should have been called but may not have completed
+			expect(mockCallback).toHaveBeenCalled()
+		})
+	})
+
+	describe("clearQueue", () => {
+		it("should clear all events from the queue", async () => {
+			await queue.addEvent(
+				{
+					event: TelemetryEventName.TASK_CREATED,
+					properties: {},
+				},
+				"posthog",
+			)
+			await queue.addEvent(
+				{
+					event: TelemetryEventName.TASK_COMPLETED,
+					properties: {},
+				},
+				"cloud",
+			)
+
+			expect(queue.getQueueSize()).toBe(2)
+
+			await queue.clearQueue()
+
+			expect(queue.getQueueSize()).toBe(0)
+			expect(mockContext.globalState.update).toHaveBeenCalledWith("telemetryQueue", [])
+		})
+	})
+
+	describe("persistence", () => {
+		it("should load queue from storage on initialization", () => {
+			const persistedEvents: QueuedTelemetryEvent[] = [
+				{
+					id: "persisted-1",
+					timestamp: Date.now(),
+					event: {
+						event: TelemetryEventName.TASK_CREATED,
+						properties: {},
+					},
+					clientType: "posthog",
+					retryCount: 2,
+				},
+			]
+
+			mockGlobalState.set("telemetryQueue", persistedEvents)
+
+			const newQueue = new TelemetryQueue(mockContext)
+
+			expect(newQueue.getQueueSize()).toBe(1)
+		})
+
+		it("should handle corrupted storage gracefully", () => {
+			// Set invalid data that will cause an error when loading
+			mockContext.globalState.get = vi.fn().mockImplementation((key: string) => {
+				if (key === "telemetryQueue") {
+					// Return non-array data to trigger error handling
+					return "not-an-array"
+				}
+				return undefined
+			})
+
+			// The loadQueue method doesn't throw, it just logs and continues
+			// So we need to check that it handles the invalid data gracefully
+			const newQueue = new TelemetryQueue(mockContext)
+
+			expect(newQueue.getQueueSize()).toBe(0)
+		})
+	})
+
+	describe("timer behavior", () => {
+		it("should use exponential backoff for failures", async () => {
+			const mockCallback = vi.fn().mockResolvedValue(false)
+			queue.setRetryCallback(mockCallback)
+
+			await queue.addEvent(
+				{
+					event: TelemetryEventName.TASK_CREATED,
+					properties: {},
+				},
+				"posthog",
+			)
+
+			// Start the queue
+			queue.start()
+
+			// Wait for initial execution
+			await vi.runOnlyPendingTimersAsync()
+			expect(mockCallback).toHaveBeenCalledTimes(1)
+
+			// Fast forward 1 second (initial backoff)
+			await vi.advanceTimersByTimeAsync(1000)
+			await vi.runOnlyPendingTimersAsync()
+			expect(mockCallback).toHaveBeenCalledTimes(2)
+
+			// Fast forward 2 seconds (exponential backoff)
+			await vi.advanceTimersByTimeAsync(2000)
+			await vi.runOnlyPendingTimersAsync()
+			expect(mockCallback).toHaveBeenCalledTimes(3)
+
+			// Fast forward 4 seconds (exponential backoff)
+			await vi.advanceTimersByTimeAsync(4000)
+			await vi.runOnlyPendingTimersAsync()
+			expect(mockCallback).toHaveBeenCalledTimes(4)
+		})
+
+		it("should use success interval after successful processing", async () => {
+			const mockCallback = vi.fn().mockResolvedValue(true)
+			queue.setRetryCallback(mockCallback)
+
+			await queue.addEvent(
+				{
+					event: TelemetryEventName.TASK_CREATED,
+					properties: {},
+				},
+				"posthog",
+			)
+
+			// Process successfully
+			await queue.processQueue()
+			expect(mockCallback).toHaveBeenCalledTimes(1)
+			expect(queue.getQueueSize()).toBe(0)
+
+			// Add another event
+			await queue.addEvent(
+				{
+					event: TelemetryEventName.TASK_COMPLETED,
+					properties: {},
+				},
+				"cloud",
+			)
+
+			// Fast forward 30 seconds (success interval)
+			await vi.advanceTimersByTimeAsync(30000)
+			expect(mockCallback).toHaveBeenCalledTimes(2)
+		})
+
+		it("should cap backoff at maximum", async () => {
+			const mockCallback = vi.fn().mockResolvedValue(false)
+			queue.setRetryCallback(mockCallback)
+
+			// Manually create an event that has been retried many times
+			const highRetryEvent: QueuedTelemetryEvent = {
+				id: "test-1",
+				timestamp: Date.now(),
+				event: {
+					event: TelemetryEventName.TASK_CREATED,
+					properties: {},
+				},
+				clientType: "posthog",
+				retryCount: 8, // High retry count to test max backoff
+			}
+
+			// Set the event in storage
+			mockGlobalState.set("telemetryQueue", [highRetryEvent])
+
+			// Create a new queue to load the event
+			const newQueue = new TelemetryQueue(mockContext)
+			newQueue.setRetryCallback(mockCallback)
+
+			// Process the queue
+			await newQueue.processQueue()
+
+			// Check the updated event
+			const queuedEvents = mockGlobalState.get("telemetryQueue") as QueuedTelemetryEvent[]
+			expect(queuedEvents).toBeDefined()
+			expect(queuedEvents.length).toBe(1)
+
+			const updatedEvent = queuedEvents[0]
+			expect(updatedEvent.retryCount).toBe(9)
+			expect(updatedEvent.lastAttempt).toBeDefined()
+			expect(updatedEvent.nextAttempt).toBeDefined()
+
+			// Check that backoff is capped at max
+			const backoffTime = updatedEvent.nextAttempt! - updatedEvent.lastAttempt!
+			expect(backoffTime).toBeLessThanOrEqual(300000) // 5 minutes max
+		})
+	})
+
+	describe("start/stop", () => {
+		it("should start processing immediately", () => {
+			const executeCallbackSpy = vi.spyOn(
+				queue as unknown as { executeCallback: () => Promise<void> },
+				"executeCallback",
+			)
+
+			queue.start()
+
+			expect(executeCallbackSpy).toHaveBeenCalled()
+		})
+
+		it("should not start if already running", () => {
+			queue.start()
+
+			const executeCallbackSpy = vi.spyOn(
+				queue as unknown as { executeCallback: () => Promise<void> },
+				"executeCallback",
+			)
+
+			queue.start()
+
+			expect(executeCallbackSpy).not.toHaveBeenCalled()
+		})
+
+		it("should stop timer and prevent further processing", async () => {
+			const mockCallback = vi.fn().mockResolvedValue(true)
+			queue.setRetryCallback(mockCallback)
+
+			await queue.addEvent(
+				{
+					event: TelemetryEventName.TASK_CREATED,
+					properties: {},
+				},
+				"posthog",
+			)
+
+			queue.start()
+			queue.stop()
+
+			// Fast forward time
+			await vi.advanceTimersByTimeAsync(60000)
+
+			// Should only be called once (the initial call)
+			expect(mockCallback).toHaveBeenCalledTimes(1)
+		})
+	})
+})

--- a/packages/telemetry/src/__tests__/TelemetryService.test.ts
+++ b/packages/telemetry/src/__tests__/TelemetryService.test.ts
@@ -1,0 +1,450 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import * as vscode from "vscode"
+import { TelemetryService } from "../TelemetryService"
+import { TelemetryQueue } from "../TelemetryQueue"
+import { BaseTelemetryClient } from "../BaseTelemetryClient"
+import { TelemetryEventName, TelemetryEvent } from "@roo-code/types"
+
+// Mock vscode
+vi.mock("vscode", () => ({
+	ExtensionContext: vi.fn(),
+	env: {
+		machineId: "test-machine-id",
+	},
+	workspace: {
+		getConfiguration: vi.fn().mockReturnValue({
+			get: vi.fn().mockReturnValue("all"),
+		}),
+	},
+}))
+
+// Mock posthog-node
+vi.mock("posthog-node", () => ({
+	PostHog: vi.fn().mockImplementation(() => ({
+		capture: vi.fn(),
+		optIn: vi.fn(),
+		optOut: vi.fn(),
+		shutdown: vi.fn().mockResolvedValue(undefined),
+	})),
+}))
+
+// Mock TelemetryQueue
+vi.mock("../TelemetryQueue", () => {
+	const mockQueue = {
+		setRetryCallback: vi.fn(),
+		start: vi.fn(),
+		shutdown: vi.fn(),
+		getQueueSize: vi.fn().mockReturnValue(0),
+		addEvent: vi.fn(),
+	}
+
+	return {
+		TelemetryQueue: vi.fn(() => mockQueue),
+		QueuedTelemetryEvent: vi.fn(),
+	}
+})
+
+// Create a mock telemetry client
+class MockTelemetryClient extends BaseTelemetryClient {
+	public async capture(_event: TelemetryEvent): Promise<void> {
+		// Mock implementation
+	}
+
+	protected async captureWithRetry(_event: TelemetryEvent): Promise<boolean> {
+		return true
+	}
+
+	public updateTelemetryState(didUserOptIn: boolean): void {
+		this.telemetryEnabled = didUserOptIn
+	}
+
+	public async shutdown(): Promise<void> {
+		// Mock implementation
+	}
+}
+
+describe("TelemetryService", () => {
+	let mockContext: vscode.ExtensionContext
+	let mockGlobalState: Map<string, unknown>
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+
+		// Create a mock global state
+		mockGlobalState = new Map()
+
+		// Mock extension context
+		mockContext = {
+			globalState: {
+				get: vi.fn((key: string) => mockGlobalState.get(key)),
+				update: vi.fn(async (key: string, value: unknown) => {
+					mockGlobalState.set(key, value)
+				}),
+			},
+		} as unknown as vscode.ExtensionContext
+
+		// Reset the singleton
+		// @ts-expect-error - accessing private property for testing
+		TelemetryService._instance = null
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	describe("createInstance", () => {
+		it("should create a singleton instance", () => {
+			const service1 = TelemetryService.createInstance()
+			expect(service1).toBeDefined()
+
+			// Should throw when trying to create another instance
+			expect(() => TelemetryService.createInstance()).toThrow("TelemetryService instance already created")
+		})
+
+		it("should create instance with provided clients", () => {
+			const mockClient1 = new MockTelemetryClient()
+			const mockClient2 = new MockTelemetryClient()
+
+			const service = TelemetryService.createInstance([mockClient1, mockClient2])
+			expect(service).toBeDefined()
+		})
+	})
+
+	describe("instance", () => {
+		it("should throw if not initialized", () => {
+			expect(() => TelemetryService.instance).toThrow("TelemetryService not initialized")
+		})
+
+		it("should return the instance if initialized", () => {
+			const service = TelemetryService.createInstance()
+			expect(TelemetryService.instance).toBe(service)
+		})
+	})
+
+	describe("hasInstance", () => {
+		it("should return false if not initialized", () => {
+			expect(TelemetryService.hasInstance()).toBe(false)
+		})
+
+		it("should return true if initialized", () => {
+			TelemetryService.createInstance()
+			expect(TelemetryService.hasInstance()).toBe(true)
+		})
+	})
+
+	describe("initializeQueue", () => {
+		it("should create and configure the queue", () => {
+			const mockClient1 = new MockTelemetryClient()
+			const mockClient2 = new MockTelemetryClient()
+			const service = TelemetryService.createInstance([mockClient1, mockClient2])
+
+			service.initializeQueue(mockContext)
+
+			// Verify TelemetryQueue was created
+			expect(TelemetryQueue).toHaveBeenCalledWith(mockContext)
+
+			// Get the mock queue instance
+			const MockedTelemetryQueue = vi.mocked(TelemetryQueue)
+			const mockQueue = MockedTelemetryQueue.mock.results[0]?.value
+
+			// Verify setRetryCallback was called
+			expect(mockQueue.setRetryCallback).toHaveBeenCalled()
+
+			// Verify queue was distributed to clients
+			vi.spyOn(mockClient1, "setQueue")
+			vi.spyOn(mockClient2, "setQueue")
+
+			// Re-initialize to trigger setQueue calls
+			service.initializeQueue(mockContext)
+
+			expect(mockClient1.setQueue).toHaveBeenCalledWith(mockQueue)
+			expect(mockClient2.setQueue).toHaveBeenCalledWith(mockQueue)
+
+			// Verify queue was started
+			expect(mockQueue.start).toHaveBeenCalled()
+		})
+
+		it("should not initialize if service is not ready", () => {
+			const service = TelemetryService.createInstance([])
+
+			service.initializeQueue(mockContext)
+
+			// TelemetryQueue should not be created
+			expect(TelemetryQueue).not.toHaveBeenCalled()
+		})
+
+		it("should set up retry callback that finds correct client", async () => {
+			// Import the real PostHogTelemetryClient
+			const { PostHogTelemetryClient } = await import("../PostHogTelemetryClient")
+
+			// Create instances
+			const posthogClient = new PostHogTelemetryClient()
+			const cloudClient = new MockTelemetryClient()
+
+			// Override constructor names for testing
+			Object.defineProperty(cloudClient.constructor, "name", { value: "TelemetryClient" })
+
+			// Spy on captureWithRetry methods
+			const posthogSpy = vi
+				.spyOn(
+					posthogClient as unknown as { captureWithRetry: (event: TelemetryEvent) => Promise<boolean> },
+					"captureWithRetry",
+				)
+				.mockResolvedValue(true)
+			const cloudSpy = vi
+				.spyOn(
+					cloudClient as unknown as { captureWithRetry: (event: TelemetryEvent) => Promise<boolean> },
+					"captureWithRetry",
+				)
+				.mockResolvedValue(true)
+
+			const service = TelemetryService.createInstance([posthogClient, cloudClient])
+
+			service.initializeQueue(mockContext)
+
+			// Get the retry callback
+			const MockedTelemetryQueue = vi.mocked(TelemetryQueue)
+			const mockQueue = MockedTelemetryQueue.mock.results[0]?.value
+			const retryCallback = mockQueue.setRetryCallback.mock.calls[0]?.[0]
+
+			// Test PostHog client selection
+			const posthogEvent = {
+				id: "test-1",
+				timestamp: Date.now(),
+				event: { event: TelemetryEventName.TASK_CREATED, properties: {} },
+				clientType: "posthog" as const,
+				retryCount: 0,
+			}
+
+			const result1 = await retryCallback(posthogEvent)
+			expect(result1).toBe(true)
+			expect(posthogSpy).toHaveBeenCalledWith(posthogEvent.event)
+
+			// Test Cloud client selection
+			const cloudEvent = {
+				id: "test-2",
+				timestamp: Date.now(),
+				event: { event: TelemetryEventName.TASK_CREATED, properties: {} },
+				clientType: "cloud" as const,
+				retryCount: 0,
+			}
+
+			const result2 = await retryCallback(cloudEvent)
+			expect(result2).toBe(true)
+			expect(cloudSpy).toHaveBeenCalledWith(cloudEvent.event)
+		})
+
+		it("should return false from retry callback if no matching client found", async () => {
+			const mockClient = new MockTelemetryClient()
+			const service = TelemetryService.createInstance([mockClient])
+
+			service.initializeQueue(mockContext)
+
+			// Get the retry callback
+			const MockedTelemetryQueue = vi.mocked(TelemetryQueue)
+			const mockQueue = MockedTelemetryQueue.mock.results[0]?.value
+			const retryCallback = mockQueue.setRetryCallback.mock.calls[0]?.[0]
+
+			// Test with unknown client type
+			const unknownEvent = {
+				id: "test-1",
+				timestamp: Date.now(),
+				event: { event: TelemetryEventName.TASK_CREATED, properties: {} },
+				clientType: "unknown" as "posthog" | "cloud",
+				retryCount: 0,
+			}
+
+			const result = await retryCallback(unknownEvent)
+			expect(result).toBe(false)
+		})
+	})
+
+	describe("shutdownQueue", () => {
+		it("should shutdown the queue if initialized", async () => {
+			const mockClient = new MockTelemetryClient()
+			const service = TelemetryService.createInstance([mockClient])
+
+			service.initializeQueue(mockContext)
+
+			const MockedTelemetryQueue = vi.mocked(TelemetryQueue)
+			const mockQueue = MockedTelemetryQueue.mock.results[0]?.value
+
+			await service.shutdownQueue(5000)
+
+			expect(mockQueue.shutdown).toHaveBeenCalledWith(5000)
+		})
+
+		it("should handle shutdown when queue is not initialized", async () => {
+			const service = TelemetryService.createInstance([])
+
+			// Should not throw
+			await expect(service.shutdownQueue()).resolves.toBeUndefined()
+		})
+	})
+
+	describe("getQueueStatus", () => {
+		it("should return queue status", () => {
+			const mockClient1 = new MockTelemetryClient()
+			const mockClient2 = new MockTelemetryClient()
+			const service = TelemetryService.createInstance([mockClient1, mockClient2])
+
+			service.initializeQueue(mockContext)
+
+			const MockedTelemetryQueue = vi.mocked(TelemetryQueue)
+			const mockQueue = MockedTelemetryQueue.mock.results[0]?.value
+			mockQueue.getQueueSize.mockReturnValue(5)
+
+			const status = service.getQueueStatus()
+
+			expect(status).toEqual({
+				size: 5,
+				clients: 2,
+			})
+		})
+
+		it("should return zero size when queue is not initialized", () => {
+			const service = TelemetryService.createInstance([])
+
+			const status = service.getQueueStatus()
+
+			expect(status).toEqual({
+				size: 0,
+				clients: 0,
+			})
+		})
+	})
+
+	describe("shutdown", () => {
+		it("should shutdown queue and all clients", async () => {
+			const mockClient1 = new MockTelemetryClient()
+			const mockClient2 = new MockTelemetryClient()
+
+			vi.spyOn(mockClient1, "shutdown")
+			vi.spyOn(mockClient2, "shutdown")
+
+			const service = TelemetryService.createInstance([mockClient1, mockClient2])
+
+			service.initializeQueue(mockContext)
+
+			const MockedTelemetryQueue = vi.mocked(TelemetryQueue)
+			const mockQueue = MockedTelemetryQueue.mock.results[0]?.value
+
+			await service.shutdown()
+
+			// Queue should be shutdown first
+			expect(mockQueue.shutdown).toHaveBeenCalled()
+
+			// Then clients
+			expect(mockClient1.shutdown).toHaveBeenCalled()
+			expect(mockClient2.shutdown).toHaveBeenCalled()
+		})
+
+		it("should handle shutdown when not ready", async () => {
+			const service = TelemetryService.createInstance([])
+
+			// Should not throw
+			await expect(service.shutdown()).resolves.toBeUndefined()
+		})
+	})
+
+	describe("captureEvent", () => {
+		it("should forward events to all clients", () => {
+			const mockClient1 = new MockTelemetryClient()
+			const mockClient2 = new MockTelemetryClient()
+
+			vi.spyOn(mockClient1, "capture")
+			vi.spyOn(mockClient2, "capture")
+
+			const service = TelemetryService.createInstance([mockClient1, mockClient2])
+
+			service.captureEvent(TelemetryEventName.TASK_CREATED, { taskId: "test-123" })
+
+			expect(mockClient1.capture).toHaveBeenCalledWith({
+				event: TelemetryEventName.TASK_CREATED,
+				properties: { taskId: "test-123" },
+			})
+
+			expect(mockClient2.capture).toHaveBeenCalledWith({
+				event: TelemetryEventName.TASK_CREATED,
+				properties: { taskId: "test-123" },
+			})
+		})
+
+		it("should not capture when service is not ready", () => {
+			const service = TelemetryService.createInstance([])
+
+			// Should not throw
+			expect(() => service.captureEvent(TelemetryEventName.TASK_CREATED, { taskId: "test-123" })).not.toThrow()
+		})
+	})
+
+	describe("updateTelemetryState", () => {
+		it("should update telemetry state for all clients", () => {
+			const mockClient1 = new MockTelemetryClient()
+			const mockClient2 = new MockTelemetryClient()
+
+			vi.spyOn(mockClient1, "updateTelemetryState")
+			vi.spyOn(mockClient2, "updateTelemetryState")
+
+			const service = TelemetryService.createInstance([mockClient1, mockClient2])
+
+			service.updateTelemetryState(true)
+
+			expect(mockClient1.updateTelemetryState).toHaveBeenCalledWith(true)
+			expect(mockClient2.updateTelemetryState).toHaveBeenCalledWith(true)
+		})
+	})
+
+	describe("isTelemetryEnabled", () => {
+		it("should return true if any client has telemetry enabled", () => {
+			const mockClient1 = new MockTelemetryClient()
+			const mockClient2 = new MockTelemetryClient()
+
+			mockClient1.updateTelemetryState(false)
+			mockClient2.updateTelemetryState(true)
+
+			const service = TelemetryService.createInstance([mockClient1, mockClient2])
+
+			expect(service.isTelemetryEnabled()).toBe(true)
+		})
+
+		it("should return false if no clients have telemetry enabled", () => {
+			const mockClient1 = new MockTelemetryClient()
+			const mockClient2 = new MockTelemetryClient()
+
+			mockClient1.updateTelemetryState(false)
+			mockClient2.updateTelemetryState(false)
+
+			const service = TelemetryService.createInstance([mockClient1, mockClient2])
+
+			expect(service.isTelemetryEnabled()).toBe(false)
+		})
+
+		it("should return false when service is not ready", () => {
+			const service = TelemetryService.createInstance([])
+
+			expect(service.isTelemetryEnabled()).toBe(false)
+		})
+	})
+
+	describe("setProvider", () => {
+		it("should set provider on all clients", () => {
+			const mockClient1 = new MockTelemetryClient()
+			const mockClient2 = new MockTelemetryClient()
+
+			vi.spyOn(mockClient1, "setProvider")
+			vi.spyOn(mockClient2, "setProvider")
+
+			const service = TelemetryService.createInstance([mockClient1, mockClient2])
+
+			const mockProvider = {
+				getTelemetryProperties: vi.fn(),
+			}
+
+			service.setProvider(mockProvider)
+
+			expect(mockClient1.setProvider).toHaveBeenCalledWith(mockProvider)
+			expect(mockClient2.setProvider).toHaveBeenCalledWith(mockProvider)
+		})
+	})
+})

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./BaseTelemetryClient"
 export * from "./PostHogTelemetryClient"
 export * from "./TelemetryService"
+export * from "./TelemetryQueue"


### PR DESCRIPTION
## Summary

Implements a persistent retry queue for failed telemetry events to prevent data loss during network outages or connectivity issues. The queue persists events across VSCode restarts and implements exponential backoff for retries.

Fixes #4940

## Changes

### New Features
- Added `TelemetryQueue` class with persistent storage using VSCode's globalState
- Implemented exponential backoff retry logic (1s initial, 5min max)
- Added queue size limits (1000 events max) with FIFO eviction
- Integrated queue with both PostHog and Cloud telemetry clients

### Modified Files
- **packages/telemetry/src/TelemetryQueue.ts**: Core queue implementation
- **packages/telemetry/src/BaseTelemetryClient.ts**: Added queue integration and abstract `captureWithRetry` method
- **packages/telemetry/src/PostHogTelemetryClient.ts**: Implemented retry logic and queue integration
- **packages/cloud/src/TelemetryClient.ts**: Implemented retry logic and queue integration
- **packages/telemetry/src/TelemetryService.ts**: Added queue initialization and management
- **src/extension.ts**: Initialize queue on activation, flush on deactivation
- **packages/telemetry/src/index.ts**: Export TelemetryQueue

### Tests
- Added comprehensive test coverage (99 tests total)
- **TelemetryQueue.test.ts**: 20 tests for queue functionality
- **PostHogTelemetryClient.test.ts**: Updated with queue integration tests
- **TelemetryService.test.ts**: 23 tests including queue coordination
- **TelemetryClient.test.ts**: Updated with queue integration tests

## Testing

### Automated Tests
All tests passing:
```
✓ TelemetryQueue: 20 tests
✓ PostHogTelemetryClient: 21 tests  
✓ TelemetryService: 23 tests
✓ Cloud TelemetryClient: 35 tests
Total: 99 tests passed
```

### Manual Testing Checklist
- [ ] Test network failure recovery
  1. Disconnect network
  2. Trigger telemetry events
  3. Reconnect network
  4. Verify events are sent
  
- [ ] Test extension restart with queued events
  1. Queue some events (disconnect network)
  2. Restart VSCode
  3. Verify queued events persist and retry

- [ ] Test queue size limits
  1. Generate >1000 failed events
  2. Verify oldest events are dropped (FIFO)

- [ ] Test graceful shutdown
  1. Queue some events
  2. Close VSCode
  3. Verify shutdown completes within 5 seconds

## Review Notes

### Issues Fixed During Review
1. **Console Logging**: Removed all console.warn/error statements from telemetry code
2. **Private API Access**: Removed access to PostHog's private `_events` property
3. **Error Handling**: Added proper error handling for queue initialization and shutdown
4. **Test Updates**: Updated tests to match new behavior

### Design Decisions
- **RefreshTimer Duplication**: The timer/backoff logic was intentionally duplicated from `packages/cloud/src/RefreshTimer.ts` to avoid circular dependencies between packages. This could be refactored to a shared utility package in the future.

### Success Criteria Met
✅ Events queued when network fails  
✅ Retry with exponential backoff  
✅ Queue persists across restarts  
✅ Queue has size limits (1000 events)  
✅ Graceful shutdown with timeout  
✅ User visibility via getQueueStatus  
✅ Minimal performance impact  
✅ Comprehensive test coverage  
✅ No breaking changes  
✅ Proper error handling  

## Screenshots/Recordings
N/A - Backend telemetry feature

## Related Issues
- Fixes #4940: Add persistent retry queue for failed telemetry events

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added/updated
- [x] No breaking changes
- [ ] Documentation updated (if needed)
- [x] Addressed review feedback (internal review completed)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces a persistent retry queue for telemetry events with exponential backoff, integrating with existing telemetry clients and ensuring data persistence across VSCode restarts.
> 
>   - **Behavior**:
>     - Adds `TelemetryQueue` class for persistent retry of telemetry events using VSCode's `globalState`.
>     - Implements exponential backoff for retries (1s initial, 5min max).
>     - Limits queue size to 1000 events with FIFO eviction.
>     - Integrates with `PostHogTelemetryClient` and `CloudTelemetryClient`.
>   - **Files Modified**:
>     - `TelemetryQueue.ts`: Core queue implementation.
>     - `BaseTelemetryClient.ts`, `PostHogTelemetryClient.ts`, `TelemetryClient.ts`: Add queue integration and retry logic.
>     - `TelemetryService.ts`: Manages queue initialization and shutdown.
>     - `extension.ts`: Initializes queue on activation, flushes on deactivation.
>   - **Tests**:
>     - Adds 99 tests across `TelemetryQueue.test.ts`, `PostHogTelemetryClient.test.ts`, `TelemetryService.test.ts`, and `TelemetryClient.test.ts`.
>     - Tests cover queue functionality, integration, and error handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ea718de6c543de9f79ed8c26a04c0cf72c94cea8. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->