### PR TITLE
refactor(storage): better fs check

### DIFF
--- a/src/utils/__tests__/storage.spec.ts
+++ b/src/utils/__tests__/storage.spec.ts
@@ -29,7 +29,7 @@ describe("getStorageBasePath - customStoragePath", () => {
 
 		expect(result).toBe(customPath)
 		expect((fsPromises as any).mkdir).toHaveBeenCalledWith(customPath, { recursive: true })
-		expect((fsPromises as any).access).toHaveBeenCalledWith(customPath, expect.any(Number))
+		expect((fsPromises as any).access).toHaveBeenCalledWith(customPath, 7) // 7 = R_OK(4) | W_OK(2) | X_OK(1)
 	})
 
 	it("falls back to default and shows an error when custom path is not writable", async () => {
@@ -62,5 +62,94 @@ describe("getStorageBasePath - customStoragePath", () => {
 		expect(showErrorSpy).toHaveBeenCalledTimes(1)
 		const firstArg = showErrorSpy.mock.calls[0][0]
 		expect(typeof firstArg).toBe("string")
+	})
+	it("returns the default path when customStoragePath is an empty string and does not touch fs", async () => {
+		vi.spyOn(vscode.workspace, "getConfiguration").mockReturnValue({
+			get: vi.fn().mockReturnValue(""),
+		} as any)
+
+		const fsPromises = await import("fs/promises")
+		const { getStorageBasePath } = await import("../storage")
+
+		const result = await getStorageBasePath(defaultPath)
+
+		expect(result).toBe(defaultPath)
+		expect((fsPromises as any).mkdir).not.toHaveBeenCalled()
+		expect((fsPromises as any).access).not.toHaveBeenCalled()
+	})
+
+	it("falls back to default when mkdir fails and does not attempt access", async () => {
+		const customPath = "/test/storage/failmkdir"
+
+		vi.spyOn(vscode.workspace, "getConfiguration").mockReturnValue({
+			get: vi.fn().mockReturnValue(customPath),
+		} as any)
+
+		const showErrorSpy = vi.spyOn(vscode.window, "showErrorMessage").mockResolvedValue(undefined as any)
+
+		const fsPromises = await import("fs/promises")
+		const { getStorageBasePath } = await import("../storage")
+
+		const mkdirMock = (fsPromises as any).mkdir as ReturnType<typeof vi.fn>
+		mkdirMock.mockImplementationOnce(async (p: string) => {
+			if (p === customPath) {
+				const err: any = new Error("EACCES: permission denied")
+				err.code = "EACCES"
+				throw err
+			}
+			return Promise.resolve()
+		})
+
+		const result = await getStorageBasePath(defaultPath)
+
+		expect(result).toBe(defaultPath)
+		expect((fsPromises as any).access).not.toHaveBeenCalled()
+		expect(showErrorSpy).toHaveBeenCalledTimes(1)
+	})
+
+	it("passes the correct permission flags (R_OK | W_OK | X_OK) to fs.access", async () => {
+		const customPath = "/test/storage/path"
+		vi.spyOn(vscode.workspace, "getConfiguration").mockReturnValue({
+			get: vi.fn().mockReturnValue(customPath),
+		} as any)
+
+		const fsPromises = await import("fs/promises")
+		const { getStorageBasePath } = await import("../storage")
+
+		await getStorageBasePath(defaultPath)
+
+		const constants = (fsPromises as any).constants
+		const expectedFlags = constants.R_OK | constants.W_OK | constants.X_OK
+
+		expect((fsPromises as any).access).toHaveBeenCalledWith(customPath, expectedFlags)
+	})
+
+	it("falls back when directory is readable but not writable (partial permissions)", async () => {
+		const customPath = "/test/storage/readonly"
+		vi.spyOn(vscode.workspace, "getConfiguration").mockReturnValue({
+			get: vi.fn().mockReturnValue(customPath),
+		} as any)
+
+		const showErrorSpy = vi.spyOn(vscode.window, "showErrorMessage").mockResolvedValue(undefined as any)
+
+		const fsPromises = await import("fs/promises")
+		const { getStorageBasePath } = await import("../storage")
+
+		const accessMock = (fsPromises as any).access as ReturnType<typeof vi.fn>
+		const constants = (fsPromises as any).constants
+		accessMock.mockImplementationOnce(async (p: string, mode?: number) => {
+			// Simulate readable (R_OK) but not writable/executable (W_OK | X_OK)
+			if (p === customPath && mode && mode & (constants.W_OK | constants.X_OK)) {
+				const err: any = new Error("EACCES: permission denied")
+				err.code = "EACCES"
+				throw err
+			}
+			return Promise.resolve()
+		})
+
+		const result = await getStorageBasePath(defaultPath)
+
+		expect(result).toBe(defaultPath)
+		expect(showErrorSpy).toHaveBeenCalledTimes(1)
 	})
 })

