### PR TITLE
Handle bridge config fetch errors

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -982,7 +982,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	private async startTask(task?: string, images?: string[]): Promise<void> {
 		if (this.enableTaskBridge && CloudService.hasInstance()) {
 			if (!this.taskBridgeService) {
-				const bridgeConfig = await CloudService.instance.cloudAPI?.bridgeConfig()
+				const bridgeConfig = await CloudService.instance.cloudAPI?.bridgeConfig().catch(() => undefined)
 
 				if (bridgeConfig) {
 					this.taskBridgeService = await TaskBridgeService.createInstance({
@@ -1049,7 +1049,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	private async resumeTaskFromHistory() {
 		if (this.enableTaskBridge && CloudService.hasInstance()) {
 			if (!this.taskBridgeService) {
-				const bridgeConfig = await CloudService.instance.cloudAPI?.bridgeConfig()
+				const bridgeConfig = await CloudService.instance.cloudAPI?.bridgeConfig().catch(() => undefined)
 
 				if (bridgeConfig) {
 					this.taskBridgeService = await TaskBridgeService.createInstance({

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2145,7 +2145,7 @@ export class ClineProvider
 
 		const userInfo = CloudServiceImport.instance.getUserInfo()
 
-		const bridgeConfig = await CloudServiceImport.instance.cloudAPI?.bridgeConfig()
+		const bridgeConfig = await CloudServiceImport.instance.cloudAPI?.bridgeConfig().catch(() => undefined)
 
 		if (!bridgeConfig) {
 			this.log("[CloudService] Failed to get bridge config")
@@ -2166,7 +2166,7 @@ export class ClineProvider
 			if (currentTask && !currentTask.taskBridgeService && CloudService.hasInstance()) {
 				try {
 					if (!currentTask.taskBridgeService) {
-						const bridgeConfig = await CloudService.instance.cloudAPI?.bridgeConfig()
+						const bridgeConfig = await CloudService.instance.cloudAPI?.bridgeConfig().catch(() => undefined)
 
 						if (bridgeConfig) {
 							currentTask.taskBridgeService = await TaskBridgeService.createInstance({

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,7 +134,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	cloudService.on("user-info", async ({ userInfo }) => {
 		postStateListener()
 
-		const bridgeConfig = await cloudService.cloudAPI?.bridgeConfig()
+		const bridgeConfig = await cloudService.cloudAPI?.bridgeConfig().catch(() => undefined)
 
 		if (!bridgeConfig) {
 			outputChannel.appendLine("[CloudService] Failed to get bridge config")


### PR DESCRIPTION
Roo Code Cloud http errors shouldn't obstruct the extension.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add error handling for bridge configuration fetches to prevent extension obstruction in `Task.ts`, `ClineProvider.ts`, and `extension.ts`.
> 
>   - **Error Handling**:
>     - Add `.catch(() => undefined)` to `bridgeConfig()` calls in `Task.ts` (`startTask`, `resumeTaskFromHistory`) and `ClineProvider.ts` (`handleRemoteControlToggle`).
>     - Add `.catch(() => undefined)` to `bridgeConfig()` call in `extension.ts` during `user-info` event handling.
>   - **Logging**:
>     - Log error message "[CloudService] Failed to get bridge config" if `bridgeConfig()` returns undefined in `ClineProvider.ts` and `extension.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3441116050118e30cb60d1de6a7068f60ecd2e48. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->