### PR TITLE
Fix the UI for approving chained commands

### DIFF
--- a/webview-ui/src/components/chat/CommandExecution.tsx
+++ b/webview-ui/src/components/chat/CommandExecution.tsx
@@ -192,7 +192,6 @@ export const CommandExecution = ({ executionId, text, icon, title }: CommandExec
 				</div>
 				{command && command.trim() && (
 					<CommandPatternSelector
-						command={command}
 						patterns={commandPatterns}
 						allowedCommands={allowedCommands}
 						deniedCommands={deniedCommands}

--- a/webview-ui/src/components/chat/CommandPatternSelector.tsx
+++ b/webview-ui/src/components/chat/CommandPatternSelector.tsx
@@ -11,7 +11,6 @@ interface CommandPattern {
 }
 
 interface CommandPatternSelectorProps {
-	command: string
 	patterns: CommandPattern[]
 	allowedCommands: string[]
 	deniedCommands: string[]
@@ -20,7 +19,6 @@ interface CommandPatternSelectorProps {
 }
 
 export const CommandPatternSelector: React.FC<CommandPatternSelectorProps> = ({
-	command,
 	patterns,
 	allowedCommands,
 	deniedCommands,
@@ -37,13 +35,8 @@ export const CommandPatternSelector: React.FC<CommandPatternSelectorProps> = ({
 
 	// Create a combined list with full command first, then patterns
 	const allPatterns = useMemo(() => {
-		// Trim the command to ensure consistency with extracted patterns
-		const trimmedCommand = command.trim()
-		const fullCommandPattern: CommandPattern = { pattern: trimmedCommand }
-
 		// Create a set to track unique patterns we've already seen
 		const seenPatterns = new Set<string>()
-		seenPatterns.add(trimmedCommand) // Add the trimmed full command first
 
 		// Filter out any patterns that are duplicates or are the same as the full command
 		const uniquePatterns = patterns.filter((p) => {
@@ -54,8 +47,8 @@ export const CommandPatternSelector: React.FC<CommandPatternSelectorProps> = ({
 			return true
 		})
 
-		return [fullCommandPattern, ...uniquePatterns]
-	}, [command, patterns])
+		return uniquePatterns
+	}, [patterns])
 
 	const getPatternStatus = (pattern: string): "allowed" | "denied" | "none" => {
 		if (allowedCommands.includes(pattern)) return "allowed"

--- a/webview-ui/src/components/chat/__tests__/CommandPatternSelector.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/CommandPatternSelector.spec.tsx
@@ -26,8 +26,8 @@ const TestWrapper = ({ children }: { children: React.ReactNode }) => <TooltipPro
 
 describe("CommandPatternSelector", () => {
 	const defaultProps = {
-		command: "npm install express",
 		patterns: [
+			{ pattern: "npm install express", description: "Full command" },
 			{ pattern: "npm install", description: "Install npm packages" },
 			{ pattern: "npm *", description: "Any npm command" },
 		],
@@ -51,7 +51,7 @@ describe("CommandPatternSelector", () => {
 		expect(screen.getByText("chat:commandExecution.manageCommands")).toBeInTheDocument()
 	})
 
-	it("should show full command as first pattern when expanded", () => {
+	it("should show patterns when expanded", () => {
 		render(
 			<TestWrapper>
 				<CommandPatternSelector {...defaultProps} />
@@ -62,8 +62,9 @@ describe("CommandPatternSelector", () => {
 		const expandButton = screen.getByRole("button")
 		fireEvent.click(expandButton)
 
-		// Check that the full command is shown
+		// Check that the patterns are shown
 		expect(screen.getByText("npm install express")).toBeInTheDocument()
+		expect(screen.getByText("- Full command")).toBeInTheDocument()
 	})
 
 	it("should show extracted patterns when expanded", () => {
@@ -95,9 +96,9 @@ describe("CommandPatternSelector", () => {
 		const expandButton = screen.getByRole("button")
 		fireEvent.click(expandButton)
 
-		// Click on the full command pattern
-		const fullCommandDiv = screen.getByText("npm install express").closest("div")
-		fireEvent.click(fullCommandDiv!)
+		// Click on a pattern
+		const patternDiv = screen.getByText("npm install express").closest("div")
+		fireEvent.click(patternDiv!)
 
 		// An input should appear
 		const input = screen.getByDisplayValue("npm install express") as HTMLInputElement
@@ -168,9 +169,9 @@ describe("CommandPatternSelector", () => {
 		const expandButton = screen.getByRole("button")
 		fireEvent.click(expandButton)
 
-		// Find the full command pattern row and click allow
-		const fullCommandPattern = screen.getByText("npm install express").closest(".ml-5")
-		const allowButton = fullCommandPattern?.querySelector('button[aria-label*="addToAllowed"]')
+		// Find a pattern row and click allow
+		const patternRow = screen.getByText("npm install express").closest(".ml-5")
+		const allowButton = patternRow?.querySelector('button[aria-label*="addToAllowed"]')
 		fireEvent.click(allowButton!)
 
 		// Check that the callback was called with the pattern
@@ -194,9 +195,9 @@ describe("CommandPatternSelector", () => {
 		const expandButton = screen.getByRole("button")
 		fireEvent.click(expandButton)
 
-		// Find the full command pattern row and click deny
-		const fullCommandPattern = screen.getByText("npm install express").closest(".ml-5")
-		const denyButton = fullCommandPattern?.querySelector('button[aria-label*="addToDenied"]')
+		// Find a pattern row and click deny
+		const patternRow = screen.getByText("npm install express").closest(".ml-5")
+		const denyButton = patternRow?.querySelector('button[aria-label*="addToDenied"]')
 		fireEvent.click(denyButton!)
 
 		// Check that the callback was called with the pattern
@@ -220,11 +221,11 @@ describe("CommandPatternSelector", () => {
 		const expandButton = screen.getByRole("button")
 		fireEvent.click(expandButton)
 
-		// Click on the full command pattern to edit
-		const fullCommandDiv = screen.getByText("npm install express").closest("div")
-		fireEvent.click(fullCommandDiv!)
+		// Click on a pattern to edit
+		const patternDiv = screen.getByText("npm install express").closest("div")
+		fireEvent.click(patternDiv!)
 
-		// Edit the command
+		// Edit the pattern
 		const input = screen.getByDisplayValue("npm install express") as HTMLInputElement
 		fireEvent.change(input, { target: { value: "npm install react" } })
 
@@ -254,11 +255,11 @@ describe("CommandPatternSelector", () => {
 		const expandButton = screen.getByRole("button")
 		fireEvent.click(expandButton)
 
-		// Click on the full command pattern to edit
-		const fullCommandDiv = screen.getByText("npm install express").closest("div")
-		fireEvent.click(fullCommandDiv!)
+		// Click on a pattern to edit
+		const patternDiv = screen.getByText("npm install express").closest("div")
+		fireEvent.click(patternDiv!)
 
-		// Edit the command
+		// Edit the pattern
 		const input = screen.getByDisplayValue("npm install express") as HTMLInputElement
 		fireEvent.change(input, { target: { value: "npm install react" } })
 


### PR DESCRIPTION
Before:
<img width="374" height="256" alt="Screenshot 2025-08-03 at 2 03 56 AM" src="https://github.com/user-attachments/assets/4c54e218-a44b-428f-a11c-8aa2707e3cdd" />

After:
<img width="374" height="216" alt="Screenshot 2025-08-03 at 2 03 12 AM" src="https://github.com/user-attachments/assets/692ccaf7-4ad6-49fb-8c06-ba118f789891" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor UI for command approval by removing redundant command display and enhancing pattern handling in `CommandExecution.tsx` and `CommandPatternSelector.tsx`.
> 
>   - **UI Changes**:
>     - Removed redundant `command` prop from `CommandPatternSelector` in `CommandExecution.tsx` and `CommandPatternSelector.tsx`.
>     - Updated `CommandPatternSelector` to only show unique patterns, removing full command display.
>   - **Logic Changes**:
>     - Modified `useMemo` in `CommandPatternSelector.tsx` to filter out duplicate patterns.
>     - Adjusted `handleAllowPatternChange` and `handleDenyPatternChange` in `CommandExecution.tsx` to update command lists without full command.
>   - **Tests**:
>     - Updated tests in `CommandExecution.spec.tsx` and `CommandPatternSelector.spec.tsx` to reflect UI and logic changes.
>     - Ensured tests check for individual command patterns instead of full command display.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5962f12390eae8844e89005dd18131a2d0af10b2. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->