### PR TITLE
Release v3.25.8

### DIFF
--- a/.changeset/v3.25.8.md
+++ b/.changeset/v3.25.8.md
@@ -1,0 +1,14 @@
+---
+"roo-cline": patch
+---
+
+- Fix: Prevent disabled MCP servers from starting processes and show correct status (#6036 by @hannesrudolph, PR by @app/roomote)
+- Fix: Handle current directory path "." correctly in codebase_search tool (#6514 by @hannesrudolph, PR by @app/roomote)
+- Fix: Trim whitespace from OpenAI base URL to fix model detection (#6559 by @vauhochzett, PR by @app/roomote)
+- Feat: Reduce Gemini 2.5 Pro minimum thinking budget to 128 (thanks @app/roomote!)
+- Fix: Improve handling of net::ERR_ABORTED errors in URL fetching (#6632 by @QuinsZouls, PR by @app/roomote)
+- Fix: Recover from error state when Qdrant becomes available (#6660 by @hannesrudolph, PR by @app/roomote)
+- Fix: Resolve memory leak in ChatView virtual scrolling implementation (thanks @xyOz-dev!)
+- Add: Swift files to fallback list (#5857 by @niteshbalusu11, #6555 by @sealad886, PR by @niteshbalusu11)
+- Feat: Clamp default model max tokens to 20% of context window (thanks @mrubens!)
+- Fix: Prevent unnecessary MCP server refresh on settings save (#6772 by @hannesrudolph, PR by @hannesrudolph)


### PR DESCRIPTION
Release preparation for v3.25.8. This PR includes the changeset and any necessary documentation updates.

## Changes included:
- Fix: Prevent disabled MCP servers from starting processes and show correct status
- Fix: Handle current directory path "." correctly in codebase_search tool
- Fix: Trim whitespace from OpenAI base URL to fix model detection
- Feat: Reduce Gemini 2.5 Pro minimum thinking budget to 128
- Fix: Improve handling of net::ERR_ABORTED errors in URL fetching
- Fix: Recover from error state when Qdrant becomes available
- Fix: Resolve memory leak in ChatView virtual scrolling implementation
- Add: Swift files to fallback list
- Revert: "Use @roo-code/cloud from npm"
- Feat: Clamp default model max tokens to 20% of context window
- Fix: Prevent unnecessary MCP server refresh on settings save
- Fix: Replace scrollToIndex with scrollTo to fix scroll jitter

This is a patch release with 12 merged PRs since v3.25.7.