### PR TITLE
fix: add /evals page to sitemap generation

### DIFF
--- a/apps/web-roo-code/next-sitemap.config.cjs
+++ b/apps/web-roo-code/next-sitemap.config.cjs
@@ -52,7 +52,13 @@ module.exports = {
   additionalPaths: async (config) => {
     // Add any additional paths that might not be automatically discovered
     // This is useful for dynamic routes or API-generated pages
-    const result = [];
+    // Add the /evals page since it's a dynamic route
+    return [{
+      loc: '/evals',
+      changefreq: 'monthly',
+      priority: 0.8,
+      lastmod: new Date().toISOString(),
+    }];
     
     // Add the /evals page since it's a dynamic route
     result.push({

--- a/apps/web-roo-code/next-sitemap.config.cjs
+++ b/apps/web-roo-code/next-sitemap.config.cjs
@@ -52,6 +52,16 @@ module.exports = {
   additionalPaths: async (config) => {
     // Add any additional paths that might not be automatically discovered
     // This is useful for dynamic routes or API-generated pages
-    return [];
+    const result = [];
+    
+    // Add the /evals page since it's a dynamic route
+    result.push({
+      loc: '/evals',
+      changefreq: 'monthly',
+      priority: 0.8,
+      lastmod: new Date().toISOString(),
+    });
+    
+    return result;
   },
 };


### PR DESCRIPTION
## Description

The `/evals` page was missing from the generated sitemap because it's a dynamic route that isn't automatically discovered by next-sitemap.

## Changes

- Updated `apps/web-roo-code/next-sitemap.config.cjs` to explicitly add the `/evals` page in the `additionalPaths` function
- Set proper priority (0.8) and change frequency (monthly) for the `/evals` page to match the configuration in the transform function

## Testing

- Ran `pnpm build` in `apps/web-roo-code`
- Verified that `/evals` is now included in the generated `public/sitemap.xml`
- Confirmed all pages are present in the sitemap:
  - `/` (homepage) - priority 1.0
  - `/enterprise` - priority 0.8
  - `/evals` - priority 0.8 ✅ (now fixed)
  - `/privacy` - priority 0.5
  - `/terms` - priority 0.5

## Related Issues

Follow-up fix to PR #6206 which implemented next-sitemap but missed the dynamic `/evals` route.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `/evals` page to sitemap generation in `next-sitemap.config.cjs` with priority 0.8 and monthly change frequency.
> 
>   - **Sitemap Configuration**:
>     - Updated `next-sitemap.config.cjs` to include `/evals` in `additionalPaths`.
>     - Set `/evals` priority to 0.8 and change frequency to monthly.
>   - **Testing**:
>     - Verified `/evals` inclusion in `public/sitemap.xml` after running `pnpm build`.
>     - Confirmed all pages have correct priorities in the sitemap.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b399af97dcb38d55ba11f8a2c4fa55e3b09c1b6b. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->