### PR TITLE
Remove deprecated GPT-4.5 Preview model

### DIFF
--- a/packages/types/src/providers/openai.ts
+++ b/packages/types/src/providers/openai.ts
@@ -193,15 +193,6 @@ export const openAiNativeModels = {
 		outputPrice: 4.4,
 		cacheReadsPrice: 0.55,
 	},
-	"gpt-4.5-preview": {
-		maxTokens: 16_384,
-		contextWindow: 128_000,
-		supportsImages: true,
-		supportsPromptCache: true,
-		inputPrice: 75,
-		outputPrice: 150,
-		cacheReadsPrice: 37.5,
-	},
 	"gpt-4o": {
 		maxTokens: 16_384,
 		contextWindow: 128_000,


### PR DESCRIPTION
### Description

Remove deprecated GPT-4.5 Preview model. It was removed from the API about a month ago.

Reference:

https://platform.openai.com/docs/models/gpt-4.5-preview

### Pre-Submission Checklist

- [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [ ] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [ ] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

### Get in Touch

Discord username: PeterDaveHello

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove deprecated `gpt-4.5-preview` model from `openai.ts`.
> 
>   - **Removal**:
>     - Removed `gpt-4.5-preview` model from `openAiNativeModels` in `openai.ts`. This model was deprecated and removed from the API.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 28a1e21e81731284619e34c7a458f55573543db7. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->