### PR TITLE
feat: add LiteLLM OAuth2 SSO authentication button

### DIFF
--- a/src/activate/handleUri.ts
+++ b/src/activate/handleUri.ts
@@ -35,6 +35,35 @@ export const handleUri = async (uri: vscode.Uri) => {
 			}
 			break
 		}
+		case "/litellm": {
+			const accessToken = query.get("access_token")
+			const tokenType = query.get("token_type")
+			const expiresIn = query.get("expires_in")
+			const scope = query.get("scope")
+			const error = query.get("error")
+			const errorDescription = query.get("error_description")
+
+			if (error) {
+				// Handle OAuth error
+				console.error(`LiteLLM OAuth error: ${error}`, errorDescription)
+				vscode.window.showErrorMessage(
+					`LiteLLM authentication failed: ${error}${errorDescription ? ` - ${errorDescription}` : ""}`,
+				)
+				return
+			}
+
+			if (accessToken) {
+				await visibleProvider.handleLiteLLMCallback({
+					accessToken,
+					tokenType: tokenType || "Bearer",
+					expiresIn: expiresIn ? parseInt(expiresIn, 10) : 86400,
+					scope: scope || undefined,
+				})
+			} else {
+				vscode.window.showErrorMessage("LiteLLM authentication failed: No access token received")
+			}
+			break
+		}
 		case "/auth/clerk/callback": {
 			const code = query.get("code")
 			const state = query.get("state")

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -523,6 +523,7 @@ const ApiOptions = ({
 					setApiConfigurationField={setApiConfigurationField}
 					organizationAllowList={organizationAllowList}
 					modelValidationError={modelValidationError}
+					uriScheme={uriScheme}
 				/>
 			)}
 

--- a/webview-ui/src/components/settings/providers/LiteLLM.tsx
+++ b/webview-ui/src/components/settings/providers/LiteLLM.tsx
@@ -10,6 +10,8 @@ import { vscode } from "@src/utils/vscode"
 import { useExtensionState } from "@src/context/ExtensionStateContext"
 import { useAppTranslation } from "@src/i18n/TranslationContext"
 import { Button } from "@src/components/ui"
+import { getLiteLLMAuthUrl } from "@src/oauth/urls"
+import { VSCodeButtonLink } from "@src/components/common/VSCodeButtonLink"
 
 import { inputEventTransform } from "../transforms"
 import { ModelPicker } from "../ModelPicker"
@@ -19,6 +21,7 @@ type LiteLLMProps = {
 	setApiConfigurationField: (field: keyof ProviderSettings, value: ProviderSettings[keyof ProviderSettings]) => void
 	organizationAllowList: OrganizationAllowList
 	modelValidationError?: string
+	uriScheme?: string
 }
 
 export const LiteLLM = ({
@@ -26,6 +29,7 @@ export const LiteLLM = ({
 	setApiConfigurationField,
 	organizationAllowList,
 	modelValidationError,
+	uriScheme,
 }: LiteLLMProps) => {
 	const { t } = useAppTranslation()
 	const { routerModels } = useExtensionState()
@@ -110,6 +114,15 @@ export const LiteLLM = ({
 			<div className="text-sm text-vscode-descriptionForeground -mt-2">
 				{t("settings:providers.apiKeyStorageNotice")}
 			</div>
+
+			{apiConfiguration?.litellmBaseUrl && (
+				<VSCodeButtonLink
+					href={getLiteLLMAuthUrl(apiConfiguration.litellmBaseUrl, uriScheme)}
+					style={{ width: "100%" }}
+					appearance="primary">
+					{t("settings:providers.getLiteLLMApiKey")}
+				</VSCodeButtonLink>
+			)}
 
 			<Button
 				variant="outline"

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -235,6 +235,7 @@
 		"apiKeyStorageNotice": "API keys are stored securely in VSCode's Secret Storage",
 		"glamaApiKey": "Glama API Key",
 		"getGlamaApiKey": "Get Glama API Key",
+		"getLiteLLMApiKey": "Get LiteLLM API Key via SSO",
 		"useCustomBaseUrl": "Use custom base URL",
 		"useReasoning": "Enable reasoning",
 		"useHostHeader": "Use custom Host header",

--- a/webview-ui/src/oauth/urls.ts
+++ b/webview-ui/src/oauth/urls.ts
@@ -15,3 +15,8 @@ export function getOpenRouterAuthUrl(uriScheme?: string) {
 export function getRequestyAuthUrl(uriScheme?: string) {
 	return `https://app.requesty.ai/oauth/authorize?callback_url=${getCallbackUrl("requesty", uriScheme)}`
 }
+
+export function getLiteLLMAuthUrl(baseUrl: string, uriScheme?: string) {
+	const cleanBaseUrl = baseUrl.replace(/\/+$/, "")
+	return `${cleanBaseUrl}/sso/key/generate?response_type=oauth_token&redirect_uri=${getCallbackUrl("litellm", uriScheme)}`
+}


### PR DESCRIPTION
### Related GitHub Issue

<\!-- This PR addresses LiteLLM OAuth2 SSO integration based on available LiteLLM PR #13227 -->

Closes: # <\!-- To be linked to appropriate issue if one exists -->

### Roo Code Task Context (Optional)

<\!-- This implementation was developed by analyzing LiteLLM PR #13227 and implementing the corresponding RooCode integration -->

### Description

This PR implements OAuth2 SSO integration for LiteLLM proxy authentication, enabling users to authenticate with their LiteLLM proxy via SSO and automatically configure their API key in RooCode.

**Key Implementation Details:**
- Added OAuth2 URL generation with proper `response_type=oauth_token` parameter
- Implemented VSCode extension URI callback handling for `/litellm` route
- Created `handleLiteLLMCallback()` method in ClineProvider to process OAuth responses
- Added SSO authentication button in LiteLLM settings UI that appears when base URL is configured
- Follows OAuth2 RFC 6749 standards and integrates with LiteLLM PR #13227

**Design Choices:**
- Button only appears after user enters base URL to ensure functional SSO endpoint
- Uses existing VSCodeButtonLink component for consistency with other OAuth providers
- Stores OAuth metadata (token type, expiry, scope) for future reference
- Maintains backward compatibility with manual API key entry

### Test Procedure

**Manual Testing Steps:**
1. Open RooCode settings and navigate to LiteLLM provider
2. Enter a LiteLLM base URL (e.g., `https://your-litellm-proxy.com`)
3. Verify "Get LiteLLM API Key via SSO" button appears
4. Click button and verify redirect to LiteLLM SSO page with correct parameters
5. Complete SSO authentication flow
6. Verify callback returns to RooCode with access token
7. Confirm API key is automatically configured in settings

**Testing Environment:**
- Requires LiteLLM proxy instance with SSO configured
- Should test with LiteLLM version that includes PR #13227 OAuth2 support

### Pre-Submission Checklist

- [ ] **Issue Linked**: This PR addresses LiteLLM OAuth2 integration need
- [x] **Scope**: Changes are focused on LiteLLM SSO authentication feature
- [x] **Self-Review**: Performed thorough self-review of code
- [x] **Testing**: Manual testing procedures outlined above
- [x] **Documentation Impact**: No user documentation updates required (feature is self-explanatory in UI)
- [x] **Contribution Guidelines**: Read and agree to contributor guidelines

### Screenshots / Videos

<\!-- To be added after manual testing with LiteLLM proxy instance -->

### Documentation Updates

- [x] No documentation updates are required. (Feature is intuitive through UI - button appears when base URL is configured)

### Additional Notes

This implementation is designed to work with LiteLLM proxies that have the OAuth2 SSO endpoint from [LiteLLM PR #13227](https://github.com/BerriAI/litellm/pull/13227). The feature provides a seamless authentication experience similar to other OAuth providers (OpenRouter, Glama, Requesty) already implemented in RooCode.

The OAuth flow supports:
- Standard OAuth2 token response with JSON format
- VSCode extension redirect URI scheme compatibility  
- Multiple IDE support (vscode, cursor, fleet, zed, etc.)
- Proper error handling for authentication failures

### Get in Touch

<\!-- Discord username: [to be provided if needed] -->