### PR TITLE
Fix claudeCode.notFound translation key

### DIFF
--- a/src/integrations/claude-code/run.ts
+++ b/src/integrations/claude-code/run.ts
@@ -260,7 +260,7 @@ function attemptParseChunk(data: string): ClaudeCodeMessage | null {
  * Creates a user-friendly error message for Claude Code ENOENT errors
  */
 function createClaudeCodeNotFoundError(claudePath: string, originalError: Error): Error {
-	const errorMessage = t("errors.claudeCode.notFound", {
+	const errorMessage = t("common:errors.claudeCode.notFound", {
 		claudePath,
 		installationUrl: CLAUDE_CODE_INSTALLATION_URL,
 		originalError: originalError.message,


### PR DESCRIPTION
I think I saw someone post a screenshot where "errors.claudeCode.notFound" was shown untranslated.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix translation key in `createClaudeCodeNotFoundError()` in `run.ts` for proper error message translation.
> 
>   - **Translation Key Fix**:
>     - Updated translation key from `"errors.claudeCode.notFound"` to `"common:errors.claudeCode.notFound"` in `createClaudeCodeNotFoundError()` function in `run.ts` to ensure proper translation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for f955ac578fcc269982a6a5d1d2ea03f83aec3ff5. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->