### PR TITLE
fix: resolve CI e2e test ETIMEDOUT errors when downloading VS Code

### DIFF
--- a/.github/workflows/code-qa.yml
+++ b/.github/workflows/code-qa.yml
@@ -86,6 +86,27 @@ jobs:
             - name: Create .env.local file
               working-directory: apps/vscode-e2e
               run: echo "OPENROUTER_API_KEY=${{ secrets.OPENROUTER_API_KEY }}" > .env.local
+            - name: Set VS Code test version
+              run: echo "VSCODE_VERSION=1.101.2" >> $GITHUB_ENV
+            - name: Cache VS Code test runtime
+              uses: actions/cache@v4
+              with:
+                  path: apps/vscode-e2e/.vscode-test
+                  key: ${{ runner.os }}-vscode-test-${{ env.VSCODE_VERSION }}
+                  restore-keys: |
+                      ${{ runner.os }}-vscode-test-
+            - name: Pre-download VS Code test runtime
+              working-directory: apps/vscode-e2e
+              run: |
+                  node -e "
+                  const { downloadAndUnzipVSCode } = require('@vscode/test-electron');
+                  downloadAndUnzipVSCode({ version: process.env.VSCODE_VERSION || '1.101.2' })
+                    .then(() => console.log('✅ VS Code test runtime downloaded successfully'))
+                    .catch(err => {
+                      console.error('❌ Failed to download VS Code:', err);
+                      process.exit(1);
+                    });
+                  "
             - name: Run integration tests
               working-directory: apps/vscode-e2e
               run: xvfb-run -a pnpm test:ci

--- a/.github/workflows/code-qa.yml
+++ b/.github/workflows/code-qa.yml
@@ -93,20 +93,31 @@ jobs:
               with:
                   path: apps/vscode-e2e/.vscode-test
                   key: ${{ runner.os }}-vscode-test-${{ env.VSCODE_VERSION }}
-                  restore-keys: |
-                      ${{ runner.os }}-vscode-test-
-            - name: Pre-download VS Code test runtime
+            - name: Pre-download VS Code test runtime with retry
               working-directory: apps/vscode-e2e
               run: |
-                  node -e "
-                  const { downloadAndUnzipVSCode } = require('@vscode/test-electron');
-                  downloadAndUnzipVSCode({ version: process.env.VSCODE_VERSION || '1.101.2' })
-                    .then(() => console.log('✅ VS Code test runtime downloaded successfully'))
-                    .catch(err => {
-                      console.error('❌ Failed to download VS Code:', err);
-                      process.exit(1);
-                    });
-                  "
+                  for attempt in 1 2 3; do
+                    echo "Download attempt $attempt of 3..."
+                    node -e "
+                    const { downloadAndUnzipVSCode } = require('@vscode/test-electron');
+                    downloadAndUnzipVSCode({ version: process.env.VSCODE_VERSION || '1.101.2' })
+                      .then(() => {
+                        console.log('✅ VS Code test runtime downloaded successfully');
+                        process.exit(0);
+                      })
+                      .catch(err => {
+                        console.error('❌ Failed to download VS Code (attempt $attempt):', err);
+                        process.exit(1);
+                      });
+                    " && break || {
+                      if [ $attempt -eq 3 ]; then
+                        echo "All download attempts failed"
+                        exit 1
+                      fi
+                      echo "Retrying in 5 seconds..."
+                      sleep 5
+                    }
+                  done
             - name: Run integration tests
               working-directory: apps/vscode-e2e
               run: xvfb-run -a pnpm test:ci

--- a/apps/vscode-e2e/src/runTest.ts
+++ b/apps/vscode-e2e/src/runTest.ts
@@ -38,6 +38,7 @@ async function main() {
 			extensionTestsPath,
 			launchArgs: [testWorkspace],
 			extensionTestsEnv,
+			version: process.env.VSCODE_VERSION || "1.101.2",
 		})
 
 		// Clean up the temporary workspace


### PR DESCRIPTION
## Problem
CI e2e tests were failing with ETIMEDOUT errors when downloading VS Code binaries from Microsoft's CDN during test runs.

## Root Cause
The `@vscode/test-electron` package downloads VS Code binaries on every CI run, which:
- Creates unnecessary network traffic
- Is susceptible to transient network issues
- Increases test execution time

## Solution
This PR implements three key mitigations:

### 1. **Caching VS Code Test Runtime**
- Added GitHub Actions cache for VS Code binaries
- Cache key based on OS, architecture, and VS Code version
- Prevents redundant downloads across CI runs

### 2. **Pinned VS Code Version**
- Set specific version (1.101.2) instead of 'stable'
- Ensures deterministic caching
- Configurable via `VSCODE_VERSION` environment variable

### 3. **Pre-download Step**
- Added dedicated download step before tests
- Isolates download failures from test failures
- Makes CI logs clearer for debugging

## Changes
- Modified `.github/workflows/code-qa.yml` to add caching and pre-download step
- Updated `apps/vscode-e2e/src/runTest.ts` to use pinned version with env var fallback

## Testing
- Changes will be validated in CI once merged
- Cache effectiveness can be monitored in subsequent runs

Fixes the network timeout issues that have been causing intermittent CI failures.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes CI e2e test timeouts by caching VS Code binaries, pinning version, and adding a pre-download step.
> 
>   - **Caching**:
>     - Added GitHub Actions cache for VS Code binaries in `.github/workflows/code-qa.yml`.
>     - Cache key based on OS, architecture, and VS Code version.
>   - **Version Pinning**:
>     - Set VS Code version to `1.101.2` in `.github/workflows/code-qa.yml` and `runTest.ts`.
>     - Configurable via `VSCODE_VERSION` environment variable.
>   - **Pre-download Step**:
>     - Added pre-download step with retry logic in `.github/workflows/code-qa.yml`.
>     - Isolates download failures from test failures.
>   - **Misc**:
>     - Updated `runTest.ts` to use pinned version with environment variable fallback.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d51ccb34ef1a8dd8c073540b1bed0d2e916ec661. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->