### PR TITLE
Release v3.25.14

### DIFF
--- a/.changeset/v3.25.14.md
+++ b/.changeset/v3.25.14.md
@@ -1,0 +1,7 @@
+---
+"roo-cline": patch
+---
+
+- Fix: Only include verbosity parameter for models that support it (#7054 by @eastonmeth, PR by @app/roomote)
+- Fix: AWS Bedrock 1M context - Move anthropic_beta to additionalModelRequestFields (thanks @daniel-lxs!)
+- Fix: Make cancelling requests more responsive by reverting recent changes


### PR DESCRIPTION
Release preparation for v3.25.14. This PR includes the changeset and any necessary documentation updates.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Prepare for v3.25.14 release with fixes for verbosity parameters, AWS Bedrock context, and request cancellation responsiveness.
> 
>   - **Release Preparation**:
>     - Prepare for v3.25.14 release with changeset documentation in `.changeset/v3.25.14.md`.
>   - **Fixes**:
>     - Include verbosity parameter only for models that support it.
>     - Move `anthropic_beta` to `additionalModelRequestFields` for AWS Bedrock 1M context.
>     - Improve request cancellation responsiveness by reverting recent changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1f7686a52e24365c55b83b716bcafa177b035c0d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->