### PR TITLE
fix: prevent unnecessary MCP server refresh on settings save (#6772)

### DIFF
--- a/src/core/webview/__tests__/webviewMessageHandler.spec.ts
+++ b/src/core/webview/__tests__/webviewMessageHandler.spec.ts
@@ -35,6 +35,7 @@ const mockClineProvider = {
 	getCurrentCline: vi.fn(),
 	getTaskWithId: vi.fn(),
 	initClineWithHistoryItem: vi.fn(),
+	getMcpHub: vi.fn(),
 } as unknown as ClineProvider
 
 import { t } from "../../../i18n"
@@ -574,5 +575,152 @@ describe("webviewMessageHandler - message dialog preferences", () => {
 				text: "edited content",
 			})
 		})
+	})
+})
+
+describe("webviewMessageHandler - mcpEnabled", () => {
+	let mockMcpHub: any
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+
+		// Create a mock McpHub instance
+		mockMcpHub = {
+			handleMcpEnabledChange: vi.fn().mockResolvedValue(undefined),
+		}
+
+		// Mock the getMcpHub method to return our mock McpHub
+		mockClineProvider.getMcpHub = vi.fn().mockReturnValue(mockMcpHub)
+
+		// Reset the contextProxy getValue mock
+		vi.mocked(mockClineProvider.contextProxy.getValue).mockReturnValue(undefined)
+	})
+
+	it("should not refresh MCP servers when value does not change (true to true)", async () => {
+		// Setup: mcpEnabled is already true
+		vi.mocked(mockClineProvider.contextProxy.getValue).mockReturnValue(true)
+
+		// Act: Send mcpEnabled message with same value
+		await webviewMessageHandler(mockClineProvider, {
+			type: "mcpEnabled",
+			bool: true,
+		})
+
+		// Assert: handleMcpEnabledChange should not be called
+		expect(mockMcpHub.handleMcpEnabledChange).not.toHaveBeenCalled()
+		expect(mockClineProvider.contextProxy.setValue).toHaveBeenCalledWith("mcpEnabled", true)
+		expect(mockClineProvider.postStateToWebview).toHaveBeenCalled()
+	})
+
+	it("should not refresh MCP servers when value does not change (false to false)", async () => {
+		// Setup: mcpEnabled is already false
+		vi.mocked(mockClineProvider.contextProxy.getValue).mockReturnValue(false)
+
+		// Act: Send mcpEnabled message with same value
+		await webviewMessageHandler(mockClineProvider, {
+			type: "mcpEnabled",
+			bool: false,
+		})
+
+		// Assert: handleMcpEnabledChange should not be called
+		expect(mockMcpHub.handleMcpEnabledChange).not.toHaveBeenCalled()
+		expect(mockClineProvider.contextProxy.setValue).toHaveBeenCalledWith("mcpEnabled", false)
+		expect(mockClineProvider.postStateToWebview).toHaveBeenCalled()
+	})
+
+	it("should refresh MCP servers when value changes from true to false", async () => {
+		// Setup: mcpEnabled is true
+		vi.mocked(mockClineProvider.contextProxy.getValue).mockReturnValue(true)
+
+		// Act: Send mcpEnabled message with false
+		await webviewMessageHandler(mockClineProvider, {
+			type: "mcpEnabled",
+			bool: false,
+		})
+
+		// Assert: handleMcpEnabledChange should be called
+		expect(mockMcpHub.handleMcpEnabledChange).toHaveBeenCalledWith(false)
+		expect(mockClineProvider.contextProxy.setValue).toHaveBeenCalledWith("mcpEnabled", false)
+		expect(mockClineProvider.postStateToWebview).toHaveBeenCalled()
+	})
+
+	it("should refresh MCP servers when value changes from false to true", async () => {
+		// Setup: mcpEnabled is false
+		vi.mocked(mockClineProvider.contextProxy.getValue).mockReturnValue(false)
+
+		// Act: Send mcpEnabled message with true
+		await webviewMessageHandler(mockClineProvider, {
+			type: "mcpEnabled",
+			bool: true,
+		})
+
+		// Assert: handleMcpEnabledChange should be called
+		expect(mockMcpHub.handleMcpEnabledChange).toHaveBeenCalledWith(true)
+		expect(mockClineProvider.contextProxy.setValue).toHaveBeenCalledWith("mcpEnabled", true)
+		expect(mockClineProvider.postStateToWebview).toHaveBeenCalled()
+	})
+
+	it("should handle undefined values with defaults correctly", async () => {
+		// Setup: mcpEnabled is undefined (defaults to true)
+		vi.mocked(mockClineProvider.contextProxy.getValue).mockReturnValue(undefined)
+
+		// Act: Send mcpEnabled message with undefined (defaults to true)
+		await webviewMessageHandler(mockClineProvider, {
+			type: "mcpEnabled",
+			bool: undefined,
+		})
+
+		// Assert: Should use default value (true) and not trigger refresh since both are true
+		expect(mockClineProvider.contextProxy.setValue).toHaveBeenCalledWith("mcpEnabled", true)
+		expect(mockMcpHub.handleMcpEnabledChange).not.toHaveBeenCalled()
+		expect(mockClineProvider.postStateToWebview).toHaveBeenCalled()
+	})
+
+	it("should handle when mcpEnabled changes from undefined to false", async () => {
+		// Setup: mcpEnabled is undefined (defaults to true)
+		vi.mocked(mockClineProvider.contextProxy.getValue).mockReturnValue(undefined)
+
+		// Act: Send mcpEnabled message with false
+		await webviewMessageHandler(mockClineProvider, {
+			type: "mcpEnabled",
+			bool: false,
+		})
+
+		// Assert: Should trigger refresh since undefined defaults to true and we're changing to false
+		expect(mockClineProvider.contextProxy.setValue).toHaveBeenCalledWith("mcpEnabled", false)
+		expect(mockMcpHub.handleMcpEnabledChange).toHaveBeenCalledWith(false)
+		expect(mockClineProvider.postStateToWebview).toHaveBeenCalled()
+	})
+
+	it("should not call handleMcpEnabledChange when McpHub is not available", async () => {
+		// Setup: No McpHub instance available
+		mockClineProvider.getMcpHub = vi.fn().mockReturnValue(null)
+		vi.mocked(mockClineProvider.contextProxy.getValue).mockReturnValue(true)
+
+		// Act: Send mcpEnabled message with false
+		await webviewMessageHandler(mockClineProvider, {
+			type: "mcpEnabled",
+			bool: false,
+		})
+
+		// Assert: State should be updated but handleMcpEnabledChange should not be called
+		expect(mockClineProvider.contextProxy.setValue).toHaveBeenCalledWith("mcpEnabled", false)
+		expect(mockClineProvider.postStateToWebview).toHaveBeenCalled()
+		// No error should be thrown
+	})
+
+	it("should always update state even when value doesn't change", async () => {
+		// Setup: mcpEnabled is true
+		vi.mocked(mockClineProvider.contextProxy.getValue).mockReturnValue(true)
+
+		// Act: Send mcpEnabled message with same value
+		await webviewMessageHandler(mockClineProvider, {
+			type: "mcpEnabled",
+			bool: true,
+		})
+
+		// Assert: State should still be updated to ensure consistency
+		expect(mockClineProvider.contextProxy.setValue).toHaveBeenCalledWith("mcpEnabled", true)
+		expect(mockClineProvider.postStateToWebview).toHaveBeenCalled()
 	})
 })

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -900,12 +900,18 @@ export const webviewMessageHandler = async (
 		}
 		case "mcpEnabled":
 			const mcpEnabled = message.bool ?? true
