### PR TITLE
fix: properly handle Gemini settings with schema-level defaults

### DIFF
--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -79,6 +79,10 @@ const baseProviderSettingsSchema = z.object({
 	reasoningEffort: reasoningEffortsSchema.optional(),
 	modelMaxTokens: z.number().optional(),
 	modelMaxThinkingTokens: z.number().optional(),
+
+	// URL context and grounding (optional for most providers, required for Gemini)
+	enableUrlContext: z.boolean().optional(),
+	enableGrounding: z.boolean().optional(),
 })
 
 // Several of the providers share common model config properties.
@@ -174,8 +178,8 @@ const lmStudioSchema = baseProviderSettingsSchema.extend({
 const geminiSchema = apiModelIdProviderModelSchema.extend({
 	geminiApiKey: z.string().optional(),
 	googleGeminiBaseUrl: z.string().optional(),
-	enableUrlContext: z.boolean().optional(),
-	enableGrounding: z.boolean().optional(),
+	enableUrlContext: z.boolean(),
+	enableGrounding: z.boolean(),
 })
 
 const geminiCliSchema = apiModelIdProviderModelSchema.extend({


### PR DESCRIPTION
## Description

This PR provides a proper fix for the Gemini settings checkbox issue by addressing it at the schema/data layer rather than working around it in the UI.

## Problem

When the Gemini settings checkboxes (`enableUrlContext` and `enableGrounding`) don't exist in the saved configuration, they have an `undefined` value. This causes the Save button to not activate when toggling these checkboxes.

## Solution

This PR takes a comprehensive approach similar to commit 6aea8990:

1. **Schema Changes**:
   - Moves `enableUrlContext` and `enableGrounding` to the base schema as optional fields (available to all providers)
   - Makes these fields **required** (non-optional) for the Gemini provider specifically
   - This ensures Gemini configs always have these fields defined

2. **Migration System**:
   - Adds a migration to set default values (`true`) for existing Gemini configs
   - Cleans up these fields from non-Gemini providers where they don't belong
   - Ensures data consistency across all provider configurations

3. **Data Layer Handling**:
   - Updates `ProviderSettingsManager` to properly handle these fields
   - Ensures Gemini configs always have these fields with proper defaults
   - Removes these fields from non-Gemini providers during save/load operations

## Benefits

- **Root Cause Fix**: Addresses the undefined state at its source rather than patching the UI
- **Data Integrity**: Ensures consistent data structure for Gemini configurations
- **Type Safety**: Better TypeScript type safety with required fields for Gemini
- **Future-Proof**: Any future UI components won't need special handling for undefined states
- **Cleaner Code**: No special case handling needed in the UI layer

## Alternative Approach

This supersedes PR #6617 which attempted to fix this at the UI layer. The schema-level approach is more robust and prevents the issue from occurring in the first place.

## Testing

- Existing Gemini configurations will be migrated to have these fields set to `true` by default
- New Gemini configurations will always have these fields defined
- The Save button now properly activates when toggling these checkboxes
- Non-Gemini providers are cleaned up to not have these irrelevant fields

Fixes #6616
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix Gemini settings handling by updating schema and data layer to ensure required fields are always defined for Gemini and cleaned up for non-Gemini providers.
> 
>   - **Schema Changes**:
>     - Move `enableUrlContext` and `enableGrounding` to base schema as optional fields in `provider-settings.ts`.
>     - Make these fields required for Gemini provider in `geminiSchema`.
>   - **Migration System**:
>     - Add migration in `ProviderSettingsManager.ts` to set default values for existing Gemini configs.
>     - Remove these fields from non-Gemini providers.
>   - **Data Layer Handling**:
>     - Update `ProviderSettingsManager` to ensure Gemini configs have these fields with defaults.
>     - Clean up these fields from non-Gemini providers during save/load operations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e15ec38fa670697a129e64f3e41c4156aa02fc43. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->