### PR TITLE
feat: add 'onlychat' mode

### DIFF
--- a/packages/types/src/mode.ts
+++ b/packages/types/src/mode.ts
@@ -192,4 +192,14 @@ export const DEFAULT_MODES: readonly ModeConfig[] = [
 		customInstructions:
 			"Your role is to coordinate complex workflows by delegating tasks to specialized modes. As an orchestrator, you should:\n\n1. When given a complex task, break it down into logical subtasks that can be delegated to appropriate specialized modes.\n\n2. For each subtask, use the `new_task` tool to delegate. Choose the most appropriate mode for the subtask's specific goal and provide comprehensive instructions in the `message` parameter. These instructions must include:\n    *   All necessary context from the parent task or previous subtasks required to complete the work.\n    *   A clearly defined scope, specifying exactly what the subtask should accomplish.\n    *   An explicit statement that the subtask should *only* perform the work outlined in these instructions and not deviate.\n    *   An instruction for the subtask to signal completion by using the `attempt_completion` tool, providing a concise yet thorough summary of the outcome in the `result` parameter, keeping in mind that this summary will be the source of truth used to keep track of what was completed on this project.\n    *   A statement that these specific instructions supersede any conflicting general instructions the subtask's mode might have.\n\n3. Track and manage the progress of all subtasks. When a subtask is completed, analyze its results and determine the next steps.\n\n4. Help the user understand how the different subtasks fit together in the overall workflow. Provide clear reasoning about why you're delegating specific tasks to specific modes.\n\n5. When all subtasks are completed, synthesize the results and provide a comprehensive overview of what was accomplished.\n\n6. Ask clarifying questions when necessary to better understand how to break down complex tasks effectively.\n\n7. Suggest improvements to the workflow based on the results of completed subtasks.\n\nUse subtasks to maintain clarity. If a request significantly shifts focus or requires a different expertise (mode), consider creating a subtask rather than overloading the current one.",
 	},
+	{
+		slug: "onlychat",
+		name: "🗨️OnlyChat",
+		roleDefinition:
+			"You are Roo, a knowledgeable technical assistant focused on answering questions and providing information about software development, technology, and related topics.",
+		whenToUse:
+			"Use this mode for pure conversational interactions without any tool execution. Ideal for discussions, explanations, and Q&A without file operations or code changes.",
+		groups: [],
+		description: "A chat-only mode without tool execution capabilities",
+	},
 ] as const

--- a/src/core/prompts/__tests__/system-prompt.spec.ts
+++ b/src/core/prompts/__tests__/system-prompt.spec.ts
@@ -669,6 +669,38 @@ describe("SYSTEM_PROMPT", () => {
 		expect(prompt).toContain("## update_todo_list")
 	})
 
+	it("should return only roleDefinition and customInstructions for onlychat mode", async () => {
+		const onlyChatMode: ModeConfig = {
+			slug: "onlychat",
+			name: "Only Chat",
+			roleDefinition: "You are a chat-only assistant.",
+			customInstructions: "Only chat instructions.",
+			groups: ["read"] as const,
+		}
+		const customModes = [onlyChatMode]
+		const prompt = await SYSTEM_PROMPT(
+			mockContext,
+			"/test/path",
+			false, // supportsComputerUse
+			undefined, // mcpHub
+			undefined, // diffStrategy
+			undefined, // browserViewportSize
+			"onlychat", // mode
+			undefined, // customModePrompts
+			customModes, // customModes
+			undefined, // globalCustomInstructions
+			true, // diffEnabled
+			undefined, // experiments
+			false, // enableMcpServerCreation
+			undefined, // language
+			undefined, // rooIgnoreInstructions
+			undefined, // partialReadsEnabled
+		)
+		expect(prompt).toContain("You are a chat-only assistant.")
+		expect(prompt).toContain("Only chat instructions.")
+		expect(prompt).not.toContain("apply_diff")
+	})
+
 	afterAll(() => {
 		vi.restoreAllMocks()
 	})

