### PR TITLE
fix: ensure subtask results are provided to GPT-5 in OpenAI Responses API

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1123,6 +1123,10 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 				role: "user",
 				content: [{ type: "text", text: `[new_task completed] Result: ${lastMessage}` }],
 			})
+
+			// Set skipPrevResponseIdOnce to ensure the next API call sends the full conversation
+			// including the subtask result, not just from before the subtask was created
+			this.skipPrevResponseIdOnce = true
 		} catch (error) {
 			this.providerRef
 				.deref()


### PR DESCRIPTION
## Description

This PR fixes issue #7251 where subtask results were not being provided to GPT-5 when using the OpenAI Responses API with the `previous_response_id` mechanism.

## Problem

When a subtask completes and the parent task resumes, the next API call was using a `previous_response_id` from before the subtask was created. This caused GPT-5 to only receive the new message without the subtask result context, as the API would only provide messages after the specified `previous_response_id`.

## Solution

Set `skipPrevResponseIdOnce = true` in the `resumePausedTask()` method after adding the subtask result to the conversation history. This ensures the next API call sends the full conversation including the subtask result, following the same pattern used after context condensation.

## Changes

- Added `this.skipPrevResponseIdOnce = true` in `Task.ts` line 1129 after the subtask result is added to the API conversation history

## Testing

The fix follows the established pattern already used in the codebase for context condensation scenarios where we need to ensure the full context is sent.

Fixes #7251
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue #7251 by ensuring subtask results are included in the next API call to GPT-5 in `resumePausedTask()` in `Task.ts`.
> 
>   - **Behavior**:
>     - Fixes issue #7251 by ensuring subtask results are included in the next API call to GPT-5 in `resumePausedTask()` in `Task.ts`.
>     - Sets `skipPrevResponseIdOnce = true` after adding subtask result to conversation history to ensure full context is sent.
>   - **Testing**:
>     - Follows established pattern for context condensation to ensure full context is sent.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 235a144faf7d3cff95f709df310fb1534b640902. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->