### PR TITLE
fix: restore message sending when clicking save button

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -1912,7 +1912,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 												appearance="primary"
 												disabled={!enableButtons}
 												className={secondaryButtonText ? "flex-1 mr-[6px]" : "flex-[2] mr-0"}
-												onClick={() => handlePrimaryButtonClick()}>
+												onClick={() => handlePrimaryButtonClick(inputValue, selectedImages)}>
 												{primaryButtonText}
 											</VSCodeButton>
 										</StandardTooltip>
@@ -1934,7 +1934,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 												appearance="secondary"
 												disabled={!enableButtons && !(isStreaming && !didClickCancel)}
 												className={isStreaming ? "flex-[2] ml-0" : "flex-1 ml-[6px]"}
-												onClick={() => handleSecondaryButtonClick()}>
+												onClick={() => handleSecondaryButtonClick(inputValue, selectedImages)}>
 												{isStreaming ? t("chat:cancel.title") : secondaryButtonText}
 											</VSCodeButton>
 										</StandardTooltip>


### PR DESCRIPTION
## Description

This PR fixes a regression introduced in #6222 where messages were no longer being sent when clicking the save button.

## Problem

PR #6222 removed the parameters from the button click handlers but didn't update the handler functions accordingly. This caused the  and  functions to receive undefined values for  and , preventing messages from being sent.

## Solution

Restored the original button click handlers to pass  and  as parameters:
- Line 1915: 
- Line 1937: 

## Testing

- ✅ TypeScript compilation passes
- ✅ All linting checks pass
- ✅ The fix ensures messages are properly sent when clicking the save button

## Related Issues

- Reverts unintended side effect from #6222
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes regression in `ChatView.tsx` to restore message sending on save button click by passing necessary parameters to click handlers.
> 
>   - **Behavior**:
>     - Fixes regression where messages were not sent on save button click in `ChatView.tsx`.
>     - Restores `handlePrimaryButtonClick` and `handleSecondaryButtonClick` to receive `inputValue` and `selectedImages` as parameters.
>   - **Testing**:
>     - TypeScript compilation and linting checks pass.
>     - Verified messages are sent correctly when save button is clicked.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for fb59cf9e9d824b94938b91be82b3ad8afc667823. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->