### PR TITLE
using base URL across all requesty requests

### DIFF
--- a/src/api/providers/fetchers/modelCache.ts
+++ b/src/api/providers/fetchers/modelCache.ts
@@ -59,7 +59,7 @@ export const getModels = async (options: GetModelsOptions): Promise<ModelRecord>
 				break
 			case "requesty":
 				// Requesty models endpoint requires an API key for per-user custom policies
-				models = await getRequestyModels(options.apiKey)
+				models = await getRequestyModels(options.baseUrl, options.apiKey)
 				break
 			case "glama":
 				models = await getGlamaModels()

--- a/src/api/providers/fetchers/requesty.ts
+++ b/src/api/providers/fetchers/requesty.ts
@@ -3,8 +3,9 @@ import axios from "axios"
 import type { ModelInfo } from "@roo-code/types"
 
 import { parseApiPrice } from "../../../shared/cost"
+import { toRequestyServiceUrl } from "../../../shared/utils/requesty"
 
-export async function getRequestyModels(apiKey?: string): Promise<Record<string, ModelInfo>> {
+export async function getRequestyModels(baseUrl?: string, apiKey?: string): Promise<Record<string, ModelInfo>> {
 	const models: Record<string, ModelInfo> = {}
 
 	try {
@@ -14,8 +15,10 @@ export async function getRequestyModels(apiKey?: string): Promise<Record<string,
 			headers["Authorization"] = `Bearer ${apiKey}`
 		}
 
-		const url = "https://router.requesty.ai/v1/models"
-		const response = await axios.get(url, { headers })
+		const resolvedBaseUrl = toRequestyServiceUrl(baseUrl)
+		const modelsUrl = new URL("models", resolvedBaseUrl)
+
+		const response = await axios.get(modelsUrl.toString(), { headers })
 		const rawModels = response.data.data
 
 		for (const rawModel of rawModels) {

--- a/src/api/providers/requesty.ts
+++ b/src/api/providers/requesty.ts
@@ -15,6 +15,7 @@ import { DEFAULT_HEADERS } from "./constants"
 import { getModels } from "./fetchers/modelCache"
 import { BaseProvider } from "./base-provider"
 import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import { toRequestyServiceUrl } from "../../shared/utils/requesty"
 
 // Requesty usage includes an extra field for Anthropic use cases.
 // Safely cast the prompt token details section to the appropriate structure.
@@ -40,21 +41,23 @@ export class RequestyHandler extends BaseProvider implements SingleCompletionHan
 	protected options: ApiHandlerOptions
 	protected models: ModelRecord = {}
 	private client: OpenAI
+	private baseURL: string
 
 	constructor(options: ApiHandlerOptions) {
 		super()
 
 		this.options = options
+		this.baseURL = toRequestyServiceUrl(options.requestyBaseUrl)
 
 		this.client = new OpenAI({
-			baseURL: options.requestyBaseUrl || "https://router.requesty.ai/v1",
+			baseURL: this.baseURL,
 			apiKey: this.options.requestyApiKey ?? "not-provided",
 			defaultHeaders: DEFAULT_HEADERS,
 		})
 	}
 
 	public async fetchModel() {
-		this.models = await getModels({ provider: "requesty" })
+		this.models = await getModels({ provider: "requesty", baseUrl: this.baseURL })
 		return this.getModel()
 	}
 

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -548,7 +548,14 @@ export const webviewMessageHandler = async (
 
 			const modelFetchPromises: Array<{ key: RouterName; options: GetModelsOptions }> = [
 				{ key: "openrouter", options: { provider: "openrouter" } },
-				{ key: "requesty", options: { provider: "requesty", apiKey: apiConfiguration.requestyApiKey } },
+				{
+					key: "requesty",
+					options: {
+						provider: "requesty",
+						apiKey: apiConfiguration.requestyApiKey,
+						baseUrl: apiConfiguration.requestyBaseUrl,
+					},
+				},
 				{ key: "glama", options: { provider: "glama" } },
 				{ key: "unbound", options: { provider: "unbound", apiKey: apiConfiguration.unboundApiKey } },
 			]

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -135,7 +135,7 @@ export const getModelMaxOutputTokens = ({
 export type GetModelsOptions =
 	| { provider: "openrouter" }
 	| { provider: "glama" }
-	| { provider: "requesty"; apiKey?: string }
+	| { provider: "requesty"; apiKey?: string; baseUrl?: string }
 	| { provider: "unbound"; apiKey?: string }
 	| { provider: "litellm"; apiKey: string; baseUrl: string }
 	| { provider: "ollama"; baseUrl?: string }

--- a/src/shared/utils/requesty.ts
+++ b/src/shared/utils/requesty.ts
@@ -13,5 +13,11 @@ const replaceCname = (baseUrl: string, type: URLType): string => {
 export const toRequestyServiceUrl = (baseUrl?: string, service: URLType = "router"): string => {
 	let url = replaceCname(baseUrl ?? REQUESTY_BASE_URL, service)
 
-	return new URL(url).toString()
+	try {
+		return new URL(url).toString()
+	} catch (error) {
+		// If the provided baseUrl is invalid, fall back to the default
+		console.warn(`Invalid base URL "${baseUrl}", falling back to default`)
+		return new URL(replaceCname(REQUESTY_BASE_URL, service)).toString()
+	}
 }

--- a/src/shared/utils/requesty.ts
+++ b/src/shared/utils/requesty.ts
@@ -1,0 +1,17 @@
+const REQUESTY_BASE_URL = "https://router.requesty.ai/v1"
+
+type URLType = "router" | "app" | "api"
+
+const replaceCname = (baseUrl: string, type: URLType): string => {
+	if (type === "router") {
+		return baseUrl
+	} else {
+		return baseUrl.replace("router", type).replace("v1", "")
+	}
+}
+
+export const toRequestyServiceUrl = (baseUrl?: string, service: URLType = "router"): string => {
+	let url = replaceCname(baseUrl ?? REQUESTY_BASE_URL, service)
+
+	return new URL(url).toString()
+}

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -419,6 +419,7 @@ const ApiOptions = ({
 
 			{selectedProvider === "requesty" && (
 				<Requesty
+					uriScheme={uriScheme}
 					apiConfiguration={apiConfiguration}
 					setApiConfigurationField={setApiConfigurationField}
 					routerModels={routerModels}

--- a/webview-ui/src/components/settings/providers/Requesty.tsx
+++ b/webview-ui/src/components/settings/providers/Requesty.tsx
@@ -8,12 +8,13 @@ import type { RouterModels } from "@roo/api"
 
 import { vscode } from "@src/utils/vscode"
 import { useAppTranslation } from "@src/i18n/TranslationContext"
-import { VSCodeButtonLink } from "@src/components/common/VSCodeButtonLink"
 import { Button } from "@src/components/ui"
 
 import { inputEventTransform } from "../transforms"
 import { ModelPicker } from "../ModelPicker"
 import { RequestyBalanceDisplay } from "./RequestyBalanceDisplay"
+import { getCallbackUrl } from "@/oauth/urls"
+import { toRequestyServiceUrl } from "@roo/utils/requesty"
 
 type RequestyProps = {
 	apiConfiguration: ProviderSettings
@@ -22,6 +23,7 @@ type RequestyProps = {
 	refetchRouterModels: () => void
 	organizationAllowList: OrganizationAllowList
 	modelValidationError?: string
+	uriScheme?: string
 }
 
 export const Requesty = ({
@@ -31,6 +33,7 @@ export const Requesty = ({
 	refetchRouterModels,
 	organizationAllowList,
 	modelValidationError,
+	uriScheme,
 }: RequestyProps) => {
 	const { t } = useAppTranslation()
 
@@ -54,6 +57,15 @@ export const Requesty = ({
 		[setApiConfigurationField],
 	)
 
+	const getApiKeyUrl = () => {
+		const callbackUrl = getCallbackUrl("requesty", uriScheme)
+		const baseUrl = toRequestyServiceUrl(apiConfiguration.requestyBaseUrl, "app")
+
+		const authUrl = new URL(`oauth/authorize?callback_url=${callbackUrl}`, baseUrl)
+
+		return authUrl.toString()
+	}
+
 	return (
 		<>
 			<VSCodeTextField
@@ -65,7 +77,10 @@ export const Requesty = ({
 				<div className="flex justify-between items-center mb-1">
 					<label className="block font-medium">{t("settings:providers.requestyApiKey")}</label>
 					{apiConfiguration?.requestyApiKey && (
-						<RequestyBalanceDisplay apiKey={apiConfiguration.requestyApiKey} />
+						<RequestyBalanceDisplay
+							baseUrl={apiConfiguration.requestyBaseUrl}
+							apiKey={apiConfiguration.requestyApiKey}
+						/>
 					)}
 				</div>
 			</VSCodeTextField>
@@ -73,12 +88,19 @@ export const Requesty = ({
 				{t("settings:providers.apiKeyStorageNotice")}
 			</div>
 			{!apiConfiguration?.requestyApiKey && (
-				<VSCodeButtonLink
-					href="https://app.requesty.ai/api-keys"
-					style={{ width: "100%" }}
-					appearance="primary">
+				<a
+					href={getApiKeyUrl()}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="inline-flex items-center justify-center whitespace-nowrap text-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground shadow hover:bg-primary/90 h-9 rounded-md px-3 w-full"
+					style={{
+						width: "100%",
+						textDecoration: "none",
+						color: "var(--vscode-button-foreground)",
+						backgroundColor: "var(--vscode-button-background)",
+					}}>
 					{t("settings:providers.getRequestyApiKey")}
-				</VSCodeButtonLink>
+				</a>
 			)}
 
 			<VSCodeCheckbox

--- a/webview-ui/src/components/settings/providers/RequestyBalanceDisplay.tsx
+++ b/webview-ui/src/components/settings/providers/RequestyBalanceDisplay.tsx
@@ -1,9 +1,15 @@
 import { VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 
 import { useRequestyKeyInfo } from "@/components/ui/hooks/useRequestyKeyInfo"
+import { toRequestyServiceUrl } from "@roo/utils/requesty"
 
-export const RequestyBalanceDisplay = ({ apiKey }: { apiKey: string }) => {
-	const { data: keyInfo } = useRequestyKeyInfo(apiKey)
+type RequestyBalanceDisplayProps = {
+	apiKey: string
+	baseUrl?: string
+}
+
+export const RequestyBalanceDisplay = ({ baseUrl, apiKey }: RequestyBalanceDisplayProps) => {
+	const { data: keyInfo } = useRequestyKeyInfo(baseUrl, apiKey)
 
 	if (!keyInfo) {
 		return null
@@ -13,8 +19,11 @@ export const RequestyBalanceDisplay = ({ apiKey }: { apiKey: string }) => {
 	const balance = parseFloat(keyInfo.org_balance)
 	const formattedBalance = balance.toFixed(2)
 
+	const resolvedBaseUrl = toRequestyServiceUrl(baseUrl, "app")
+	const settingsUrl = new URL("settings", resolvedBaseUrl)
+
 	return (
-		<VSCodeLink href="https://app.requesty.ai/settings" className="text-vscode-foreground hover:underline">
+		<VSCodeLink href={settingsUrl.toString()} className="text-vscode-foreground hover:underline">
 			${formattedBalance}
 		</VSCodeLink>
 	)

--- a/webview-ui/src/components/ui/hooks/useRequestyKeyInfo.ts
+++ b/webview-ui/src/components/ui/hooks/useRequestyKeyInfo.ts
@@ -45,7 +45,7 @@ async function getRequestyKeyInfo(baseUrl?: string, apiKey?: string) {
 type UseRequestyKeyInfoOptions = Omit<UseQueryOptions<RequestyKeyInfo | null>, "queryKey" | "queryFn">
 export const useRequestyKeyInfo = (baseUrl?: string, apiKey?: string, options?: UseRequestyKeyInfoOptions) => {
 	return useQuery<RequestyKeyInfo | null>({
-		queryKey: ["requesty-key-info", apiKey],
+		queryKey: ["requesty-key-info", baseUrl, apiKey],
 		queryFn: () => getRequestyKeyInfo(baseUrl, apiKey),
 		staleTime: 30 * 1000, // 30 seconds
 		enabled: !!apiKey,

--- a/webview-ui/src/components/ui/hooks/useRequestyKeyInfo.ts
+++ b/webview-ui/src/components/ui/hooks/useRequestyKeyInfo.ts
@@ -1,6 +1,7 @@
 import axios from "axios"
 import { z } from "zod"
 import { useQuery, UseQueryOptions } from "@tanstack/react-query"
+import { toRequestyServiceUrl } from "@roo/utils/requesty"
 
 const requestyKeyInfoSchema = z.object({
 	name: z.string(),
@@ -14,11 +15,14 @@ const requestyKeyInfoSchema = z.object({
 
 export type RequestyKeyInfo = z.infer<typeof requestyKeyInfoSchema>
 
-async function getRequestyKeyInfo(apiKey?: string) {
+async function getRequestyKeyInfo(baseUrl?: string, apiKey?: string) {
 	if (!apiKey) return null
 
+	const url = toRequestyServiceUrl(baseUrl, "api")
+	const apiKeyUrl = new URL("x/apikey", url)
+
 	try {
-		const response = await axios.get("https://api.requesty.ai/x/apikey", {
+		const response = await axios.get(apiKeyUrl.toString(), {
 			headers: {
 				Authorization: `Bearer ${apiKey}`,
 				"Content-Type": "application/json",
@@ -39,10 +43,10 @@ async function getRequestyKeyInfo(apiKey?: string) {
 }
 
 type UseRequestyKeyInfoOptions = Omit<UseQueryOptions<RequestyKeyInfo | null>, "queryKey" | "queryFn">
-export const useRequestyKeyInfo = (apiKey?: string, options?: UseRequestyKeyInfoOptions) => {
+export const useRequestyKeyInfo = (baseUrl?: string, apiKey?: string, options?: UseRequestyKeyInfoOptions) => {
 	return useQuery<RequestyKeyInfo | null>({
 		queryKey: ["requesty-key-info", apiKey],
-		queryFn: () => getRequestyKeyInfo(apiKey),
+		queryFn: () => getRequestyKeyInfo(baseUrl, apiKey),
 		staleTime: 30 * 1000, // 30 seconds
 		enabled: !!apiKey,
 		...options,


### PR DESCRIPTION
Closes: #7274

### Description

Replace every URL where Requesty is used and use the base URL the user provided. This is mostly for models and API keys.

### Test Procedure

1. Open Roo-Code and set Requesty as a provider
2. Set a Requesty base URL
3. Click "Get Requesty API key" and check it redirected you to the base URL.

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

### Documentation Updates

### Additional Notes

### Get in Touch
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This PR standardizes the use of a base URL for Requesty across API requests and UI components, ensuring consistent URL handling in the application.
> 
>   - **Behavior**:
>     - Use `baseUrl` for Requesty API requests in `getRequestyModels()` in `requesty.ts` and `getRequestyKeyInfo()` in `useRequestyKeyInfo.ts`.
>     - Update `RequestyHandler` in `requesty.ts` to use `baseUrl` for initializing `OpenAI` client.
>     - Modify `webviewMessageHandler` to include `baseUrl` in `GetModelsOptions` for Requesty.
>   - **UI Components**:
>     - Add `baseUrl` handling in `Requesty` component in `Requesty.tsx` for API key and model selection.
>     - Update `RequestyBalanceDisplay` in `RequestyBalanceDisplay.tsx` to use `baseUrl` for balance URL.
>   - **Utilities**:
>     - Introduce `toRequestyServiceUrl()` in `requesty.ts` to resolve service URLs based on `baseUrl`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for f0a5bd68da622cb278fa354d53e0e16660d6aa42. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->