+			const currentMcpEnabled = getGlobalState("mcpEnabled") ?? true
+
+			// Always update the state to ensure consistency
 			await updateGlobalState("mcpEnabled", mcpEnabled)
 
-			// Delegate MCP enable/disable logic to McpHub
-			const mcpHubInstance = provider.getMcpHub()
-			if (mcpHubInstance) {
-				await mcpHubInstance.handleMcpEnabledChange(mcpEnabled)
+			// Only refresh MCP connections if the value actually changed
+			if (currentMcpEnabled !== mcpEnabled) {
+				// Delegate MCP enable/disable logic to McpHub
+				const mcpHubInstance = provider.getMcpHub()
+				if (mcpHubInstance) {
+					await mcpHubInstance.handleMcpEnabledChange(mcpEnabled)
+				}
 			}
 
 			await provider.postStateToWebview()

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -906,6 +906,7 @@ export const webviewMessageHandler = async (
 			await updateGlobalState("mcpEnabled", mcpEnabled)
 
 			// Only refresh MCP connections if the value actually changed
+			// This prevents expensive MCP server refresh operations when saving unrelated settings
 			if (currentMcpEnabled !== mcpEnabled) {
 				// Delegate MCP enable/disable logic to McpHub
 				const mcpHubInstance = provider.getMcpHub()


### PR DESCRIPTION
## Summary

Fixes #6772 - MCP servers no longer refresh unnecessarily when saving unrelated settings.

## Problem

MCP servers were incorrectly refreshing every time any settings were saved, not just when MCP-related settings changed. This caused unnecessary reconnections and confusing notifications for users.

## Solution

Added a state comparison check in the `mcpEnabled` message handler to only trigger MCP server refresh when the value actually changes. The handler now:
1. Retrieves the current `mcpEnabled` state
2. Compares it with the new value
3. Only calls `handleMcpEnabledChange()` if the values differ
4. Always updates the state to ensure consistency

## Changes

### Modified Files
- `src/core/webview/webviewMessageHandler.ts` - Added state comparison logic to mcpEnabled handler
- `src/core/webview/__tests__/webviewMessageHandler.spec.ts` - Added comprehensive test suite for the fix

### Key Changes
```typescript
// Before: Always refreshed MCP servers
await mcpHubInstance.handleMcpEnabledChange(mcpEnabled)

// After: Only refresh when value changes
if (currentMcpEnabled !== mcpEnabled) {
    await mcpHubInstance.handleMcpEnabledChange(mcpEnabled)
}
```

## Testing

### Automated Tests
✅ Added 8 comprehensive test cases covering:
- No refresh when value doesn't change (true → true, false → false)
- Refresh when value changes (true → false, false → true)
- Handling of undefined values with defaults
- Graceful handling when McpHub is unavailable
- State consistency verification

### Manual Testing Performed
✅ **Scenario 1**: Changed non-MCP settings → No refresh notification
✅ **Scenario 2**: Toggled MCP enabled → Refresh notification appears
✅ **Scenario 3**: Multiple saves without changes → No spurious notifications

### Test Results
```
✓ webviewMessageHandler - mcpEnabled (8 tests)
  ✓ should not refresh MCP servers when value does not change (true to true)
  ✓ should not refresh MCP servers when value does not change (false to false)
  ✓ should refresh MCP servers when value changes from true to false
  ✓ should refresh MCP servers when value changes from false to true
  ✓ should handle undefined values with defaults correctly
  ✓ should handle when mcpEnabled changes from undefined to false
  ✓ should not call handleMcpEnabledChange when McpHub is not available
  ✓ should always update state even when value doesn't change

Test Suites: 1 passed, 1 total
Tests:       21 passed, 21 total
Time:        2.89s
```

## Impact

- **Bug Fixed**: Eliminates unnecessary MCP server refreshes when saving unrelated settings
- **Performance**: Reduces unnecessary reconnection overhead
- **User Experience**: Removes confusing notifications that appeared when they shouldn't
- **Backward Compatibility**: ✅ No breaking changes

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated
- [x] All tests pass
- [x] No linting errors
- [x] Changes are focused on the issue (no scope creep)
- [x] No debug logs or commented code
- [x] Manual testing completed
- [x] Backward compatibility maintained

## Related

- Fixes #6772
- Related PR: #6773 (community submission with similar approach)

## Notes for Reviewers

- The fix is minimal and focused - only 6 lines of production code changed
- The state comparison pattern is unique to this handler as other handlers don't trigger expensive operations like server refreshes
- Test coverage is comprehensive to ensure the fix works correctly in all scenarios
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes unnecessary MCP server refreshes by adding a state comparison in `mcpEnabled` handler to only refresh when the value changes.
> 
>   - **Behavior**:
>     - `mcpEnabled` handler in `webviewMessageHandler.ts` now compares current and new `mcpEnabled` values before refreshing MCP servers.
>     - Refresh only occurs if the `mcpEnabled` value changes, reducing unnecessary operations.
>   - **Testing**:
>     - Added tests in `webviewMessageHandler.spec.ts` to cover scenarios where `mcpEnabled` does not change, changes from true to false, false to true, and handles undefined values.
>     - Tests ensure no refresh occurs when `mcpEnabled` value remains the same and verify state consistency.
>   - **Impact**:
>     - Fixes unnecessary MCP server refreshes, improving performance and user experience by eliminating confusing notifications.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3b92231a77d4da48f23e90d4c22f4c782d67489e. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->