### PR TITLE
fix: special tokens should not break task processing

### DIFF
--- a/src/utils/__tests__/tiktoken.spec.ts
+++ b/src/utils/__tests__/tiktoken.spec.ts
@@ -25,6 +25,15 @@ describe("tiktoken", () => {
 		expect(result).toBe(0)
 	})
 
+	it("should not throw on text content with special tokens", async () => {
+		const content: Anthropic.Messages.ContentBlockParam[] = [
+			{ type: "text", text: "something<|endoftext|>something" },
+		]
+
+		const result = await tiktoken(content)
+		expect(result).toBeGreaterThan(0)
+	})
+
 	it("should handle missing text content", async () => {
 		// Using 'as any' to bypass TypeScript's type checking for this test case
 		// since we're specifically testing how the function handles undefined text

--- a/src/utils/tiktoken.ts
+++ b/src/utils/tiktoken.ts
@@ -24,7 +24,7 @@ export async function tiktoken(content: Anthropic.Messages.ContentBlockParam[]):
 			const text = block.text || ""
 
 			if (text.length > 0) {
-				const tokens = encoder.encode(text)
+				const tokens = encoder.encode(text, undefined, [])
 				totalTokens += tokens.length
 			}
 		} else if (block.type === "image") {


### PR DESCRIPTION
### Related GitHub Issue

Closes: https://github.com/RooCodeInc/Roo-Code/issues/7539

### Description

Add `disabled_specials = []` to `encoder.encode(...)` parameters in `tiktoken.ts` to guarantee that specials do not break task execution.

### Test Procedure

Added a test to `tiktoken.spec.ts` to check this case.

### Pre-Submission Checklist

- [X] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [X] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [X] **Self-Review**: I have performed a thorough self-review of my code.
- [X] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [X] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [X] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Documentation Updates

Does this PR necessitate updates to user-facing documentation?
- [X] No documentation updates are required.

### Get in Touch

ilintar on Discord