### PR TITLE
fix: preserve scroll position when switching tabs in settings

### DIFF
--- a/webview-ui/src/components/common/Tab.tsx
+++ b/webview-ui/src/components/common/Tab.tsx
@@ -45,6 +45,7 @@ export const TabContent = forwardRef<HTMLDivElement, TabProps>(({ className, chi
 		</div>
 	)
 })
+TabContent.displayName = "TabContent"
 
 export const TabList = forwardRef<
 	HTMLDivElement,

--- a/webview-ui/src/components/common/Tab.tsx
+++ b/webview-ui/src/components/common/Tab.tsx
@@ -17,7 +17,7 @@ export const TabHeader = ({ className, children, ...props }: TabProps) => (
 	</div>
 )
 
-export const TabContent = ({ className, children, ...props }: TabProps) => {
+export const TabContent = forwardRef<HTMLDivElement, TabProps>(({ className, children, ...props }, ref) => {
 	const { renderContext } = useExtensionState()
 
 	const onWheel = useCallback(
@@ -40,11 +40,11 @@ export const TabContent = ({ className, children, ...props }: TabProps) => {
 	)
 
 	return (
-		<div className={cn("flex-1 overflow-auto p-5", className)} onWheel={onWheel} {...props}>
+		<div ref={ref} className={cn("flex-1 overflow-auto p-5", className)} onWheel={onWheel} {...props}>
 			{children}
 		</div>
 	)
-}
+})
 
 export const TabList = forwardRef<
 	HTMLDivElement,

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -411,12 +411,10 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 		[activeTab],
 	)
 
-	useEffect(() => {
-		requestAnimationFrame(() => {
-			if (contentRef.current) {
-				contentRef.current.scrollTop = scrollPositions.current[activeTab] ?? 0
-			}
-		})
+	useLayoutEffect(() => {
+		if (contentRef.current) {
+			contentRef.current.scrollTop = scrollPositions.current[activeTab] ?? 0
+		}
 	}, [activeTab])
 
 	// Store direct DOM element refs for each tab

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -112,6 +112,11 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 			: "providers",
 	)
 
+	const scrollPositions = useRef<Record<SectionName, number>>(
+		Object.fromEntries(sectionNames.map((s) => [s, 0])) as Record<SectionName, number>,
+	)
+	const contentRef = useRef<HTMLDivElement | null>(null)
+
 	const prevApiConfigName = useRef(currentApiConfigName)
 	const confirmDialogHandler = useRef<() => void>()
 
@@ -398,11 +403,21 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 	// Handle tab changes with unsaved changes check
 	const handleTabChange = useCallback(
 		(newTab: SectionName) => {
-			// Directly switch tab without checking for unsaved changes
+			if (contentRef.current) {
+				scrollPositions.current[activeTab] = contentRef.current.scrollTop
+			}
 			setActiveTab(newTab)
 		},
-		[], // No dependency on isChangeDetected needed anymore
+		[activeTab],
 	)
+
+	useEffect(() => {
+		requestAnimationFrame(() => {
+			if (contentRef.current) {
+				contentRef.current.scrollTop = scrollPositions.current[activeTab] ?? 0
+			}
+		})
+	}, [activeTab])
 
 	// Store direct DOM element refs for each tab
 	const tabRefs = useRef<Record<SectionName, HTMLButtonElement | null>>(
@@ -579,7 +594,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 				</TabList>
 
 				{/* Content area */}
-				<TabContent className="p-0 flex-1 overflow-auto">
+				<TabContent ref={contentRef} className="p-0 flex-1 overflow-auto">
 					{/* Providers Section */}
 					{activeTab === "providers" && (
 						<div>


### PR DESCRIPTION
### Description

This PR implements independent scroll positions for each tab within the settings view, enhancing user experience. Previously, the scroll position was shared across all tabs, causing incorrect scrollbar behavior when switching between tabs of different lengths. Now, the view remembers each tab's scroll position, restoring it when the user navigates back.

### Changes
- **src/components/Tab.tsx:** Enabled ref forwarding for the TabContent component to allow parent access.

- **src/views/SettingsView.tsx:** Implemented logic to save and restore individual scroll positions when switching tabs.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [ ] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [ ] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [ ] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Implements independent scroll positions for each tab in settings, enhancing user experience by restoring positions when switching tabs.
> 
>   - **Behavior**:
>     - Implements independent scroll positions for each tab in `SettingsView.tsx`, restoring them when switching tabs.
>     - Previously, scroll position was shared across tabs, causing incorrect behavior.
>   - **Components**:
>     - Enables ref forwarding in `TabContent` in `Tab.tsx` to allow parent access.
>     - Uses `useRef` and `useEffect` in `SettingsView.tsx` to manage scroll positions.
>   - **Functions**:
>     - `handleTabChange` and `useEffect` in `SettingsView.tsx` updated to save and restore scroll positions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ad07bf4e0dacf1c7e937e3fcb5a7c8a36335996a. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->