### PR TITLE
Show cache read and write prices for OpenRouter inference providers

### DIFF
--- a/src/api/providers/fetchers/__tests__/openrouter.spec.ts
+++ b/src/api/providers/fetchers/__tests__/openrouter.spec.ts
@@ -24,6 +24,7 @@ describe("OpenRouter API", () => {
 			const models = await getOpenRouterModels()
 
 			const openRouterSupportedCaching = Object.entries(models)
+				.filter(([id, _]) => id.startsWith("anthropic/claude") || id.startsWith("google/gemini")) // only these support cache_control breakpoints (https://openrouter.ai/docs/features/prompt-caching)
 				.filter(([_, model]) => model.supportsPromptCache)
 				.map(([id, _]) => id)
 
@@ -229,7 +230,7 @@ describe("OpenRouter API", () => {
 			const endpoints = await getOpenRouterModelEndpoints("google/gemini-2.5-pro-preview")
 
 			expect(endpoints).toEqual({
-				Google: {
+				"google-vertex": {
 					maxTokens: 65535,
 					contextWindow: 1048576,
 					supportsImages: true,
@@ -243,7 +244,7 @@ describe("OpenRouter API", () => {
 					supportsReasoningEffort: undefined,
 					supportedParameters: undefined,
 				},
-				"Google AI Studio": {
+				"google-ai-studio": {
 					maxTokens: 65536,
 					contextWindow: 1048576,
 					supportsImages: true,

--- a/src/api/providers/fetchers/openrouter.ts
+++ b/src/api/providers/fetchers/openrouter.ts
@@ -58,6 +58,7 @@ export type OpenRouterModel = z.infer<typeof openRouterModelSchema>
 
 export const openRouterModelEndpointSchema = modelRouterBaseModelSchema.extend({
 	provider_name: z.string(),
+	tag: z.string().optional(),
 })
 
 export type OpenRouterModelEndpoint = z.infer<typeof openRouterModelEndpointSchema>
@@ -149,7 +150,7 @@ export async function getOpenRouterModelEndpoints(
 		const { id, architecture, endpoints } = data
 
 		for (const endpoint of endpoints) {
-			models[endpoint.provider_name] = parseOpenRouterModel({
+			models[endpoint.tag ?? endpoint.provider_name] = parseOpenRouterModel({
 				id,
 				model: endpoint,
 				modality: architecture?.modality,
@@ -188,7 +189,7 @@ export const parseOpenRouterModel = ({
 
 	const cacheReadsPrice = model.pricing?.input_cache_read ? parseApiPrice(model.pricing?.input_cache_read) : undefined
 
-	const supportsPromptCache = typeof cacheWritesPrice !== "undefined" && typeof cacheReadsPrice !== "undefined"
+	const supportsPromptCache = typeof cacheReadsPrice !== "undefined" // some models support caching but don't charge a cacheWritesPrice, e.g. GPT-5
 
 	const modelInfo: ModelInfo = {
 		maxTokens: maxTokens || Math.ceil(model.context_length * 0.2),

--- a/webview-ui/src/components/ui/hooks/useOpenRouterModelProviders.ts
+++ b/webview-ui/src/components/ui/hooks/useOpenRouterModelProviders.ts
@@ -22,12 +22,15 @@ const openRouterEndpointsSchema = z.object({
 		endpoints: z.array(
 			z.object({
 				name: z.string(),
+				tag: z.string().optional(),
 				context_length: z.number(),
 				max_completion_tokens: z.number().nullish(),
 				pricing: z
 					.object({
 						prompt: z.union([z.string(), z.number()]).optional(),
 						completion: z.union([z.string(), z.number()]).optional(),
+						input_cache_read: z.union([z.string(), z.number()]).optional(),
+						input_cache_write: z.union([z.string(), z.number()]).optional(),
 					})
 					.optional(),
 			}),
@@ -51,47 +54,26 @@ async function getOpenRouterProvidersForModel(modelId: string) {
 			return models
 		}
 
-		const { id, description, architecture, endpoints } = result.data.data
+		const { description, architecture, endpoints } = result.data.data
 
 		for (const endpoint of endpoints) {
-			const providerName = endpoint.name.split("|")[0].trim()
+			const providerName = endpoint.tag ?? endpoint.name
 			const inputPrice = parseApiPrice(endpoint.pricing?.prompt)
 			const outputPrice = parseApiPrice(endpoint.pricing?.completion)
+			const cacheReadsPrice = parseApiPrice(endpoint.pricing?.input_cache_read)
+			const cacheWritesPrice = parseApiPrice(endpoint.pricing?.input_cache_write)
 
 			const modelInfo: OpenRouterModelProvider = {
 				maxTokens: endpoint.max_completion_tokens || endpoint.context_length,
 				contextWindow: endpoint.context_length,
 				supportsImages: architecture?.modality?.includes("image"),
-				supportsPromptCache: false,
+				supportsPromptCache: typeof cacheReadsPrice !== "undefined",
+				cacheReadsPrice,
+				cacheWritesPrice,
 				inputPrice,
 				outputPrice,
 				description,
 				label: providerName,
-			}
-
-			// TODO: This is wrong. We need to fetch the model info from
-			// OpenRouter instead of hardcoding it here. The endpoints payload
-			// doesn't include this unfortunately, so we need to get it from the
-			// main models endpoint.
-			switch (true) {
-				case modelId.startsWith("anthropic/claude-3.7-sonnet"):
-					modelInfo.supportsComputerUse = true
-					modelInfo.supportsPromptCache = true
-					modelInfo.cacheWritesPrice = 3.75
-					modelInfo.cacheReadsPrice = 0.3
-					modelInfo.maxTokens = id === "anthropic/claude-3.7-sonnet:thinking" ? 64_000 : 8192
-					break
-				case modelId.startsWith("anthropic/claude-3.5-sonnet-20240620"):
-					modelInfo.supportsPromptCache = true
-					modelInfo.cacheWritesPrice = 3.75
-					modelInfo.cacheReadsPrice = 0.3
-					modelInfo.maxTokens = 8192
-					break
-				default:
-					modelInfo.supportsPromptCache = true
-					modelInfo.cacheWritesPrice = 0.3
-					modelInfo.cacheReadsPrice = 0.03
-					break
 			}
 
 			models[providerName] = modelInfo


### PR DESCRIPTION
### Related GitHub Issue

Upstreaming some changes from Kilo Code: https://github.com/Kilo-Org/kilocode/pull/1893, https://github.com/Kilo-Org/kilocode/pull/1940

### Description

Fixes OpenRouters models that don't list a cache write price, but do support caching showing as "Does not support prompt caching" (e.g. GPT-5).

Fixes all models showing as "Supports prompt caching" when a specific inference provider is selected, even when they don't support prompt caching.

For specific inference providers, show the cache read and write prices from the OpenRouter metadata.

Use the unique tag for inference providers, rather than the non-unique provider_name.

### Test Procedure

Go into the API Providers settings, select OpenRouter and verify all displayed info is correct:
* "Supports prompt caching" label
* Cache read/write prices
* Names of inference providers are unique

### Pre-Submission Checklist

- [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

#### Before

GPT-5 shown as not supporting prompt caching even though it does:

<img width="300" height="264" alt="CleanShot 2025-08-18 at 10 57 40" src="https://github.com/user-attachments/assets/9c8689a4-115f-40e1-87bb-b463cd1e7adc" />

Qwen3 Coder with DeepInfra inference provider showing it does support prompt caching even though it doesn't:

<img width="299" height="297" alt="CleanShot 2025-08-18 at 10 59 39" src="https://github.com/user-attachments/assets/7c7f2dcd-fe2c-47ad-b8df-e53d57ffb18f" />

Inference provider list for Sonnet 4 being incomplete, because the names are not unique:

<img width="301" height="200" alt="CleanShot 2025-08-18 at 11 00 37" src="https://github.com/user-attachments/assets/0e9e2773-ec81-41f7-8ea7-85017b4126f8" />

#### After

GPT-5 shown as supporting prompt caching:

<img width="310" height="275" alt="CleanShot 2025-08-18 at 11 01 25" src="https://github.com/user-attachments/assets/062c8738-7210-45e4-8f57-30daceeaacfd" />

Qwen3 Coder with DeepInfra inference provider shown as not supporting prompt caching:

<img width="305" height="262" alt="CleanShot 2025-08-18 at 11 02 17" src="https://github.com/user-attachments/assets/c826ed17-2baf-4a3b-a2b3-5d1ca59fa9ab" />

GLM 4.5 metadata without specific inference provider selected:

<img width="300" height="263" alt="CleanShot 2025-08-18 at 11 05 13" src="https://github.com/user-attachments/assets/7edf357d-71c2-4212-bc43-47c1ab7cba3f" />

GLM 4.5 metadata with Z.AI selected as inference provider, which supports prompt caching:

<img width="300" height="281" alt="CleanShot 2025-08-18 at 11 06 00" src="https://github.com/user-attachments/assets/8ad7640d-7290-4531-b5dc-a6ec169d47f9" />

Entire list of Sonnet 4 providers shown with unique tags:

<img width="301" height="231" alt="CleanShot 2025-08-18 at 11 02 58" src="https://github.com/user-attachments/assets/46e0f1e6-d3c8-4d23-93da-6ee2ab4efce7" />

### Additional Notes

Some of the fields in the OpenRouter metadata are not documented. I have pinged our OpenRouter reps to update the docs.

### Get in Touch

Christiaan in shared Slack

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes cache support and pricing display for OpenRouter models, using unique tags for provider identification.
> 
>   - **Behavior**:
>     - Fixes incorrect cache support display for models without cache write price in `openrouter.ts`.
>     - Corrects cache support display for specific inference providers in `useOpenRouterModelProviders.ts`.
>     - Displays cache read/write prices from OpenRouter metadata in `useOpenRouterModelProviders.ts`.
>   - **Schema and Parsing**:
>     - Adds `tag` field to `openRouterModelEndpointSchema` in `openrouter.ts` and `useOpenRouterModelProviders.ts`.
>     - Updates `parseOpenRouterModel` to use `tag` for provider identification in `openrouter.ts`.
>   - **Tests**:
>     - Updates tests in `openrouter.spec.ts` to reflect changes in cache support and provider identification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4733f154504bae52cf154686c41d0a805d91bd3e. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->