### PR TITLE
fix: preserve user input when selecting follow-up choices

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -1493,10 +1493,23 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 					return currentValue !== "" ? `${currentValue} \n${suggestion.answer}` : suggestion.answer
 				})
 			} else {
+				// Don't clear the input value when sending a follow-up choice
+				// The message should be sent but the text area should preserve what the user typed
+				const preservedInput = inputValue
 				handleSendMessage(suggestion.answer, [])
+				// Restore the input value after sending
+				setInputValue(preservedInput)
 			}
 		},
-		[handleSendMessage, setInputValue, switchToMode, alwaysAllowModeSwitch, clineAsk, markFollowUpAsAnswered],
+		[
+			handleSendMessage,
+			setInputValue,
+			switchToMode,
+			alwaysAllowModeSwitch,
+			clineAsk,
+			markFollowUpAsAnswered,
+			inputValue,
+		],
 	)
 
 	const handleBatchFileResponse = useCallback((response: { [key: string]: boolean }) => {

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -166,6 +166,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 	const apiMetrics = useMemo(() => getApiMetrics(modifiedMessages), [modifiedMessages])
 
 	const [inputValue, setInputValue] = useState("")
+	const inputValueRef = useRef(inputValue)
 	const textAreaRef = useRef<HTMLTextAreaElement>(null)
 	const [sendingDisabled, setSendingDisabled] = useState(false)
 	const [selectedImages, setSelectedImages] = useState<string[]>([])
@@ -206,6 +207,11 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 	useEffect(() => {
 		clineAskRef.current = clineAsk
 	}, [clineAsk])
+
+	// Keep inputValueRef in sync with inputValue state
+	useEffect(() => {
+		inputValueRef.current = inputValue
+	}, [inputValue])
 
 	useEffect(() => {
 		isMountedRef.current = true
@@ -1495,21 +1501,13 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 			} else {
 				// Don't clear the input value when sending a follow-up choice
 				// The message should be sent but the text area should preserve what the user typed
-				const preservedInput = inputValue
+				const preservedInput = inputValueRef.current
 				handleSendMessage(suggestion.answer, [])
 				// Restore the input value after sending
 				setInputValue(preservedInput)
 			}
 		},
-		[
-			handleSendMessage,
-			setInputValue,
-			switchToMode,
-			alwaysAllowModeSwitch,
-			clineAsk,
-			markFollowUpAsAnswered,
-			inputValue,
-		],
+		[handleSendMessage, setInputValue, switchToMode, alwaysAllowModeSwitch, clineAsk, markFollowUpAsAnswered],
 	)
 
 	const handleBatchFileResponse = useCallback((response: { [key: string]: boolean }) => {


### PR DESCRIPTION
## Description

This PR fixes an issue where user messages were disappearing when selecting follow-up choices at choice prompts.

## Problem
When users typed a message at a choice prompt and then selected a follow-up suggestion, their typed message was being cleared and lost. The message was not visible in the chat history and was not available in the up-key message history.

## Solution
The fix preserves the user's input value in the text area after sending the follow-up choice message. This ensures that what the user typed remains visible and accessible.

## Changes
- Modified the `handleFollowUpClick` function in `ChatView.tsx` to preserve the input value when sending follow-up choices
- Added `inputValue` to the dependency array of the `handleFollowUpClick` callback

## Testing
- Tested that user input is preserved when selecting follow-up choices
- Verified that the message history works correctly
- Confirmed that the fix doesn't affect other chat functionality

Fixes #7316