### PR TITLE
Fix: Resolve Memory Leak in ChatView Virtual Scrolling Implementation

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -465,22 +465,6 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 		}
 	}, [])
 
-	useEffect(() => {
-		const cleanupInterval = setInterval(() => {
-			const cache = everVisibleMessagesTsRef.current
-			const currentMessageIds = new Set(modifiedMessages.map((m: ClineMessage) => m.ts))
-			const viewportMessages = visibleMessages.slice(Math.max(0, visibleMessages.length - 100))
-			const viewportMessageIds = new Set(viewportMessages.map((m: ClineMessage) => m.ts))
-
-			cache.forEach((_value: boolean, key: number) => {
-				if (!currentMessageIds.has(key) && !viewportMessageIds.has(key)) {
-					cache.delete(key)
-				}
-			})
-		}, 60000)
-
-		return () => clearInterval(cleanupInterval)
-	}, [modifiedMessages, visibleMessages])
 
 	useEffect(() => {
 		const prev = prevExpandedRowsRef.current
@@ -915,16 +899,6 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 	// NOTE: the VSCode window needs to be focused for this to work.
 	useMount(() => textAreaRef.current?.focus())
 
-	useDebounceEffect(
-		() => {
-			if (!isHidden && !sendingDisabled && !enableButtons) {
-				textAreaRef.current?.focus()
-			}
-		},
-		50,
-		[isHidden, sendingDisabled, enableButtons],
-	)
-
 	const visibleMessages = useMemo(() => {
 		const currentMessageCount = modifiedMessages.length
 		const startIndex = Math.max(0, currentMessageCount - 500)
@@ -990,6 +964,33 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 
 		return newVisibleMessages
 	}, [modifiedMessages])
+	
+	useEffect(() => {
+		const cleanupInterval = setInterval(() => {
+			const cache = everVisibleMessagesTsRef.current
+			const currentMessageIds = new Set(modifiedMessages.map((m: ClineMessage) => m.ts))
+			const viewportMessages = visibleMessages.slice(Math.max(0, visibleMessages.length - 100))
+			const viewportMessageIds = new Set(viewportMessages.map((m: ClineMessage) => m.ts))
+	
+			cache.forEach((_value: boolean, key: number) => {
+				if (!currentMessageIds.has(key) && !viewportMessageIds.has(key)) {
+					cache.delete(key)
+				}
+			})
+		}, 60000)
+	
+		return () => clearInterval(cleanupInterval)
+	}, [modifiedMessages, visibleMessages])
+	
+	useDebounceEffect(
+		() => {
+			if (!isHidden && !sendingDisabled && !enableButtons) {
+				textAreaRef.current?.focus()
+			}
+		},
+		50,
+		[isHidden, sendingDisabled, enableButtons],
+	)
 
 	const isReadOnlyToolAction = useCallback((message: ClineMessage | undefined) => {
 		if (message?.type === "ask") {


### PR DESCRIPTION
# Fix: Resolve Memory Leak in ChatView Virtual Scrolling Implementation

## Root Cause

The memory leak was caused by React Virtuoso rendering ALL messages below the current viewport due to `increaseViewportBy={{ bottom: Number.MAX_SAFE_INTEGER }}`. This prevented React from unmounting components and releasing memory, causing linear memory growth with conversation length.

## Changes Made

### 1. Fix infinite viewport rendering (line 1872)
- **Changed:** `increaseViewportBy` from `{ top: 3_000, bottom: Number.MAX_SAFE_INTEGER }` to `{ top: 3_000, bottom: 1000 }`
- **Reasoning:** Limits viewport to render only 1000px below current view instead of infinite, allowing React to properly unmount and garbage collect off-screen components

### 2. Optimize LRU cache configuration (lines 183-186)
- Reduced cache size from 250 to 100 entries
- Reduced TTL from 15 minutes to 5 minutes
- **Reasoning:** Smaller cache reduces memory footprint while still preventing message flickering for recently viewed messages

### 3. Implement viewport-based message filtering (lines 926-928, 982-985)
- Process only the most recent 500 messages from modifiedMessages
- Track only the last 100 messages in the viewport window
- **Reasoning:** Prevents processing and tracking of thousands of messages in long conversations, significantly reducing memory usage

### 4. Add periodic cache cleanup (lines 467-480)
- Implement 60-second interval to remove cached entries for deleted messages
- **Reasoning:** Ensures the LRU cache doesn't retain references to messages that have been removed from the conversation, preventing memory leaks from stale entries

## Impact

- Memory usage now remains bounded regardless of conversation length
- Virtual scrolling performance maintained while preventing unbounded memory growth
- Fixes issue where users experienced insane memory usage in long conversations resulting in grey screens and other major issues
*Note: Default VSCode + RooCode Scrolling up and down messages*

[Video demonstration 1](https://github.com/user-attachments/assets/c728828c-ff90-4936-a6bd-1c3419d0727d)

*Note:  VSCode Debugger + RooCode Scrolling up and down messages so memory is 3gig by default due to double vscode and the debugger*

[Video demonstration 2](https://github.com/user-attachments/assets/376de25b-0d22-4b75-b43b-f220cce4b2a1)

*Note:  Videos are sped up 4x*

---
*Developed & Implemented by The Saturn Pipeline*
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes memory leak in `ChatView` by optimizing virtual scrolling and cache management.
> 
>   - **Behavior**:
>     - Changed `increaseViewportBy` in `ChatView.tsx` from `{ top: 3_000, bottom: Number.MAX_SAFE_INTEGER }` to `{ top: 3_000, bottom: 1000 }` to limit rendering to 1000px below the viewport.
>     - Reduced LRU cache size from 250 to 100 entries and TTL from 15 to 5 minutes.
>     - Filters `modifiedMessages` to process only the most recent 500 messages and track the last 100 in the viewport.
>     - Added a 60-second interval for cache cleanup to remove entries for deleted messages.
>   - **Impact**:
>     - Memory usage is now bounded regardless of conversation length.
>     - Virtual scrolling performance is maintained while preventing unbounded memory growth.
>     - Fixes issues with high memory usage in long conversations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 17b0cc08c7306b2a6c9478a3ba9214333aa5d6ec. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->