### PR TITLE
fix: eliminate getStorageBasePath race condition and vscode popup

### DIFF
--- a/src/utils/__tests__/storage.test.ts
+++ b/src/utils/__tests__/storage.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import * as fs from "fs/promises"
+import * as path from "path"
+import * as os from "os"
+import { getStorageBasePath } from "../storage"
+
+// Mock VSCode
+vi.mock("vscode", () => ({
+	workspace: {
+		getConfiguration: vi.fn(),
+	},
+	window: {
+		showErrorMessage: vi.fn(),
+	},
+}))
+
+// Mock i18n
+vi.mock("../../i18n", () => ({
+	t: vi.fn((key: string) => key),
+}))
+
+describe("getStorageBasePath", () => {
+	let tempDir: string
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "storage-test-"))
+		vi.clearAllMocks()
+	})
+
+	afterEach(async () => {
+		await fs.rm(tempDir, { recursive: true, force: true })
+		vi.restoreAllMocks()
+	})
+
+	it("should handle concurrent storage validations without race conditions", async () => {
+		const customPath = path.join(tempDir, "custom-storage")
+		const defaultPath = path.join(tempDir, "default-storage")
+
+		// Mock VSCode configuration to return custom path
+		const mockConfig = {
+			get: vi.fn().mockReturnValue(customPath),
+			has: vi.fn().mockReturnValue(true),
+			inspect: vi.fn(),
+			update: vi.fn(),
+		} as any
+
+		const vscode = await import("vscode")
+		vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig)
+
+		// Create the custom storage directory
+		await fs.mkdir(customPath, { recursive: true })
+
+		// Run multiple concurrent storage validations
+		const concurrentCalls = Array(10)
+			.fill(null)
+			.map(() => getStorageBasePath(defaultPath))
+
+		// All should succeed and return the custom path
+		const results = await Promise.all(concurrentCalls)
+
+		// Verify all calls succeeded
+		expect(results).toHaveLength(10)
+		results.forEach((result) => {
+			expect(result).toBe(customPath)
+		})
+
+		// Verify no leftover test files (all should be cleaned up with unique names)
+		const dirContents = await fs.readdir(customPath)
+		const testFiles = dirContents.filter((file) => file.startsWith(".write_test"))
+		expect(testFiles).toHaveLength(0)
+	})
+})

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -32,8 +32,9 @@ export async function getStorageBasePath(defaultPath: string): Promise<string> {
 		// Ensure custom path exists
 		await fs.mkdir(customStoragePath, { recursive: true })
 
-		// Test if path is writable
-		const testFile = path.join(customStoragePath, ".write_test")
+		// Test if path is writable (use unique filename to avoid race conditions)
+		const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`
+		const testFile = path.join(customStoragePath, `.write_test_${uniqueSuffix}`)
 		await fs.writeFile(testFile, "test")
 		await fs.rm(testFile)
 


### PR DESCRIPTION
### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: # [7173](https://github.com/RooCodeInc/Roo-Code/issues/7173)

### Roo Code Task Context (Optional)

N/A

### Description

When using vscode setting `roo-cline.customStoragePath` there is a race condition in getStorageBasePath().

Update getStorageBasePath() to append a random suffix to `.write_test` file to prevent a race condition where concurrent operations want to read or remove the file.

add a test to verify functionality.

### Test Procedure

```
cd src && npx vitest run utils/__tests__/storage.test.ts --reporter=verbose
```

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

n/a

### Documentation Updates

Does this PR necessitate updates to user-facing documentation?
- [x] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).

### Additional Notes

n/a

### Get in Touch

jim.weller
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix race condition in `getStorageBasePath` by appending unique suffix to test file, ensuring concurrent operations do not conflict.
> 
>   - **Behavior**:
>     - Fix race condition in `getStorageBasePath` in `storage.ts` by appending unique suffix to `.write_test` file.
>     - Ensures concurrent operations do not conflict when validating custom storage paths.
>   - **Testing**:
>     - Adds test in `storage.test.ts` to verify concurrent storage validations handle race conditions correctly.
>     - Mocks VSCode and i18n modules to simulate environment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 6f3f6eb7f45c7a287e0a5067e0db2e194bfd5d2b. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->