### PR TITLE
fix: linter not applied to locales/*/README.md

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Update contributors and format
         run: |
           pnpm update-contributors
-          npx prettier --write README.md
+          npx prettier --write README.md locales/*/README.md
           if git diff --quiet; then echo "changes=false" >> $GITHUB_OUTPUT; else echo "changes=true" >> $GITHUB_OUTPUT; fi
         id: check-changes
         env:


### PR DESCRIPTION
## Issue
Right now we run a script to auto update our contributors but our script only runs `npx prettier --write README.md` and does not apply prettier to the locales/*/README.md. The result is that we have non-linted README files in main.

This is annoying because the locales/*/README.md files are all linted on commit so when you merge main into an old branch, it lints the README on commit which pollutes the PR diff and is just annoying to have to undo. **Are other people having this problem or is it just me?!**

## Way to reproduce
Make a new branch, make some trivial edit to any locales/*/README.md file, commit, then git diff your branch.

## Change
Now we just run prettier when the script runs. This shouldn't affect any of the markdown rendering. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Applies `prettier` to `locales/*/README.md` in `update-contributors.yml` to prevent non-linted files from causing diffs.
> 
>   - **Behavior**:
>     - Applies `prettier` to `locales/*/README.md` in addition to `README.md` in `update-contributors.yml`.
>     - Prevents non-linted `README.md` files from causing diffs when merging branches.
>   - **Workflow**:
>     - Modifies `update-contributors.yml` to run `npx prettier --write README.md locales/*/README.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 322faedb24ca56af0405adc31e57017932d8a80e. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->