### PR TITLE
Always set remoteControlEnabled to true for cloud agents

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -141,11 +141,20 @@ export async function activate(context: vscode.ExtensionContext) {
 		try {
 			const config = await CloudService.instance.cloudAPI.bridgeConfig()
 
+			const isCloudAgent =
+				typeof process.env.ROO_CODE_CLOUD_TOKEN === "string" && process.env.ROO_CODE_CLOUD_TOKEN.length > 0
+
+			cloudLogger(`[CloudService] isCloudAgent = ${isCloudAgent}, socketBridgeUrl = ${config.socketBridgeUrl}`)
+
 			ExtensionBridgeService.handleRemoteControlState(
 				userInfo,
-				contextProxy.getValue("remoteControlEnabled"),
-				{ ...config, provider, sessionId: vscode.env.sessionId },
-				(message: string) => outputChannel.appendLine(message),
+				isCloudAgent ? true : contextProxy.getValue("remoteControlEnabled"),
+				{
+					...config,
+					provider,
+					sessionId: vscode.env.sessionId,
+				},
+				cloudLogger,
 			)
 		} catch (error) {
 			cloudLogger(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Always enable remote control for cloud agents in `extension.ts` by checking `ROO_CODE_CLOUD_TOKEN`.
> 
>   - **Behavior**:
>     - In `activate()` in `extension.ts`, always set `remoteControlEnabled` to `true` for cloud agents by checking `process.env.ROO_CODE_CLOUD_TOKEN`.
>     - Logs the `isCloudAgent` status and `socketBridgeUrl` using `cloudLogger`.
>   - **Logging**:
>     - Replaces inline logging with `cloudLogger` for consistency in `extension.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 52b8f27ffb6551fd9f12e39945532afaac0514e3. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->