### PR TITLE
Fix terminal reuse logic

### DIFF
--- a/src/core/tools/__tests__/executeCommand.spec.ts
+++ b/src/core/tools/__tests__/executeCommand.spec.ts
@@ -213,12 +213,7 @@ describe("executeCommand", () => {
 
 			// Verify
 			expect(rejected).toBe(false)
-			expect(TerminalRegistry.getOrCreateTerminal).toHaveBeenCalledWith(
-				customCwd,
-				true, // customCwd provided
-				mockTask.taskId,
-				"vscode",
-			)
+			expect(TerminalRegistry.getOrCreateTerminal).toHaveBeenCalledWith(customCwd, mockTask.taskId, "vscode")
 			expect(result).toContain(`within working directory '${customCwd}'`)
 		})
 
@@ -248,12 +243,7 @@ describe("executeCommand", () => {
 
 			// Verify
 			expect(rejected).toBe(false)
-			expect(TerminalRegistry.getOrCreateTerminal).toHaveBeenCalledWith(
-				resolvedCwd,
-				true, // customCwd provided
-				mockTask.taskId,
-				"vscode",
-			)
+			expect(TerminalRegistry.getOrCreateTerminal).toHaveBeenCalledWith(resolvedCwd, mockTask.taskId, "vscode")
 			expect(result).toContain(`within working directory '${resolvedCwd.toPosix()}'`)
 		})
 
@@ -302,12 +292,7 @@ describe("executeCommand", () => {
 			await executeCommand(mockTask, options)
 
 			// Verify
-			expect(TerminalRegistry.getOrCreateTerminal).toHaveBeenCalledWith(
-				mockTask.cwd,
-				false, // no customCwd
-				mockTask.taskId,
-				"vscode",
-			)
+			expect(TerminalRegistry.getOrCreateTerminal).toHaveBeenCalledWith(mockTask.cwd, mockTask.taskId, "vscode")
 		})
 
 		it("should use execa provider when shell integration is disabled", async () => {
@@ -330,12 +315,7 @@ describe("executeCommand", () => {
 			await executeCommand(mockTask, options)
 
 			// Verify
-			expect(TerminalRegistry.getOrCreateTerminal).toHaveBeenCalledWith(
-				mockTask.cwd,
-				false, // no customCwd
-				mockTask.taskId,
-				"execa",
-			)
+			expect(TerminalRegistry.getOrCreateTerminal).toHaveBeenCalledWith(mockTask.cwd, mockTask.taskId, "execa")
 		})
 	})
 

--- a/src/core/tools/executeCommandTool.ts
+++ b/src/core/tools/executeCommandTool.ts
@@ -238,7 +238,7 @@ export async function executeCommand(
 		}
 	}
 
-	const terminal = await TerminalRegistry.getOrCreateTerminal(workingDir, !!customCwd, task.taskId, terminalProvider)
+	const terminal = await TerminalRegistry.getOrCreateTerminal(workingDir, task.taskId, terminalProvider)
 
 	if (terminal instanceof Terminal) {
 		terminal.terminal.show(true)

--- a/src/integrations/terminal/TerminalRegistry.ts
+++ b/src/integrations/terminal/TerminalRegistry.ts
@@ -146,13 +146,11 @@ export class TerminalRegistry {
 	 * directory.
 	 *
 	 * @param cwd The working directory path
-	 * @param requiredCwd Whether the working directory is required (if false, may reuse any non-busy terminal)
 	 * @param taskId Optional task ID to associate with the terminal
 	 * @returns A Terminal instance
 	 */
 	public static async getOrCreateTerminal(
 		cwd: string,
-		requiredCwd: boolean = false,
 		taskId?: string,
 		provider: RooTerminalProvider = "vscode",
 	): Promise<RooTerminal> {
@@ -192,12 +190,6 @@ export class TerminalRegistry {
 
 				return arePathsEqual(vscode.Uri.file(cwd).fsPath, terminalCwd)
 			})
-		}
-
-		// Third priority: Find any non-busy terminal (only if directory is not
-		// required).
-		if (!terminal && !requiredCwd) {
-			terminal = terminals.find((t) => !t.busy && t.provider === provider)
 		}
 
 		// If no suitable terminal found, create a new one.


### PR DESCRIPTION
In the words of Opus:

> Now I understand the issue. The terminal logic has a mismatch between what the prompt tells the model and what the implementation actually does:
> 
> The Problem:
> 
> The prompt tells the model that when no cwd is specified, commands will execute in the project root directory (args.cwd)
> But the implementation sets requiredCwd to false when no custom cwd is provided, which allows reusing ANY non-busy terminal regardless of its current directory
> This means a command could execute in a completely different directory than expected
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes terminal reuse logic by removing `requiredCwd` parameter, ensuring commands execute in the specified directory.
> 
>   - **Behavior**:
>     - Fixes terminal reuse logic by removing `requiredCwd` parameter in `TerminalRegistry.getOrCreateTerminal()`.
>     - Ensures commands execute in the specified directory, aligning with prompt expectations.
>   - **Tests**:
>     - Updates `executeCommand.spec.ts` to reflect changes in terminal reuse logic.
>     - Removes `requiredCwd` parameter from test cases in `executeCommand.spec.ts`.
>   - **Misc**:
>     - Removes logic for reusing any non-busy terminal in `TerminalRegistry.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 72f8c1a4e52aa1a31c6c98d3a1e90c315e571ad0. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->