### PR TITLE
feat: simplify attempt_completion tool description

### DIFF
--- a/src/core/prompts/tools/__tests__/attempt-completion.spec.ts
+++ b/src/core/prompts/tools/__tests__/attempt-completion.spec.ts
@@ -56,14 +56,17 @@ describe("getAttemptCompletionDescription", () => {
 		const description = getAttemptCompletionDescription()
 
 		// Should contain core functionality
-		const coreText = "After each tool use, the user will respond with the result of that tool use"
+		const coreText = "Use this tool when the current task is complete and you're ready for the user's next request"
 		expect(description).toContain(coreText)
 
-		// Should contain the important note
-		const importantNote = "IMPORTANT NOTE: This tool CANNOT be used until you've confirmed"
-		expect(description).toContain(importantNote)
+		// Should contain the new concise instruction
+		const conciseNote = "Be ** CONCISE ** and ** DIRECT**"
+		expect(description).toContain(conciseNote)
 
 		// Should contain result parameter
 		expect(description).toContain("- result: (required)")
+
+		// Should contain the instruction about not ending with questions
+		expect(description).toContain("**DO NOT** end with questions or offers for further assistance")
 	})
 })

--- a/src/core/prompts/tools/attempt-completion.ts
+++ b/src/core/prompts/tools/attempt-completion.ts
@@ -2,10 +2,10 @@ import { ToolArgs } from "./types"
 
 export function getAttemptCompletionDescription(args?: ToolArgs): string {
 	return `## attempt_completion
-Description: After each tool use, the user will respond with the result of that tool use, i.e. if it succeeded or failed, along with any reasons for failure. Once you've received the results of tool uses and can confirm that the task is complete, use this tool to present the result of your work to the user. The user may respond with feedback if they are not satisfied with the result, which you can use to make improvements and try again.
-IMPORTANT NOTE: This tool CANNOT be used until you've confirmed from the user that any previous tool uses were successful. Failure to do so will result in code corruption and system failure. Before using this tool, you must ask yourself in <thinking></thinking> tags if you've confirmed from the user that any previous tool uses were successful. If not, then DO NOT use this tool.
+Description: Use this tool when the current task is complete and you're ready for the user's next request. This signals that you've finished the active work and are awaiting further instructions.
+
 Parameters:
-- result: (required) The result of the task. Formulate this result in a way that is final and does not require further input from the user. Don't end your result with questions or offers for further assistance.
+- result: (required) A summary of what was accomplished. Be ** CONCISE ** and ** DIRECT**. **DO NOT** end with questions or offers for further assistance.
 Usage:
 <attempt_completion>
 <result>


### PR DESCRIPTION
## Description

This PR simplifies the `attempt_completion` tool description to make it clearer and more concise for AI assistants.

## Changes Made

- **Simplified tool description**: Removed the complex warning about confirming previous tool success, which was overly verbose and potentially confusing
- **Clearer purpose**: The tool now clearly states it's for signaling task completion and readiness for the next request
- **Emphasized conciseness**: Added explicit instructions to be **CONCISE** and **DIRECT** in the result parameter
- **Removed ambiguity**: Added clear instruction to **NOT** end with questions or offers for further assistance
- **Updated tests**: Modified the test suite to match the new description requirements

## Testing

- ✅ All tests in `src/core/prompts/tools/__tests__/attempt-completion.spec.ts` pass
- ✅ All tests in the tools directory pass
- ✅ Linting checks pass
- ✅ Type checking passes

## Verification

```bash
cd src && npx vitest run core/prompts/tools/
# Result: 2 test files passed, 9 tests passed
```

## Impact

This change improves the clarity of the tool description for AI assistants, making it easier to understand when and how to use the `attempt_completion` tool. The simplified description should lead to more consistent and appropriate usage of the tool.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests updated and passing
- [x] No breaking changes