### PR TITLE
Cloud: remove extension_bridge_enabled for personal users

### DIFF
--- a/packages/cloud/src/WebAuthService.ts
+++ b/packages/cloud/src/WebAuthService.ts
@@ -563,11 +563,7 @@ export class WebAuthService extends EventEmitter<AuthServiceEvents> implements A
 			)?.email_address
 		}
 
-		// Check for extension_bridge_enabled in user's public metadata
-		let extensionBridgeEnabled = false
-		if (userData.public_metadata?.extension_bridge_enabled === true) {
-			extensionBridgeEnabled = true
-		}
+		let extensionBridgeEnabled = true
 
 		// Fetch organization info if user is in organization context
 		try {
@@ -583,11 +579,7 @@ export class WebAuthService extends EventEmitter<AuthServiceEvents> implements A
 					if (userMembership) {
 						this.setUserOrganizationInfo(userInfo, userMembership)
 
-						// Check organization public metadata for extension_bridge_enabled
-						// Organization setting takes precedence over user setting
-						if (await this.isExtensionBridgeEnabledForOrganization(storedOrgId)) {
-							extensionBridgeEnabled = true
-						}
+						extensionBridgeEnabled = await this.isExtensionBridgeEnabledForOrganization(storedOrgId)
 
 						this.log("[auth] User in organization context:", {
 							id: userMembership.organization.id,
@@ -608,10 +600,9 @@ export class WebAuthService extends EventEmitter<AuthServiceEvents> implements A
 				if (primaryOrgMembership) {
 					this.setUserOrganizationInfo(userInfo, primaryOrgMembership)
 
-					// Check organization public metadata for extension_bridge_enabled
-					if (await this.isExtensionBridgeEnabledForOrganization(primaryOrgMembership.organization.id)) {
-						extensionBridgeEnabled = true
-					}
+					extensionBridgeEnabled = await this.isExtensionBridgeEnabledForOrganization(
+						primaryOrgMembership.organization.id,
+					)
 
 					this.log("[auth] Legacy credentials: Found organization membership:", {
 						id: primaryOrgMembership.organization.id,

--- a/packages/cloud/src/__tests__/WebAuthService.spec.ts
+++ b/packages/cloud/src/__tests__/WebAuthService.spec.ts
@@ -560,7 +560,7 @@ describe("WebAuthService", () => {
 					name: "John Doe",
 					email: "john@example.com",
 					picture: "https://example.com/avatar.jpg",
-					extensionBridgeEnabled: false,
+					extensionBridgeEnabled: true,
 				},
 			})
 		})
@@ -725,7 +725,7 @@ describe("WebAuthService", () => {
 				name: "Jane Smith",
 				email: "jane@example.com",
 				picture: "https://example.com/jane.jpg",
-				extensionBridgeEnabled: false,
+				extensionBridgeEnabled: true,
 			})
 		})
 
@@ -844,7 +844,7 @@ describe("WebAuthService", () => {
 				name: "John Doe",
 				email: undefined,
 				picture: undefined,
-				extensionBridgeEnabled: false,
+				extensionBridgeEnabled: true,
 			})
 		})
 	})
@@ -969,7 +969,7 @@ describe("WebAuthService", () => {
 					name: "Test User",
 					email: undefined,
 					picture: undefined,
-					extensionBridgeEnabled: false,
+					extensionBridgeEnabled: true,
 				},
 			})
 		})


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Default `extensionBridgeEnabled` to `true` and prioritize organization settings over user settings in `WebAuthService`.
> 
>   - **Behavior**:
>     - Default `extensionBridgeEnabled` to `true` in `WebAuthService`.
>     - Remove check for `extension_bridge_enabled` in user metadata.
>     - Prioritize organization setting for `extension_bridge_enabled` over user setting.
>   - **Tests**:
>     - Update `WebAuthService.spec.ts` to set `extensionBridgeEnabled` to `true` in test cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e7922fffd24a256a24e65a7df7c28c63d36db796. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->