### PR TITLE
fix: use CDATA sections in XML examples to prevent parser errors (#4852)

### DIFF
--- a/src/core/diff/strategies/multi-file-search-replace.ts
+++ b/src/core/diff/strategies/multi-file-search-replace.ts
@@ -139,8 +139,7 @@ Search/Replace content:
 <file>
   <path>eg.file.py</path>
   <diff>
-    <content>
-\`\`\`
+    <content><![CDATA[
 <<<<<<< SEARCH
 def calculate_total(items):
     total = 0
@@ -152,8 +151,7 @@ def calculate_total(items):
     """Calculate total with 10% markup"""
     return sum(item * 1.1 for item in items)
 >>>>>>> REPLACE
-\`\`\`
-    </content>
+]]></content>
   </diff>
 </file>
 </args>
@@ -165,8 +163,7 @@ Search/Replace content with multi edits across multiple files:
 <file>
   <path>eg.file.py</path>
   <diff>
-    <content>
-\`\`\`
+    <content><![CDATA[
 <<<<<<< SEARCH
 def calculate_total(items):
     sum = 0
@@ -174,12 +171,10 @@ def calculate_total(items):
 def calculate_sum(items):
     sum = 0
 >>>>>>> REPLACE
-\`\`\`
-    </content>
+]]></content>
   </diff>
   <diff>
-    <content>
-\`\`\`
+    <content><![CDATA[
 <<<<<<< SEARCH
         total += item
     return total
@@ -187,15 +182,13 @@ def calculate_sum(items):
         sum += item
     return sum 
 >>>>>>> REPLACE
-\`\`\`
-    </content>
+]]></content>
   </diff>
 </file>
 <file>
   <path>eg.file2.py</path>
   <diff>
-    <content>
-\`\`\`
+    <content><![CDATA[
 <<<<<<< SEARCH
 def greet(name):
     return "Hello " + name
@@ -203,8 +196,7 @@ def greet(name):
 def greet(name):
     return f"Hello {name}!"
 >>>>>>> REPLACE
-\`\`\`
-    </content>
+]]></content>
   </diff>
 </file>
 </args>


### PR DESCRIPTION
## Related GitHub Issue

Fixes #4852

## Description

This PR fixes the root cause of the `apply_diff` tool errors on complex XML by properly escaping content in the XML examples using CDATA sections.

### The Real Problem

The XML examples in `multi-file-search-replace.ts` contained unescaped markdown backticks (```) within the XML content blocks. This caused fast-xml-parser to fail with "Cannot read properties of undefined (reading 'addChild')" errors.

### The Solution

Use CDATA sections to properly escape the content that contains special characters. This is the standard XML way to include content that might otherwise be interpreted as markup.

### Changes Made

- Updated all XML examples in `src/core/diff/strategies/multi-file-search-replace.ts` to use CDATA sections
- No fallback parser or workarounds needed - this is the proper fix

### Before
```xml
<content>
\`\`\`
<<<<<<< SEARCH
...
\`\`\`
</content>
```

### After
```xml
<content><![CDATA[
<<<<<<< SEARCH
...
]]></content>
```

This is a much cleaner solution than the fallback parser approach in PR #6774.