### PR TITLE
fix: add cache reporting support for OpenAI-Native provider

### DIFF
--- a/src/api/providers/__tests__/openai-native-usage.spec.ts
+++ b/src/api/providers/__tests__/openai-native-usage.spec.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { OpenAiNativeHandler } from "../openai-native"
+import { openAiNativeModels } from "@roo-code/types"
+
+describe("OpenAiNativeHandler - normalizeUsage", () => {
+	let handler: OpenAiNativeHandler
+	const mockModel = {
+		id: "gpt-4o",
+		info: openAiNativeModels["gpt-4o"],
+	}
+
+	beforeEach(() => {
+		handler = new OpenAiNativeHandler({
+			openAiNativeApiKey: "test-key",
+		})
+	})
+
+	describe("detailed token shapes (Responses API)", () => {
+		it("should handle detailed shapes with cached and miss tokens", () => {
+			const usage = {
+				input_tokens: 100,
+				output_tokens: 50,
+				input_tokens_details: {
+					cached_tokens: 30,
+					cache_miss_tokens: 70,
+				},
+			}
+
+			const result = (handler as any).normalizeUsage(usage, mockModel)
+
+			expect(result).toMatchObject({
+				type: "usage",
+				inputTokens: 100,
+				outputTokens: 50,
+				cacheReadTokens: 30,
+				cacheWriteTokens: 70,
+			})
+		})
+
+		it("should derive total input tokens from details when totals are missing", () => {
+			const usage = {
+				// No input_tokens or prompt_tokens
+				output_tokens: 50,
+				input_tokens_details: {
+					cached_tokens: 30,
+					cache_miss_tokens: 70,
+				},
+			}
+
+			const result = (handler as any).normalizeUsage(usage, mockModel)
+
+			expect(result).toMatchObject({
+				type: "usage",
+				inputTokens: 100, // Derived from 30 + 70
+				outputTokens: 50,
+				cacheReadTokens: 30,
+				cacheWriteTokens: 70,
+			})
+		})
+
+		it("should handle prompt_tokens_details variant", () => {
+			const usage = {
+				prompt_tokens: 100,
+				completion_tokens: 50,
+				prompt_tokens_details: {
+					cached_tokens: 30,
+					cache_miss_tokens: 70,
+				},
+			}
+
+			const result = (handler as any).normalizeUsage(usage, mockModel)
+
+			expect(result).toMatchObject({
+				type: "usage",
+				inputTokens: 100,
+				outputTokens: 50,
+				cacheReadTokens: 30,
+				cacheWriteTokens: 70,
+			})
+		})
+
+		it("should handle reasoning tokens in output details", () => {
+			const usage = {
+				input_tokens: 100,
+				output_tokens: 150,
+				output_tokens_details: {
+					reasoning_tokens: 50,
+				},
+			}
+
+			const result = (handler as any).normalizeUsage(usage, mockModel)
+
+			expect(result).toMatchObject({
+				type: "usage",
+				inputTokens: 100,
+				outputTokens: 150,
+				reasoningTokens: 50,
+			})
+		})
+	})
+
+	describe("legacy field names", () => {
+		it("should handle cache_creation_input_tokens and cache_read_input_tokens", () => {
+			const usage = {
+				input_tokens: 100,
+				output_tokens: 50,
+				cache_creation_input_tokens: 20,
+				cache_read_input_tokens: 30,
+			}
+
+			const result = (handler as any).normalizeUsage(usage, mockModel)
+
+			expect(result).toMatchObject({
+				type: "usage",
+				inputTokens: 100,
+				outputTokens: 50,
+				cacheReadTokens: 30,
+				cacheWriteTokens: 20,
+			})
+		})
+
+		it("should handle cache_write_tokens and cache_read_tokens", () => {
+			const usage = {
+				input_tokens: 100,
+				output_tokens: 50,
+				cache_write_tokens: 20,
+				cache_read_tokens: 30,
+			}
+
+			const result = (handler as any).normalizeUsage(usage, mockModel)
+
+			expect(result).toMatchObject({
+				type: "usage",
+				inputTokens: 100,
+				outputTokens: 50,
+				cacheReadTokens: 30,
+				cacheWriteTokens: 20,
+			})
+		})
+
+		it("should handle cached_tokens field", () => {
+			const usage = {
+				input_tokens: 100,
+				output_tokens: 50,
+				cached_tokens: 30,
+			}
+
+			const result = (handler as any).normalizeUsage(usage, mockModel)
+
+			expect(result).toMatchObject({
+				type: "usage",
+				inputTokens: 100,
+				outputTokens: 50,
+				cacheReadTokens: 30,
+			})
+		})
+
+		it("should handle prompt_tokens and completion_tokens", () => {
+			const usage = {
+				prompt_tokens: 100,
+				completion_tokens: 50,
+			}
+
+			const result = (handler as any).normalizeUsage(usage, mockModel)
+
+			expect(result).toMatchObject({
+				type: "usage",
+				inputTokens: 100,
+				outputTokens: 50,
+				cacheReadTokens: 0,
+				cacheWriteTokens: 0,
+			})
+		})
+	})
+
+	describe("SSE-only events", () => {
+		it("should handle SSE events with minimal usage data", () => {
+			const usage = {
+				input_tokens: 100,
+				output_tokens: 50,
+			}
+
+			const result = (handler as any).normalizeUsage(usage, mockModel)
+
+			expect(result).toMatchObject({
+				type: "usage",
+				inputTokens: 100,
+				outputTokens: 50,
+				cacheReadTokens: 0,
+				cacheWriteTokens: 0,
+			})
+		})
+
+		it("should handle SSE events with no cache information", () => {
+			const usage = {
+				prompt_tokens: 100,
+				completion_tokens: 50,
+			}
+
+			const result = (handler as any).normalizeUsage(usage, mockModel)
+
+			expect(result).toMatchObject({
+				type: "usage",
+				inputTokens: 100,
+				outputTokens: 50,
+				cacheReadTokens: 0,
+				cacheWriteTokens: 0,
+			})
+		})
+	})
+
+	describe("edge cases", () => {
+		it("should handle undefined usage", () => {
+			const result = (handler as any).normalizeUsage(undefined, mockModel)
+			expect(result).toBeUndefined()
+		})
+
+		it("should handle null usage", () => {
+			const result = (handler as any).normalizeUsage(null, mockModel)
+			expect(result).toBeUndefined()
+		})
+
+		it("should handle empty usage object", () => {
+			const usage = {}
+
+			const result = (handler as any).normalizeUsage(usage, mockModel)
+
+			expect(result).toMatchObject({
+				type: "usage",
+				inputTokens: 0,
+				outputTokens: 0,
+				cacheReadTokens: 0,
+				cacheWriteTokens: 0,
+			})
+		})
+
+		it("should handle missing details but with cache fields", () => {
+			const usage = {
+				input_tokens: 100,
+				output_tokens: 50,
+				cache_read_input_tokens: 30,
+				// No input_tokens_details
+			}
+
+			const result = (handler as any).normalizeUsage(usage, mockModel)
+
+			expect(result).toMatchObject({
+				type: "usage",
+				inputTokens: 100,
+				outputTokens: 50,
+				cacheReadTokens: 30,
+				cacheWriteTokens: 0,
+			})
+		})
+
+		it("should use all available cache information with proper fallbacks", () => {
+			const usage = {
+				input_tokens: 100,
+				output_tokens: 50,
+				cached_tokens: 20, // Legacy field (will be used as fallback)
+				input_tokens_details: {
+					cached_tokens: 30, // Detailed shape
+					cache_miss_tokens: 70,
+				},
+			}
+
+			const result = (handler as any).normalizeUsage(usage, mockModel)
+
+			// The implementation uses nullish coalescing, so it will use the first non-nullish value:
+			// cache_read_input_tokens ?? cache_read_tokens ?? cached_tokens ?? cachedFromDetails
+			// Since none of the first two exist, it falls back to cached_tokens (20) before cachedFromDetails
+			expect(result).toMatchObject({
+				type: "usage",
+				inputTokens: 100,
+				outputTokens: 50,
+				cacheReadTokens: 20, // From cached_tokens (legacy field comes before details in fallback chain)
+				cacheWriteTokens: 70,
+			})
+		})
+
+		it("should use detailed shapes when legacy fields are not present", () => {
+			const usage = {
+				input_tokens: 100,
+				output_tokens: 50,
+				// No cached_tokens legacy field
+				input_tokens_details: {
+					cached_tokens: 30,
+					cache_miss_tokens: 70,
+				},
+			}
+
+			const result = (handler as any).normalizeUsage(usage, mockModel)
+
+			expect(result).toMatchObject({
+				type: "usage",
+				inputTokens: 100,
+				outputTokens: 50,
+				cacheReadTokens: 30, // From details since no legacy field exists
+				cacheWriteTokens: 70,
+			})
+		})
+
+		it("should handle totals missing with only partial details", () => {
+			const usage = {
+				// No input_tokens or prompt_tokens
+				output_tokens: 50,
+				input_tokens_details: {
+					cached_tokens: 30,
+					// No cache_miss_tokens
+				},
+			}
+
+			const result = (handler as any).normalizeUsage(usage, mockModel)
+
+			expect(result).toMatchObject({
+				type: "usage",
+				inputTokens: 30, // Derived from cached_tokens only
+				outputTokens: 50,
+				cacheReadTokens: 30,
+				cacheWriteTokens: 0,
+			})
+		})
+	})
+
+	describe("cost calculation", () => {
+		it("should calculate cost using uncached input tokens", () => {
+			const usage = {
+				input_tokens: 100,
+				output_tokens: 50,
+				input_tokens_details: {
+					cached_tokens: 30,
+					cache_miss_tokens: 70,
+				},
+			}
+
+			const result = (handler as any).normalizeUsage(usage, mockModel)
+
+			expect(result).toHaveProperty("totalCost")
+			expect(result.totalCost).toBeGreaterThan(0)
+			// Cost should be calculated with uncachedInputTokens = 100 - 30 = 70
+		})
+
+		it("should handle cost calculation with no cache reads", () => {
+			const usage = {
+				input_tokens: 100,
+				output_tokens: 50,
+			}
+
+			const result = (handler as any).normalizeUsage(usage, mockModel)
+
+			expect(result).toHaveProperty("totalCost")
+			expect(result.totalCost).toBeGreaterThan(0)
+			// Cost should be calculated with full input tokens since no cache reads
+		})
+	})
+})


