### PR TITLE
Fix: Add 'roo' provider to checkExistKey function

### DIFF
--- a/src/shared/checkExistApiConfig.ts
+++ b/src/shared/checkExistApiConfig.ts
@@ -5,8 +5,8 @@ export function checkExistKey(config: ProviderSettings | undefined) {
 		return false
 	}
 
-	// Special case for human-relay, fake-ai, and claude-code providers which don't need any configuration.
-	if (config.apiProvider && ["human-relay", "fake-ai", "claude-code"].includes(config.apiProvider)) {
+	// Special case for human-relay, fake-ai, claude-code, and roo providers which don't need any configuration.
+	if (config.apiProvider && ["human-relay", "fake-ai", "claude-code", "roo"].includes(config.apiProvider)) {
 		return true
 	}
 


### PR DESCRIPTION
Fixes the 'Let's go' button not working for Roo Code Cloud provider on the welcome screen.

Added 'roo' to the special case list in checkExistApiConfig.ts since it uses cloud authentication instead of API keys.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds 'roo' to special case list in `checkExistApiConfig.ts` to fix 'Let's go' button for Roo Code Cloud provider.
> 
>   - **Behavior**:
>     - Fixes 'Let's go' button for Roo Code Cloud provider by adding 'roo' to special case list in `checkExistApiConfig.ts`.
>     - 'roo' now bypasses configuration check like 'human-relay', 'fake-ai', and 'claude-code'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a1a0f44b85163a2f6a109346e7ec7675abd03221. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->