### PR TITLE
feat: add OpenAI GPT OSS model to Cerebras providers

### DIFF
--- a/packages/types/src/providers/cerebras.ts
+++ b/packages/types/src/providers/cerebras.ts
@@ -63,4 +63,14 @@ export const cerebrasModels = {
 		description: "SOTA performance with ~1500 tokens/s",
 		supportsReasoningEffort: true,
 	},
+	"gpt-oss-120b": {
+		maxTokens: 8000,
+		contextWindow: 64000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0,
+		outputPrice: 0,
+		description:
+			"OpenAI GPT OSS model with ~2800 tokens/s\n\n• 64K context window\n• Excels at efficient reasoning across science, math, and coding",
+	},
 } as const satisfies Record<string, ModelInfo>


### PR DESCRIPTION
## Summary

Adds the new OpenAI GPT OSS (gpt-oss-120b) model to the Cerebras provider configuration.

## Details

- Model ID: `gpt-oss-120b`
- Max tokens: 8K
- Context window: 64K
- Speed: ~2800 tokens/sec
- Pricing: Free (/bin/sh)

## Notes

The model has limited tool calling support as documented in the description.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `gpt-oss-120b` model to Cerebras provider configuration in `cerebras.ts`.
> 
>   - **Model Addition**:
>     - Adds `gpt-oss-120b` to `cerebrasModels` in `cerebras.ts`.
>     - Model specs: 8K max tokens, 64K context window, ~2800 tokens/sec.
>     - Pricing: Free, no support for images or prompt cache.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0107a7b964695fb719cc5bb967caec67c496334c. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->