### PR DESCRIPTION
## Description

This PR fixes an issue where caching information was not being reported when using the OpenAI-Native provider with the Responses API.

## Problem
The OpenAI-Native provider was not properly extracting and reporting cache token usage from the Responses API, which meant users couldn't see when their requests were using cached content or how many tokens were being cached.

## Solution
Added a `normalizeUsage` method that properly extracts cache-related token information from the Responses API response, with support for both detailed token shapes and legacy field names for compatibility.

### Key Changes:
- Added `normalizeUsage` method to extract and normalize usage data from various response formats
- Support for detailed token shapes (`input_tokens_details`, `output_tokens_details`) when available
- Proper fallback handling for legacy field names to ensure compatibility across different API versions and transport methods
- Calculate cache read/write tokens with appropriate fallbacks
- Include reasoning tokens when available in the output details
- Ensure accurate cost calculation using uncached input tokens to avoid double-counting

## Why Fallbacks Are Needed
Even though we exclusively use the Responses API, fallbacks are necessary because:
1. **SDK vs SSE transport differences**: When the SDK fails or returns non-AsyncIterable responses, we fall back to raw SSE which may use different field names
2. **Proxy/gateway variations**: Custom base URLs may point to proxies that transform field names
3. **Model/rollout differences**: Different models or API versions may omit detailed token info
4. **No-cache responses**: Responses without cache usage may omit the detailed blocks entirely

