### PR TITLE
Fix: Kill button for execute_command tool

### DIFF
--- a/src/integrations/terminal/ExecaTerminalProcess.ts
+++ b/src/integrations/terminal/ExecaTerminalProcess.ts
@@ -9,6 +9,7 @@ export class ExecaTerminalProcess extends BaseTerminalProcess {
 	private terminalRef: WeakRef<RooTerminal>
 	private aborted = false
 	private pid?: number
+	private subprocess?: ReturnType<typeof execa>
 
 	constructor(terminal: RooTerminal) {
 		super()
@@ -36,7 +37,7 @@ export class ExecaTerminalProcess extends BaseTerminalProcess {
 		try {
 			this.isHot = true
 
-			const subprocess = execa({
+			this.subprocess = execa({
 				shell: true,
 				cwd: this.terminal.getCurrentWorkingDirectory(),
 				all: true,
@@ -48,9 +49,32 @@ export class ExecaTerminalProcess extends BaseTerminalProcess {
 				},
 			})`${command}`
 
-			this.pid = subprocess.pid
-			const stream = subprocess.iterable({ from: "all", preserveNewlines: true })
-			this.terminal.setActiveStream(stream, subprocess.pid)
+			this.pid = this.subprocess.pid
+
+			// When using shell: true, the PID is for the shell, not the actual command
+			// Find the actual command PID after a small delay
+			if (this.pid) {
+				setTimeout(() => {
+					psTree(this.pid!, (err, children) => {
+						if (!err && children.length > 0) {
+							// Update PID to the first child (the actual command)
+							const actualPid = parseInt(children[0].PID)
+							this.pid = actualPid
+						}
+					})
+				}, 100)
+			}
+
+			const rawStream = this.subprocess.iterable({ from: "all", preserveNewlines: true })
+
+			// Wrap the stream to ensure all chunks are strings (execa can return Uint8Array)
+			const stream = (async function* () {
+				for await (const chunk of rawStream) {
+					yield typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk)
+				}
+			})()
+
+			this.terminal.setActiveStream(stream, this.subprocess.pid)
 
 			for await (const line of stream) {
 				if (this.aborted) {
@@ -77,7 +101,7 @@ export class ExecaTerminalProcess extends BaseTerminalProcess {
 
 					timeoutId = setTimeout(() => {
 						try {
-							subprocess.kill("SIGKILL")
+							this.subprocess?.kill("SIGKILL")
 						} catch (e) {}
 
 						resolve()
@@ -85,7 +109,7 @@ export class ExecaTerminalProcess extends BaseTerminalProcess {
 				})
 
 				try {
-					await Promise.race([subprocess, kill])
+					await Promise.race([this.subprocess, kill])
 				} catch (error) {
 					console.log(
 						`[ExecaTerminalProcess#run] subprocess termination error: ${error instanceof Error ? error.message : String(error)}`,
@@ -116,6 +140,7 @@ export class ExecaTerminalProcess extends BaseTerminalProcess {
 		this.stopHotTimer()
 		this.emit("completed", this.fullOutput)
 		this.emit("continue")
+		this.subprocess = undefined
 	}
 
 	public override continue() {
@@ -127,7 +152,24 @@ export class ExecaTerminalProcess extends BaseTerminalProcess {
 	public override abort() {
 		this.aborted = true
 
+		// Try to kill using the subprocess object
+		if (this.subprocess) {
+			try {
+				this.subprocess.kill("SIGKILL")
+			} catch (e) {
+				// Ignore errors, will try direct kill below
+			}
+		}
+
+		// Kill the stored PID (which should be the actual command after our update)
 		if (this.pid) {
+			try {
+				process.kill(this.pid, "SIGKILL")
+			} catch (e) {
+				// Process might already be dead
+			}
+
+			// Also check for any child processes
 			psTree(this.pid, async (err, children) => {
 				if (!err) {
 					const pids = children.map((p) => parseInt(p.PID))
@@ -148,15 +190,6 @@ export class ExecaTerminalProcess extends BaseTerminalProcess {
 					)
 				}
 			})
-
-			try {
-				console.error(`[ExecaTerminalProcess#abort] SIGKILL parent -> ${this.pid}`)
-				process.kill(this.pid, "SIGKILL")
-			} catch (e) {
-				console.warn(
-					`[ExecaTerminalProcess#abort] Failed to send SIGKILL to main PID ${this.pid}: ${e instanceof Error ? e.message : String(e)}`,
-				)
-			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes the kill button (skull icon) functionality for commands executed via the `execute_command` tool.

## Problem

When using `shell: true` with execa, the PID returned is for the shell process, not the actual command. The shell often exits immediately after spawning the command, leaving us with an invalid PID when trying to kill the process.

## Solution

1. Store the subprocess reference as an instance variable to enable `subprocess.kill()`
2. After spawning, use psTree to find child processes and update the PID to the actual command
3. In `abort()`, try both `subprocess.kill()` and direct `process.kill()` on the updated PID
4. Add stream wrapper to handle TypeScript types (execa can return string or Uint8Array)

## Testing

Tested with long-running commands like `sleep 60` - the kill button now successfully terminates the process.

## Related

This issue seems to have been introduced in PR #3136 which switched from AbortController to manual process killing.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes kill button in `ExecaTerminalProcess` by updating PID to actual command's PID and ensuring proper process termination.
> 
>   - **Behavior**:
>     - Fixes kill button functionality in `ExecaTerminalProcess` by updating PID to actual command's PID using `psTree`.
>     - In `abort()`, attempts to kill both subprocess and updated PID.
>     - Adds stream wrapper to ensure all chunks are strings.
>   - **Implementation**:
>     - Stores subprocess reference as an instance variable for direct `kill()` calls.
>     - Introduces `pidUpdatePromise` to handle PID updates asynchronously.
>   - **Testing**:
>     - Verified with long-running commands like `sleep 60` to ensure kill button terminates process correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ed8dcf4140862ac8a9bfcc569c532589e36b169b. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->