### PR TITLE
refactor: Remove exceptions from RooHandler constructor

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -143,6 +143,8 @@ export function buildApiHandler(configuration: ProviderSettings): ApiHandler {
 		case "io-intelligence":
 			return new IOIntelligenceHandler(options)
 		case "roo":
+			// Never throw exceptions from provider constructors
+			// The provider-proxy server will handle authentication and return appropriate error codes
 			return new RooHandler(options)
 		case "featherless":
 			return new FeatherlessHandler(options)

--- a/src/api/providers/__tests__/roo.spec.ts
+++ b/src/api/providers/__tests__/roo.spec.ts
@@ -131,21 +131,25 @@ describe("RooHandler", () => {
 			expect(handler.getModel().id).toBe(mockOptions.apiModelId)
 		})
 
-		it("should throw error if CloudService is not available", () => {
+		it("should not throw error if CloudService is not available", () => {
 			mockHasInstanceFn.mockReturnValue(false)
 			expect(() => {
 				new RooHandler(mockOptions)
-			}).toThrow("Authentication required for Roo Code Cloud")
-			expect(t).toHaveBeenCalledWith("common:errors.roo.authenticationRequired")
+			}).not.toThrow()
+			// Constructor should succeed even without CloudService
+			const handler = new RooHandler(mockOptions)
+			expect(handler).toBeInstanceOf(RooHandler)
 		})
 
-		it("should throw error if session token is not available", () => {
+		it("should not throw error if session token is not available", () => {
 			mockHasInstanceFn.mockReturnValue(true)
 			mockGetSessionTokenFn.mockReturnValue(null)
 			expect(() => {
 				new RooHandler(mockOptions)
-			}).toThrow("Authentication required for Roo Code Cloud")
-			expect(t).toHaveBeenCalledWith("common:errors.roo.authenticationRequired")
+			}).not.toThrow()
+			// Constructor should succeed even without session token
+			const handler = new RooHandler(mockOptions)
+			expect(handler).toBeInstanceOf(RooHandler)
 		})
 
 		it("should initialize with default model if no model specified", () => {
@@ -400,7 +404,7 @@ describe("RooHandler", () => {
 			expect(mockGetSessionTokenFn).toHaveBeenCalled()
 		})
 
-		it("should handle undefined auth service", () => {
+		it("should handle undefined auth service gracefully", () => {
 			mockHasInstanceFn.mockReturnValue(true)
 			// Mock CloudService with undefined authService
 			const originalGetter = Object.getOwnPropertyDescriptor(CloudService, "instance")?.get
@@ -413,7 +417,10 @@ describe("RooHandler", () => {
 
 				expect(() => {
 					new RooHandler(mockOptions)
-				}).toThrow("Authentication required for Roo Code Cloud")
+				}).not.toThrow()
+				// Constructor should succeed even with undefined auth service
+				const handler = new RooHandler(mockOptions)
+				expect(handler).toBeInstanceOf(RooHandler)
 			} finally {
 				// Always restore original getter, even if test fails
 				if (originalGetter) {
@@ -425,12 +432,15 @@ describe("RooHandler", () => {
 			}
 		})
 
-		it("should handle empty session token", () => {
+		it("should handle empty session token gracefully", () => {
 			mockGetSessionTokenFn.mockReturnValue("")
 
 			expect(() => {
 				new RooHandler(mockOptions)
-			}).toThrow("Authentication required for Roo Code Cloud")
+			}).not.toThrow()
+			// Constructor should succeed even with empty session token
+			const handler = new RooHandler(mockOptions)
+			expect(handler).toBeInstanceOf(RooHandler)
 		})
 	})
 })

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -288,7 +288,24 @@ export const webviewMessageHandler = async (
 			// Initializing new instance of Cline will make sure that any
 			// agentically running promises in old instance don't affect our new
 			// task. This essentially creates a fresh slate for the new task.
-			await provider.createTask(message.text, message.images)
+			try {
+				await provider.createTask(message.text, message.images)
+				// Task created successfully - notify the UI to reset
+				await provider.postMessageToWebview({
+					type: "invoke",
+					invoke: "newChat",
+				})
+			} catch (error) {
+				// For all errors, reset the UI and show error
+				await provider.postMessageToWebview({
+					type: "invoke",
+					invoke: "newChat",
+				})
+				// Show error to user
+				vscode.window.showErrorMessage(
+					`Failed to create task: ${error instanceof Error ? error.message : String(error)}`,
+				)
+			}
 			break
 		case "customInstructions":
 			await provider.updateCustomInstructions(message.text)


### PR DESCRIPTION
## Summary

This PR refactors the Roo provider to ensure that constructors never throw exceptions. Instead, authentication errors are now handled at the server level through HTTP status codes (e.g., 401 for unauthenticated requests).

## Changes

- **RooHandler constructor no longer throws exceptions**: The constructor now attempts to get a session token but proceeds with an empty/unauthenticated token if not available
- **Removed RooAuthenticationError class**: This exception class is no longer needed since we're not throwing from constructors
- **Removed pre-flight authentication check**: The check in `ClineProvider.createTask()` for the Roo provider has been removed
- **Updated error handling in webviewMessageHandler**: Now uses generic error handling instead of catching specific `RooAuthenticationError`
- **Server-side error handling**: The provider-proxy server will return appropriate HTTP status codes (401) for authentication failures

## Rationale

Based on feedback from PR #7298, provider constructors should never throw exceptions. This ensures:
1. Better separation of concerns between client initialization and server authentication
2. More consistent error handling across all providers
3. Graceful degradation when authentication is not available

## Testing

- [ ] Verified that RooHandler constructor succeeds even without authentication
- [ ] Confirmed that authentication errors are properly handled by the server (401 responses)
- [ ] Tested that the extension handles server error responses gracefully
- [ ] All existing tests pass

## Related

- Addresses feedback from PR #7298
- Follows the pattern established by other providers in the codebase
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor `RooHandler` to avoid exceptions in constructor, handle authentication errors server-side, and update tests accordingly.
> 
>   - **Behavior**:
>     - `RooHandler` constructor no longer throws exceptions; uses empty token if session token unavailable.
>     - Server returns HTTP 401 for authentication failures.
>   - **Error Handling**:
>     - Removed `RooAuthenticationError` class.
>     - Updated `webviewMessageHandler` to use generic error handling.
>   - **Testing**:
>     - Updated tests in `roo.spec.ts` to ensure `RooHandler` constructor does not throw exceptions.
>     - Tests cover cases with unavailable CloudService, missing session token, and undefined auth service.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for bbf9c1340a5e6f89faa597a07e96fe0f4ef3ded3. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->