## Testing
- The changes maintain backward compatibility with existing usage tracking
- Properly handles responses with and without cache usage
- Correctly calculates costs based on cached vs uncached tokens

## Impact
Users will now be able to see:
- How many tokens were read from cache
- How many tokens were written to cache  
- Accurate cost calculations that account for cached content
- Reasoning tokens when using models that support them

Fixes the unreported issue with OpenAI-Native provider cache reporting.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds cache reporting support for OpenAI-Native provider by implementing `normalizeUsage` method to handle various response formats and cache-related fields.
> 
>   - **Behavior**:
>     - Adds `normalizeUsage` method in `openai-native.ts` to extract and normalize cache-related token information from Responses API.
>     - Supports detailed token shapes (`input_tokens_details`, `output_tokens_details`) and legacy field names.
>     - Calculates cache read/write tokens and includes reasoning tokens when available.
>     - Ensures accurate cost calculation using uncached input tokens.
>   - **Testing**:
>     - Adds tests in `openai-native-usage.spec.ts` to verify handling of detailed token shapes, legacy fields, SSE events, and edge cases.
>     - Tests cost calculation with and without cache reads.
>   - **Impact**:
>     - Users can see cache read/write tokens and accurate cost calculations, including reasoning tokens when supported.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3e073f3b4fe341699a4d0db047f34b5f0d7bab8d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->