### PR TITLE
Fix rounding of max tokens

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -92,7 +92,7 @@ export const getModelMaxOutputTokens = ({
 
 	// If model has explicit maxTokens, clamp it to 20% of the context window
 	if (model.maxTokens) {
-		return Math.min(model.maxTokens, model.contextWindow * 0.2)
+		return Math.min(model.maxTokens, Math.ceil(model.contextWindow * 0.2))
 	}
 
 	// For non-Anthropic formats without explicit maxTokens, return undefined


### PR DESCRIPTION
Fixes #6806
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change rounding method to `Math.ceil` in `getModelMaxOutputTokens` in `api.ts` to round up max tokens to 20% of context window.
> 
>   - **Behavior**:
>     - In `getModelMaxOutputTokens` in `api.ts`, change rounding method to `Math.ceil` for clamping `model.maxTokens` to 20% of `contextWindow`.
>     - Ensures max tokens are rounded up instead of down.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c636d247376056e378be4c051f44e1d2c415ba5e. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->