### PR TITLE
Support free imagegen

### DIFF
--- a/src/core/tools/generateImageTool.ts
+++ b/src/core/tools/generateImageTool.ts
@@ -12,10 +12,7 @@ import { safeWriteJson } from "../../utils/safeWriteJson"
 import { OpenRouterHandler } from "../../api/providers/openrouter"
 
 // Hardcoded list of image generation models for now
-const IMAGE_GENERATION_MODELS = [
-	"google/gemini-2.5-flash-image-preview",
-	// Add more models as they become available
-]
+const IMAGE_GENERATION_MODELS = ["google/gemini-2.5-flash-image-preview", "google/gemini-2.5-flash-image-preview:free"]
 
 export async function generateImageTool(
 	cline: Task,

--- a/webview-ui/src/components/settings/ImageGenerationSettings.tsx
+++ b/webview-ui/src/components/settings/ImageGenerationSettings.tsx
@@ -17,6 +17,7 @@ interface ImageGenerationSettingsProps {
 // Hardcoded list of image generation models
 const IMAGE_GENERATION_MODELS = [
 	{ value: "google/gemini-2.5-flash-image-preview", label: "Gemini 2.5 Flash Image Preview" },
+	{ value: "google/gemini-2.5-flash-image-preview:free", label: "Gemini 2.5 Flash Image Preview (Free)" },
 	// Add more models as they become available
 ]
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for a free image generation model in `generateImageTool.ts` and updates UI in `ImageGenerationSettings.tsx`.
> 
>   - **Behavior**:
>     - Adds support for a free image generation model `google/gemini-2.5-flash-image-preview:free` in `generateImageTool` function in `generateImageTool.ts`.
>     - Updates `IMAGE_GENERATION_MODELS` in `ImageGenerationSettings.tsx` to include the free model option.
>   - **UI**:
>     - Adds "Gemini 2.5 Flash Image Preview (Free)" option to the model selection dropdown in `ImageGenerationSettings.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d029385a96e46569085564aea05483d69b6820dc. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->