### PR TITLE
fix: remove duplicate cache display in task header

### DIFF
--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -264,19 +264,6 @@ const TaskHeader = ({
 										</tr>
 									)}
 
-									{/* Cache size display */}
-									{((typeof cacheReads === "number" && cacheReads > 0) ||
-										(typeof cacheWrites === "number" && cacheWrites > 0)) && (
-										<tr>
-											<th className="font-bold text-left align-top w-1 whitespace-nowrap pl-1 pr-3 h-[24px]">
-												{t("chat:task.cache")}
-											</th>
-											<td className="align-top">
-												{prettyBytes(((cacheReads || 0) + (cacheWrites || 0)) * 4)}
-											</td>
-										</tr>
-									)}
-
 									{/* Size display */}
 									{!!currentTaskItem?.size && currentTaskItem.size > 0 && (
 										<tr>


### PR DESCRIPTION
## Problem
The task header was displaying two confusing 'Cache' rows:
1. Cache token counts (↑ 231.8k ↓ 2.6k) 
2. Cache byte size (927 kB)

This created confusion about what each Cache entry represented.

## Solution
- Removed the redundant second cache row that showed byte size calculation
- Kept only the meaningful cache token count display with ↑/↓ format
- Improves UI clarity by eliminating duplicate information

## Changes
- Removed lines 267-278 in TaskHeader.tsx that displayed cache size in bytes
- The interface now shows only:
  - **Cache**: Token counts (↑ for writes, ↓ for reads)
  - **Size**: Task directory disk usage

## Testing
- [x] Linting passes
- [x] Type checking passes
- [x] No

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove redundant cache size display in `TaskHeader.tsx`, retaining only cache token counts for clarity.
> 
>   - **UI Changes**:
>     - Removed redundant cache size display in bytes from `TaskHeader.tsx`.
>     - Retained cache token count display with ↑/↓ format for clarity.
>     - Size now only refers to task directory disk usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 37d0671cb82857608af74cfb3936649f67877ebc. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->