--- a/src/core/prompts/sections/modes.ts
+++ b/src/core/prompts/sections/modes.ts
@@ -19,6 +19,7 @@ MODES
 
 - These are the currently available modes:
 ${allModes
+	.filter((mode: ModeConfig) => mode.slug !== "onlychat")
 	.map((mode: ModeConfig) => {
 		let description: string
 		if (mode.whenToUse && mode.whenToUse.trim() !== "") {

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -170,8 +170,10 @@ export const SYSTEM_PROMPT = async (
 	// Get full mode config from custom modes or fall back to built-in modes
 	const currentMode = getModeBySlug(mode, customModes) || modes.find((m) => m.slug === mode) || modes[0]
 
+	const isOnlyChatMode = currentMode.slug === "onlychat"
+
 	// If a file-based custom system prompt exists, use it
-	if (fileCustomSystemPrompt) {
+	if (fileCustomSystemPrompt || isOnlyChatMode) {
 		const { roleDefinition, baseInstructions: baseInstructionsForFile } = getModeSelection(
 			mode,
 			promptComponent,
@@ -193,7 +195,7 @@ export const SYSTEM_PROMPT = async (
 		// For file-based prompts, don't include the tool sections
 		return `${roleDefinition}
 
-${fileCustomSystemPrompt}
+${fileCustomSystemPrompt || ""}
 
 ${customInstructions}`
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: https://github.com/RooCodeInc/Roo-Code/discussions/6082

### Roo Code Task Context (Optional)

<!--
If you used Roo Code to help create this PR, you can share public task links here.
This helps reviewers understand your development process and provides additional context.
Example: https://app.roocode.com/share/task-id
-->

### Description

<!--
Briefly summarize the changes in this PR and how they address the linked issue.
The issue should cover the "what" and "why"; this section should focus on:
- The "how": key implementation details, design choices, or trade-offs made.
- Anything specific reviewers should pay attention to in this PR.
-->

This tool provides a pure chat mode that a toolless variant of the ASK mode.

It has two advantages:
1. It saves tokens
2. It leaves the entire process under user control and still integrates with VS Code for easy contextual addition.

### Test Procedure

<!--
Detail the steps to test your changes. This helps reviewers verify your work.
- How did you test this specific implementation? (e.g., unit tests, manual testing steps)
- How can reviewers reproduce your tests or verify the fix/feature?
- Include relevant testing environment details if applicable.
-->

Just switch to onlychat

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [X] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [X] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [X] **Self-Review**: I have performed a thorough self-review of my code.
- [X] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [X] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [X] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->
<img width="849" height="1387" alt="image" src="https://github.com/user-attachments/assets/3d55bb99-459e-48f2-9213-753b216a3634" />

<img width="851" height="1405" alt="image" src="https://github.com/user-attachments/assets/878cabdf-4cb8-4527-88c5-12876ac9e8e4" />

<img width="860" height="1432" alt="image" src="https://github.com/user-attachments/assets/bce3c8ae-a89a-4e7b-b0b1-c8baa4aaae0b" />



### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->

### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces `onlychat` mode as a chat-only mode without tool execution, updating system prompts and task handling to accommodate this mode.
> 
>   - **Behavior**:
>     - Adds `onlychat` mode to `mode.ts` as a chat-only mode without tool execution capabilities.
>     - In `Task.ts`, modifies task loop to break if `onlychat` mode is active, preventing tool actions.
>   - **System Prompt**:
>     - Updates `system.ts` to handle `onlychat` mode by excluding tool sections in prompts.
>     - In `system-prompt.spec.ts`, adds test to verify `onlychat` mode returns only roleDefinition and customInstructions.
>   - **Misc**:
>     - Filters out `onlychat` mode from mode listings in `modes.ts` and `sections/modes.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d3d3799ce75adb3b7d7ecd315e0bf1a73dad763d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->