### PR TITLE
fix: Replace scrollToIndex with scrollTo to fix scroll jitter

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -1334,23 +1334,10 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 
 	const scrollToBottomSmooth = useMemo(
 		() =>
-			debounce(
-				() => {
-					const lastIndex = groupedMessages.length - 1
-					if (lastIndex >= 0) {
-						virtuosoRef.current?.scrollToIndex({
-							index: lastIndex,
-							behavior: "smooth",
-							align: "end",
-						})
-					}
-				},
-				10,
-				{
-					immediate: true,
-				},
-			),
-		[groupedMessages.length],
+			debounce(() => virtuosoRef.current?.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "smooth" }), 10, {
+				immediate: true,
+			}),
+		[],
 	)
 
 	useEffect(() => {
@@ -1362,15 +1349,11 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 	}, [scrollToBottomSmooth])
 
 	const scrollToBottomAuto = useCallback(() => {
-		const lastIndex = groupedMessages.length - 1
-		if (lastIndex >= 0) {
-			virtuosoRef.current?.scrollToIndex({
-				index: lastIndex,
-				behavior: "auto", // Instant causes crash.
-				align: "end",
-			})
-		}
-	}, [groupedMessages.length])
+		virtuosoRef.current?.scrollTo({
+			top: Number.MAX_SAFE_INTEGER,
+			behavior: "auto", // Instant causes crash.
+		})
+	}, [])
 
 	const handleSetExpandedRow = useCallback(
 		(ts: number, expand?: boolean) => {


### PR DESCRIPTION
## Summary

This PR fixes the scroll jitter issue introduced in PR #6697 by reverting only the problematic scrolling method change.

## Problem
PR #6697 introduced scroll jitter during streaming, particularly noticeable with code blocks. Through systematic testing, we identified that the change from `scrollTo` to `scrollToIndex` was the root cause.

## Solution
This PR changes only the scroll implementation back from `scrollToIndex` to `scrollTo`, keeping all memory optimizations from PR #6697 intact.

## Changes
- Replace `scrollToIndex` with `scrollTo` in both `scrollToBottomSmooth` and `scrollToBottomAuto` functions
- Remove dependency on `groupedMessages.length` from the scroll functions
- Use `Number.MAX_SAFE_INTEGER` to scroll to bottom

## Why this fixes the jitter
The `scrollToIndex` method tries to calculate and jump to specific message indices while content is rapidly changing during streaming. The `scrollTo` method with `Number.MAX_SAFE_INTEGER` simply scrolls to the bottom without tracking specific message indices, eliminating the jitter.

## Testing
Tested with streaming responses containing code blocks - no jitter observed.

## Related PRs
- Original PR with memory optimizations that introduced jitter: #6697
- PR attempting to fix scroll lock (still has jitter): #6763