### PR TITLE
Fix allowedMaxRequests and allowedMaxCost values not showing in the settings UI

### DIFF
--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -629,6 +629,8 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 							alwaysAllowUpdateTodoList={alwaysAllowUpdateTodoList}
 							followupAutoApproveTimeoutMs={followupAutoApproveTimeoutMs}
 							allowedCommands={allowedCommands}
+							allowedMaxRequests={allowedMaxRequests ?? undefined}
+							allowedMaxCost={allowedMaxCost ?? undefined}
 							deniedCommands={deniedCommands}
 							setCachedStateField={setCachedStateField}
 						/>


### PR DESCRIPTION
Kilo Code issue: https://github.com/Kilo-Org/kilocode/issues/1880

### Description

Relevant properties were not set on AutoApproveSettings, causes the value to be saved but not shown.

### Test Procedure

Open settings, edit allowedMaxRequests and allowedMaxCost and verify the values stay on-screen when the inputs lose focus.

### Get in Touch

Christiaan in shared Slack
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes display issue for `allowedMaxRequests` and `allowedMaxCost` in settings UI by ensuring proper value assignment in `SettingsView.tsx`.
> 
>   - **Behavior**:
>     - Fixes issue where `allowedMaxRequests` and `allowedMaxCost` values were not displayed in the settings UI.
>     - Ensures these values are set to `undefined` if not provided, preventing display issues.
>   - **Code Changes**:
>     - Updates `SettingsView` in `SettingsView.tsx` to include `allowedMaxRequests` and `allowedMaxCost` with fallback to `undefined`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 9340758c392ff40dfbf5953e34184728ba0df2ee. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->