### PR TITLE
fix: reset condensing state when switching tasks

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -434,9 +434,12 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 	}, [messages.length])
 
 	useEffect(() => {
+		// Reset UI states
 		setExpandedRows({})
 		everVisibleMessagesTsRef.current.clear() // Clear for new task
 		setCurrentFollowUpTs(null) // Clear follow-up answered state for new task
+		setIsCondensing(false) // Reset condensing state when switching tasks
+		// Note: sendingDisabled is not reset here as it's managed by message effects
 
 		// Clear any pending auto-approval timeout from previous task
 		if (autoApproveTimeoutRef.current) {


### PR DESCRIPTION
### Related GitHub Issue

Closes: #6919

### Roo Code Task Context (Optional)

N/A

### Description

This PR fixes a UI state management issue where the context condensing indicator persists incorrectly when switching between tasks.

The fix adds `setIsCondensing(false)` to the task switching effect in `ChatView.tsx`, ensuring the condensing state is properly reset when users switch tasks. The change is minimal and focused - just one line of code with appropriate comments.

### Test Procedure

1. Open any task in Roo Code with sufficient context
2. Click the context condensing button (fold icon) 
3. While condensing is in progress (showing "正在智能压缩上下文..."), switch to another task
4. Verify the condensing indicator does NOT appear on the new task
5. Confirm the fix by switching between multiple tasks during condensing operations

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [ ] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

N/A - This is a state management fix with no visual UI changes, only behavioral correction.

### Documentation Updates

- [x] No documentation updates are required.
- [ ] Yes, documentation updates are required.

### Additional Notes

- Single line fix in `webview-ui/src/components/chat/ChatView.tsx` (line 440)
- Added explanatory comment about not resetting `sendingDisabled` 
- Grouped with other UI state resets for code organization
- This prevents user confusion when the condensing indicator appears on unrelated tasks

### Get in Touch

N/A - Available via GitHub @f14XuanLv

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes UI state issue in `ChatView.tsx` by resetting `isCondensing` when switching tasks to prevent indicator persistence.
> 
>   - **Behavior**:
>     - Fixes UI state issue in `ChatView.tsx` by resetting `isCondensing` to `false` when switching tasks.
>     - Ensures condensing indicator does not persist on new tasks after switching.
>   - **Code Changes**:
>     - Adds `setIsCondensing(false)` in the task switching `useEffect` in `ChatView.tsx`.
>     - Includes a comment explaining why `sendingDisabled` is not reset.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 872bf4ad5b1eb3c97a3c21e16e1c206ba7ffe0fe. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->