### PR TITLE
Add minimal reasoning support to OpenRouter

### DIFF
--- a/src/api/transform/__tests__/reasoning.spec.ts
+++ b/src/api/transform/__tests__/reasoning.spec.ts
@@ -178,12 +178,8 @@ describe("reasoning.ts", () => {
 					reasoningEffort: effort,
 				}
 				const result = getOpenRouterReasoning(options)
-				// "minimal" should return undefined for OpenRouter
-				if (effort === "minimal") {
-					expect(result).toBeUndefined()
-				} else {
-					expect(result).toEqual({ effort })
-				}
+				// All effort values including "minimal" should be passed through
+				expect(result).toEqual({ effort })
 			})
 		})
 
@@ -206,8 +202,8 @@ describe("reasoning.ts", () => {
 
 			const result = getOpenRouterReasoning(options)
 
-			// "minimal" should return undefined for OpenRouter
-			expect(result).toBeUndefined()
+			// "minimal" should be passed through to OpenRouter
+			expect(result).toEqual({ effort: "minimal" })
 		})
 
 		it("should handle minimal reasoning effort from settings", () => {
@@ -229,8 +225,8 @@ describe("reasoning.ts", () => {
 
 			const result = getOpenRouterReasoning(options)
 
-			// "minimal" should return undefined for OpenRouter
-			expect(result).toBeUndefined()
+			// "minimal" should be passed through to OpenRouter
+			expect(result).toEqual({ effort: "minimal" })
 		})
 
 		it("should handle zero reasoningBudget", () => {

--- a/src/api/transform/__tests__/reasoning.spec.ts
+++ b/src/api/transform/__tests__/reasoning.spec.ts
@@ -165,7 +165,6 @@ describe("reasoning.ts", () => {
 				const modelWithEffort: ModelInfo = {
 					...baseModel,
 					supportsReasoningEffort: true,
-					reasoningEffort: effort === "minimal" ? undefined : effort,
 				}
 
 				const settingsWithEffort: ProviderSettings = {
@@ -179,7 +178,12 @@ describe("reasoning.ts", () => {
 					reasoningEffort: effort,
 				}
 				const result = getOpenRouterReasoning(options)
-				expect(result).toEqual({ effort })
+				// "minimal" should return undefined for OpenRouter
+				if (effort === "minimal") {
+					expect(result).toBeUndefined()
+				} else {
+					expect(result).toEqual({ effort })
+				}
 			})
 		})
 
@@ -202,7 +206,8 @@ describe("reasoning.ts", () => {
 
 			const result = getOpenRouterReasoning(options)
 
-			expect(result).toEqual({ effort: "minimal" })
+			// "minimal" should return undefined for OpenRouter
+			expect(result).toBeUndefined()
 		})
 
 		it("should handle minimal reasoning effort from settings", () => {
@@ -224,7 +229,8 @@ describe("reasoning.ts", () => {
 
 			const result = getOpenRouterReasoning(options)
 
-			expect(result).toEqual({ effort: "minimal" })
+			// "minimal" should return undefined for OpenRouter
+			expect(result).toBeUndefined()
 		})
 
 		it("should handle zero reasoningBudget", () => {

--- a/src/api/transform/__tests__/reasoning.spec.ts
+++ b/src/api/transform/__tests__/reasoning.spec.ts
@@ -1,6 +1,6 @@
 // npx vitest run src/api/transform/__tests__/reasoning.spec.ts
 
-import type { ModelInfo, ProviderSettings } from "@roo-code/types"
+import type { ModelInfo, ProviderSettings, ReasoningEffortWithMinimal } from "@roo-code/types"
 
 import {
 	getOpenRouterReasoning,
@@ -154,22 +154,77 @@ describe("reasoning.ts", () => {
 
 			const result = getOpenRouterReasoning(optionsWithoutEffort)
 
-			expect(result).toEqual({ effort: undefined })
+			// When reasoningEffort is undefined, the function should return undefined
+			expect(result).toBeUndefined()
 		})
 
-		it("should handle all reasoning effort values", () => {
-			const efforts: Array<"low" | "medium" | "high"> = ["low", "medium", "high"]
+		it("should handle all reasoning effort values including minimal", () => {
+			const efforts: Array<ReasoningEffortWithMinimal> = ["minimal", "low", "medium", "high"]
 
 			efforts.forEach((effort) => {
 				const modelWithEffort: ModelInfo = {
 					...baseModel,
+					supportsReasoningEffort: true,
+					reasoningEffort: effort === "minimal" ? undefined : effort,
+				}
+
+				const settingsWithEffort: ProviderSettings = {
 					reasoningEffort: effort,
 				}
 
-				const options = { ...baseOptions, model: modelWithEffort, reasoningEffort: effort }
+				const options = {
+					...baseOptions,
+					model: modelWithEffort,
+					settings: settingsWithEffort,
+					reasoningEffort: effort,
+				}
 				const result = getOpenRouterReasoning(options)
 				expect(result).toEqual({ effort })
 			})
+		})
+
+		it("should handle minimal reasoning effort specifically", () => {
+			const modelWithSupported: ModelInfo = {
+				...baseModel,
+				supportsReasoningEffort: true,
+			}
+
+			const settingsWithEffort: ProviderSettings = {
+				reasoningEffort: "minimal",
+			}
+
+			const options = {
+				...baseOptions,
+				model: modelWithSupported,
+				settings: settingsWithEffort,
+				reasoningEffort: "minimal" as ReasoningEffortWithMinimal,
+			}
+
+			const result = getOpenRouterReasoning(options)
+
+			expect(result).toEqual({ effort: "minimal" })
+		})
+
+		it("should handle minimal reasoning effort from settings", () => {
+			const modelWithSupported: ModelInfo = {
+				...baseModel,
+				supportsReasoningEffort: true,
+			}
+
+			const settingsWithMinimal: ProviderSettings = {
+				reasoningEffort: "minimal" as ReasoningEffortWithMinimal,
+			}
+
+			const options = {
+				...baseOptions,
+				model: modelWithSupported,
+				settings: settingsWithMinimal,
+				reasoningEffort: "minimal" as ReasoningEffortWithMinimal,
+			}
+
+			const result = getOpenRouterReasoning(options)
+
+			expect(result).toEqual({ effort: "minimal" })
 		})
 
 		it("should handle zero reasoningBudget", () => {

--- a/src/api/transform/reasoning.ts
+++ b/src/api/transform/reasoning.ts
@@ -34,7 +34,7 @@ export const getOpenRouterReasoning = ({
 	shouldUseReasoningBudget({ model, settings })
 		? { max_tokens: reasoningBudget }
 		: shouldUseReasoningEffort({ model, settings })
-			? reasoningEffort && reasoningEffort !== "minimal"
+			? reasoningEffort
 				? { effort: reasoningEffort }
 				: undefined
 			: undefined

--- a/src/api/transform/reasoning.ts
+++ b/src/api/transform/reasoning.ts
@@ -6,10 +6,8 @@ import type { ModelInfo, ProviderSettings, ReasoningEffortWithMinimal } from "@r
 
 import { shouldUseReasoningBudget, shouldUseReasoningEffort } from "../../shared/api"
 
-type ReasoningEffort = "minimal" | "low" | "medium" | "high"
-
 export type OpenRouterReasoningParams = {
-	effort?: ReasoningEffort
+	effort?: ReasoningEffortWithMinimal
 	max_tokens?: number
 	exclude?: boolean
 }
@@ -36,7 +34,7 @@ export const getOpenRouterReasoning = ({
 	shouldUseReasoningBudget({ model, settings })
 		? { max_tokens: reasoningBudget }
 		: shouldUseReasoningEffort({ model, settings })
-			? reasoningEffort
+			? reasoningEffort && reasoningEffort !== "minimal"
 				? { effort: reasoningEffort }
 				: undefined
 			: undefined

--- a/src/api/transform/reasoning.ts
+++ b/src/api/transform/reasoning.ts
@@ -6,7 +6,7 @@ import type { ModelInfo, ProviderSettings, ReasoningEffortWithMinimal } from "@r
 
 import { shouldUseReasoningBudget, shouldUseReasoningEffort } from "../../shared/api"
 
-type ReasoningEffort = "low" | "medium" | "high"
+type ReasoningEffort = "minimal" | "low" | "medium" | "high"
 
 export type OpenRouterReasoningParams = {
 	effort?: ReasoningEffort
@@ -36,7 +36,7 @@ export const getOpenRouterReasoning = ({
 	shouldUseReasoningBudget({ model, settings })
 		? { max_tokens: reasoningBudget }
 		: shouldUseReasoningEffort({ model, settings })
-			? reasoningEffort !== "minimal"
+			? reasoningEffort
 				? { effort: reasoningEffort }
 				: undefined
 			: undefined

--- a/webview-ui/src/components/settings/ThinkingBudget.tsx
+++ b/webview-ui/src/components/settings/ThinkingBudget.tsx
@@ -24,6 +24,17 @@ interface ThinkingBudgetProps {
 	modelInfo?: ModelInfo
 }
 
+// Helper function to determine if minimal option should be shown
+const shouldShowMinimalOption = (
+	provider: string | undefined,
+	modelId: string | undefined,
+	supportsEffort: boolean | undefined,
+): boolean => {
+	const isGpt5Model = provider === "openai-native" && modelId?.startsWith("gpt-5")
+	const isOpenRouterWithEffort = provider === "openrouter" && supportsEffort === true
+	return !!(isGpt5Model || isOpenRouterWithEffort)
+}
+
 export const ThinkingBudget = ({ apiConfiguration, setApiConfigurationField, modelInfo }: ThinkingBudgetProps) => {
 	const { t } = useAppTranslation()
 	const { id: selectedModelId } = useSelectedModel(apiConfiguration)
@@ -37,14 +48,15 @@ export const ThinkingBudget = ({ apiConfiguration, setApiConfigurationField, mod
 	const isReasoningBudgetRequired = !!modelInfo && modelInfo.requiredReasoningBudget
 	const isReasoningEffortSupported = !!modelInfo && modelInfo.supportsReasoningEffort
 
-	// Check if this is a GPT-5 model or OpenRouter to show "minimal" option
-	const isOpenAiNativeProvider = apiConfiguration.apiProvider === "openai-native"
-	const isOpenRouterProvider = apiConfiguration.apiProvider === "openrouter"
-	const isGpt5Model = isOpenAiNativeProvider && selectedModelId && selectedModelId.startsWith("gpt-5")
-	// Add "minimal" option for GPT-5 models and OpenRouter models that support reasoning effort
-	// Spread to convert readonly tuple into a mutable array, then expose as readonly for safety
+	// Determine if minimal option should be shown
+	const showMinimalOption = shouldShowMinimalOption(
+		apiConfiguration.apiProvider,
+		selectedModelId,
+		isReasoningEffortSupported,
+	)
+
+	// Build available reasoning efforts list
 	const baseEfforts = [...reasoningEfforts] as ReasoningEffortWithMinimal[]
-	const showMinimalOption = isGpt5Model || (isOpenRouterProvider && isReasoningEffortSupported)
 	const availableReasoningEfforts: ReadonlyArray<ReasoningEffortWithMinimal> = showMinimalOption
 		? (["minimal", ...baseEfforts] as ReasoningEffortWithMinimal[])
 		: baseEfforts

--- a/webview-ui/src/components/settings/ThinkingBudget.tsx
+++ b/webview-ui/src/components/settings/ThinkingBudget.tsx
@@ -32,14 +32,20 @@ export const ThinkingBudget = ({ apiConfiguration, setApiConfigurationField, mod
 	const isGemini25Pro = selectedModelId && selectedModelId.includes("gemini-2.5-pro")
 	const minThinkingTokens = isGemini25Pro ? GEMINI_25_PRO_MIN_THINKING_TOKENS : 1024
 
-	// Check if this is a GPT-5 model to show "minimal" option
-	// Only show minimal for OpenAI Native provider GPT-5 models
+	// Check model capabilities
+	const isReasoningBudgetSupported = !!modelInfo && modelInfo.supportsReasoningBudget
+	const isReasoningBudgetRequired = !!modelInfo && modelInfo.requiredReasoningBudget
+	const isReasoningEffortSupported = !!modelInfo && modelInfo.supportsReasoningEffort
+
+	// Check if this is a GPT-5 model or OpenRouter to show "minimal" option
 	const isOpenAiNativeProvider = apiConfiguration.apiProvider === "openai-native"
+	const isOpenRouterProvider = apiConfiguration.apiProvider === "openrouter"
 	const isGpt5Model = isOpenAiNativeProvider && selectedModelId && selectedModelId.startsWith("gpt-5")
-	// Add "minimal" option for GPT-5 models
+	// Add "minimal" option for GPT-5 models and OpenRouter models that support reasoning effort
 	// Spread to convert readonly tuple into a mutable array, then expose as readonly for safety
 	const baseEfforts = [...reasoningEfforts] as ReasoningEffortWithMinimal[]
-	const availableReasoningEfforts: ReadonlyArray<ReasoningEffortWithMinimal> = isGpt5Model
+	const showMinimalOption = isGpt5Model || (isOpenRouterProvider && isReasoningEffortSupported)
+	const availableReasoningEfforts: ReadonlyArray<ReasoningEffortWithMinimal> = showMinimalOption
 		? (["minimal", ...baseEfforts] as ReasoningEffortWithMinimal[])
 		: baseEfforts
 
@@ -49,10 +55,6 @@ export const ThinkingBudget = ({ apiConfiguration, setApiConfigurationField, mod
 	const defaultReasoningEffort: ReasoningEffortWithMinimal = modelDefaultReasoningEffort || "medium"
 	const currentReasoningEffort: ReasoningEffortWithMinimal =
 		(apiConfiguration.reasoningEffort as ReasoningEffortWithMinimal | undefined) || defaultReasoningEffort
-
-	const isReasoningBudgetSupported = !!modelInfo && modelInfo.supportsReasoningBudget
-	const isReasoningBudgetRequired = !!modelInfo && modelInfo.requiredReasoningBudget
-	const isReasoningEffortSupported = !!modelInfo && modelInfo.supportsReasoningEffort
 
 	// Set default reasoning effort when model supports it and no value is set
 	useEffect(() => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for 'minimal' reasoning effort in OpenRouter and update UI and tests accordingly.
> 
>   - **Behavior**:
>     - Add 'minimal' reasoning effort support in `getOpenRouterReasoning` in `reasoning.ts`.
>     - Update `ThinkingBudget.tsx` to show 'minimal' option for specific models and providers.
>   - **Tests**:
>     - Add tests for 'minimal' reasoning effort in `reasoning.spec.ts`.
>     - Ensure all reasoning effort values, including 'minimal', are handled correctly.
>   - **Types**:
>     - Extend `ReasoningEffortWithMinimal` type to include 'minimal'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 255c282cd0362d3df8cc9175b8f0c0c228c94a9f. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->