### PR TITLE
Bedrock: workaround LiteLLM passthrough issues

### DIFF
--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -226,6 +226,11 @@ export class AwsBedrockHandler extends BaseProvider implements SingleCompletionH
 			// Use API key/token-based authentication if enabled and API key is set
 			clientConfig.token = { token: this.options.awsApiKey }
 			clientConfig.authSchemePreference = ["httpBearerAuth"] // Otherwise there's no end of credential problems.
+			clientConfig.requestHandler = {
+				// This should be the default anyway, but without setting something
+				// this provider fails to work with LiteLLM passthrough.
+				requestTimeout: 0,
+			}
 		} else if (this.options.awsUseProfile && this.options.awsProfile) {
 			// Use profile-based credentials if enabled and profile is set
 			clientConfig.credentials = fromIni({


### PR DESCRIPTION
Explicitly setting `requestTimeout` seems to be required for it to be possible to use the Bedrock provider with LiteLLM
Bedrock passthrough.

Example litellm config: https://gist.github.com/jr/bb8188c29719adb27565cffe45e0b5c3 Without this change trying to connect to LiteLLM using the bedrock provider with Bedrock API Key "sk-my_special_key" and custom VPC endpoint http://localhost:4000/bedrock will quickly fail. Seems like the requests are failing immediately for some reason.

I would love it if someone understood this more deeply, because it seems crazy.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `requestTimeout: 0` to `AwsBedrockHandler` in `bedrock.ts` to fix LiteLLM passthrough issues.
> 
>   - **Behavior**:
>     - Adds `requestTimeout: 0` to `clientConfig.requestHandler` in `AwsBedrockHandler` in `bedrock.ts` to ensure compatibility with LiteLLM passthrough.
>   - **Context**:
>     - Without this change, requests to LiteLLM using the Bedrock provider fail immediately.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 9228a9147843db2e377557c2af107f2e5a1b2885. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->