### PR TITLE
Handle images in roolease notes

### DIFF
--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -83,8 +83,9 @@ jobs:
             echo "Found changelog section for version ${current_package_version}"
             # Convert relative image paths to full GitHub URLs for proper display in release notes
             # Use the main branch URL since the images will be merged there before release
-            # Only match .png files to avoid accidentally modifying other references
-            changelog_content=$(echo "$changelog_content" | sed "s|(releases/\([^)]*\.png\))|(https://github.com/${{ github.repository }}/raw/main/releases/\1)|g")
+            # Match common image file extensions: png, jpg, jpeg, gif, webp, svg
+            # Using extended regex (-E) for better portability
+            changelog_content=$(echo "$changelog_content" | sed -E "s/\(releases\/([^)]*\.(png|jpg|jpeg|gif|webp|svg))\)/(https:\/\/github.com\/${{ github.repository }}\/raw\/main\/releases\/\1)/g")
           fi
 
           # Create release with changelog content

--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -81,6 +81,10 @@ jobs:
             changelog_content="Release v${current_package_version}"
           else
             echo "Found changelog section for version ${current_package_version}"
+            # Convert relative image paths to full GitHub URLs for proper display in release notes
+            # Use the main branch URL since the images will be merged there before release
+            # Only match .png files to avoid accidentally modifying other references
+            changelog_content=$(echo "$changelog_content" | sed "s|(releases/\([^)]*\.png\))|(https://github.com/${{ github.repository }}/raw/main/releases/\1)|g")
           fi
 
           # Create release with changelog content

--- a/.roo/commands/release.md
+++ b/.roo/commands/release.md
@@ -41,4 +41,5 @@ argument-hint: patch | minor | major
 11. The GitHub Actions workflow will automatically:
     - Create a version bump PR when changesets are merged to main
     - Update the CHANGELOG.md with proper formatting
+    - Convert PNG image paths in release notes to GitHub raw URLs for proper display
     - Publish the release when the version bump PR is merged


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Converts relative image paths in release notes to full GitHub URLs in `marketplace-publish.yml` and updates `release.md` documentation.
> 
>   - **GitHub Actions Workflow**:
>     - In `marketplace-publish.yml`, converts relative image paths in changelog to full GitHub URLs for PNG, JPG, JPEG, GIF, WEBP, and SVG files.
>   - **Documentation**:
>     - Updates `release.md` to mention conversion of PNG image paths to GitHub raw URLs in release notes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for f8051e82beb125396f36230b9e9406195038a997. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->