### PR TITLE
Fix requesty model listing

### DIFF
--- a/.changeset/spotty-queens-crash.md
+++ b/.changeset/spotty-queens-crash.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix requesty model listing

--- a/.changeset/spotty-queens-crash.md
+++ b/.changeset/spotty-queens-crash.md
@@ -1,5 +1,0 @@
----
-"roo-cline": patch
----
-
-Fix requesty model listing

--- a/src/api/providers/fetchers/requesty.ts
+++ b/src/api/providers/fetchers/requesty.ts
@@ -16,7 +16,7 @@ export async function getRequestyModels(baseUrl?: string, apiKey?: string): Prom
 		}
 
 		const resolvedBaseUrl = toRequestyServiceUrl(baseUrl)
-		const modelsUrl = new URL("models", resolvedBaseUrl)
+		const modelsUrl = new URL("v1/models", resolvedBaseUrl)
 
 		const response = await axios.get(modelsUrl.toString(), { headers })
 		const rawModels = response.data.data


### PR DESCRIPTION
### Related GitHub Issue

Closes: #7377 

### Roo Code Task Context (Optional)

### Description

Fix the model listing URL for Requesty

### Test Procedure

Check that the model listing URL ends with /v1/models, not just /models.

### Pre-Submission Checklist

- [X] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [X] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [X] **Self-Review**: I have performed a thorough self-review of my code.
- [X] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [X] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [X] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

N/A

### Documentation Updates

N/A

### Additional Notes

Please help us merge this into nightly before the current nightly hits prod.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes the model listing URL in `getRequestyModels` to use `/v1/models` endpoint.
> 
>   - **Behavior**:
>     - Fixes the model listing URL in `getRequestyModels` function in `requesty.ts` to use `/v1/models` instead of `/models`.
>   - **Misc**:
>     - Adds a changeset file `spotty-queens-crash.md` for versioning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for aca659200d151e2dad76b1d9e87cd27744f017b4. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->