### PR TITLE
fix: Use workspacePath from instance if available in CodeIndexManager and QdrantVectorStore

### DIFF
--- a/src/services/code-index/manager.ts
+++ b/src/services/code-index/manager.ts
@@ -1,5 +1,4 @@
 import * as vscode from "vscode"
-import { getWorkspacePath } from "../../utils/path"
 import { ContextProxy } from "../../core/config/ContextProxy"
 import { VectorStoreSearchResult } from "./interfaces"
 import { IndexingState } from "./interfaces/manager"
@@ -132,7 +131,7 @@ export class CodeIndexManager {
 		}
 
 		// 3. Check if workspace is available
-		const workspacePath = this.workspacePath || getWorkspacePath()
+		const workspacePath = this.workspacePath
 		if (!workspacePath) {
 			this._stateManager.setSystemState("Standby", "No workspace folder open")
 			return { requiresRestart }

--- a/src/services/code-index/manager.ts
+++ b/src/services/code-index/manager.ts
@@ -132,7 +132,7 @@ export class CodeIndexManager {
 		}
 
 		// 3. Check if workspace is available
-		const workspacePath = getWorkspacePath()
+		const workspacePath = this.workspacePath || getWorkspacePath()
 		if (!workspacePath) {
 			this._stateManager.setSystemState("Standby", "No workspace folder open")
 			return { requiresRestart }
@@ -305,7 +305,7 @@ export class CodeIndexManager {
 		)
 
 		const ignoreInstance = ignore()
-		const workspacePath = getWorkspacePath()
+		const workspacePath = this.workspacePath
 
 		if (!workspacePath) {
 			this._stateManager.setSystemState("Standby", "")

--- a/src/services/code-index/vector-store/qdrant-client.ts
+++ b/src/services/code-index/vector-store/qdrant-client.ts
@@ -17,7 +17,7 @@ export class QdrantVectorStore implements IVectorStore {
 	private client: QdrantClient
 	private readonly collectionName: string
 	private readonly qdrantUrl: string = "http://localhost:6333"
-	private readonly workspaceRoot: string
+	private readonly workspacePath: string
 
 	/**
 	 * Creates a new Qdrant vector store
@@ -30,7 +30,7 @@ export class QdrantVectorStore implements IVectorStore {
 
 		// Store the resolved URL for our property
 		this.qdrantUrl = parsedUrl
-		this.workspaceRoot = workspacePath
+		this.workspacePath = workspacePath
 
 		try {
 			const urlObj = new URL(parsedUrl)
@@ -447,7 +447,7 @@ export class QdrantVectorStore implements IVectorStore {
 				return
 			}
 
-			const workspaceRoot = this.workspaceRoot || getWorkspacePath()
+			const workspaceRoot = this.workspacePath
 
 			// Build filters using pathSegments to match the indexed fields
 			const filters = filePaths.map((filePath) => {

--- a/src/services/code-index/vector-store/qdrant-client.ts
+++ b/src/services/code-index/vector-store/qdrant-client.ts
@@ -17,6 +17,7 @@ export class QdrantVectorStore implements IVectorStore {
 	private client: QdrantClient
 	private readonly collectionName: string
 	private readonly qdrantUrl: string = "http://localhost:6333"
+	private readonly workspaceRoot: string
 
 	/**
 	 * Creates a new Qdrant vector store
@@ -29,6 +30,7 @@ export class QdrantVectorStore implements IVectorStore {
 
 		// Store the resolved URL for our property
 		this.qdrantUrl = parsedUrl
+		this.workspaceRoot = workspacePath
 
 		try {
 			const urlObj = new URL(parsedUrl)
@@ -445,7 +447,7 @@ export class QdrantVectorStore implements IVectorStore {
 				return
 			}
 
-			const workspaceRoot = getWorkspacePath()
+			const workspaceRoot = this.workspaceRoot || getWorkspacePath()
 
 			// Build filters using pathSegments to match the indexed fields
 			const filters = filePaths.map((filePath) => {


### PR DESCRIPTION
https://github.com/RooCodeInc/Roo-Code/issues/6897

In multi-folder workspaces, mimic the history and index status, binding the dialog to the CWD when creating a new ChatView. This will prevent CWD switching during a conversation and further confusion.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Use instance-specific `workspacePath` in `CodeIndexManager` and `QdrantVectorStore` to ensure consistent workspace handling.
> 
>   - **Behavior**:
>     - In `CodeIndexManager`, use `this.workspacePath` if available instead of `getWorkspacePath()` in `initialize()` and `_recreateServices()`.
>     - In `QdrantVectorStore`, use `this.workspaceRoot` if available instead of `getWorkspacePath()` in `deletePointsByMultipleFilePaths()`.
>   - **Classes**:
>     - Add `workspaceRoot` property to `QdrantVectorStore` to store the workspace path.
>   - **Misc**:
>     - Ensures consistent workspace path usage in multi-folder workspaces to prevent CWD switching during operations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 58b0b64178914b03ced5ff1e78adcffc7a2b9c23. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->