--- a/src/utils/__tests__/storage.spec.ts
+++ b/src/utils/__tests__/storage.spec.ts
@@ -1,0 +1,66 @@
+import * as vscode from "vscode"
+
+vi.mock("fs/promises", async () => {
+	const mod = await import("../../__mocks__/fs/promises")
+	return (mod as any).default ?? mod
+})
+
+describe("getStorageBasePath - customStoragePath", () => {
+	const defaultPath = "/test/global-storage"
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it("returns the configured custom path when it is writable", async () => {
+		const customPath = "/test/storage/path"
+		vi.spyOn(vscode.workspace, "getConfiguration").mockReturnValue({
+			get: vi.fn().mockReturnValue(customPath),
+		} as any)
+
+		const fsPromises = await import("fs/promises")
+		const { getStorageBasePath } = await import("../storage")
+
+		const result = await getStorageBasePath(defaultPath)
+
+		expect(result).toBe(customPath)
+		expect((fsPromises as any).mkdir).toHaveBeenCalledWith(customPath, { recursive: true })
+		expect((fsPromises as any).access).toHaveBeenCalledWith(customPath, expect.any(Number))
+	})
+
+	it("falls back to default and shows an error when custom path is not writable", async () => {
+		const customPath = "/test/storage/unwritable"
+
+		vi.spyOn(vscode.workspace, "getConfiguration").mockReturnValue({
+			get: vi.fn().mockReturnValue(customPath),
+		} as any)
+
+		const showErrorSpy = vi.spyOn(vscode.window, "showErrorMessage").mockResolvedValue(undefined as any)
+
+		const fsPromises = await import("fs/promises")
+		const { getStorageBasePath } = await import("../storage")
+
+		await (fsPromises as any).mkdir(customPath, { recursive: true })
+
+		const accessMock = (fsPromises as any).access as ReturnType<typeof vi.fn>
+		accessMock.mockImplementationOnce(async (p: string) => {
+			if (p === customPath) {
+				const err: any = new Error("EACCES: permission denied")
+				err.code = "EACCES"
+				throw err
+			}
+			return Promise.resolve()
+		})
+
+		const result = await getStorageBasePath(defaultPath)
+
+		expect(result).toBe(defaultPath)
+		expect(showErrorSpy).toHaveBeenCalledTimes(1)
+		const firstArg = showErrorSpy.mock.calls[0][0]
+		expect(typeof firstArg).toBe("string")
+	})
+})

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -131,7 +131,7 @@ export async function promptForCustomStoragePath(): Promise<void> {
 				try {
 					// Test if path is accessible
 					await fs.mkdir(result, { recursive: true })
-					await fs.access(result, fsConstants.W_OK | fsConstants.X_OK)
+					await fs.access(result, fsConstants.R_OK | fsConstants.W_OK | fsConstants.X_OK)
 					vscode.window.showInformationMessage(t("common:info.custom_storage_path_set", { path: result }))
 				} catch (error) {
 					vscode.window.showErrorMessage(

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode"
 import * as path from "path"
 import * as fs from "fs/promises"
+import { constants as fsConstants } from "fs"
 
 import { Package } from "../shared/package"
 import { t } from "../i18n"
@@ -32,10 +33,8 @@ export async function getStorageBasePath(defaultPath: string): Promise<string> {
 		// Ensure custom path exists
 		await fs.mkdir(customStoragePath, { recursive: true })
 
-		// Test if path is writable
-		const testFile = path.join(customStoragePath, ".write_test")
-		await fs.writeFile(testFile, "test")
-		await fs.rm(testFile)
+		// Check directory write permission without creating temp files
+		await fs.access(customStoragePath, fsConstants.R_OK | fsConstants.W_OK | fsConstants.X_OK)
 
 		return customStoragePath
 	} catch (error) {
@@ -132,6 +131,7 @@ export async function promptForCustomStoragePath(): Promise<void> {
 				try {
 					// Test if path is accessible
 					await fs.mkdir(result, { recursive: true })
+					await fs.access(result, fsConstants.W_OK | fsConstants.X_OK)
 					vscode.window.showInformationMessage(t("common:info.custom_storage_path_set", { path: result }))
 				} catch (error) {
 					vscode.window.showErrorMessage(


### PR DESCRIPTION
### Related GitHub Issue

Closes: #3788 
Closes: #7173

### Roo Code Task Context (Optional)

-

### Description

Currently we're checking if directory is writable by writing a file there and removing it, this could provide false-negative result. This PR changes it to use `fs.access` instead so it is more consistent between runs.

### Test Procedure

Tried to run some sessions with the new changes and it seems to be fixed. I also added a new test, though it currently only checks on mocked fs if `fs.access` call fails and whether or not it should default path / show warning instead of checking with the actual filesystem, not exactly sure what to do here.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

-

### Documentation Updates

-

### Additional Notes

-

### Get in Touch

@elianiva

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor directory writability check in `storage.ts` using `fs.access` and add tests in `storage.spec.ts`.
> 
>   - **Behavior**:
>     - Refactor `getStorageBasePath` in `storage.ts` to use `fs.access` for checking directory writability instead of creating and deleting a test file.
>     - Update `promptForCustomStoragePath` in `storage.ts` to use `fs.access` for path validation.
>   - **Tests**:
>     - Add tests in `storage.spec.ts` to verify behavior when custom path is writable and when it is not.
>     - Mock `fs/promises` to simulate different filesystem scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ba9264693b0559d55a7fdb29d93af51ea40c7421. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->