### PR TITLE
Clear terminal output buffers to prevent memory leaks

### DIFF
--- a/src/integrations/terminal/BaseTerminalProcess.ts
+++ b/src/integrations/terminal/BaseTerminalProcess.ts
@@ -137,6 +137,20 @@ export abstract class BaseTerminalProcess extends EventEmitter<RooTerminalProces
 	 */
 	abstract getUnretrievedOutput(): string
 
+	/**
+	 * Trims already retrieved content from the internal output buffer.
+	 *
+	 * This prevents unbounded memory growth when processing large
+	 * command outputs by discarding data that has already been
+	 * consumed by callers of `getUnretrievedOutput`.
+	 */
+	protected trimRetrievedOutput(): void {
+		if (this.lastRetrievedIndex > 0) {
+			this.fullOutput = this.fullOutput.slice(this.lastRetrievedIndex)
+			this.lastRetrievedIndex = 0
+		}
+	}
+
 	protected startHotTimer(data: string) {
 		this.isHot = true
 

--- a/src/integrations/terminal/ExecaTerminalProcess.ts
+++ b/src/integrations/terminal/ExecaTerminalProcess.ts
@@ -146,6 +146,8 @@ export class ExecaTerminalProcess extends BaseTerminalProcess {
 		this.emitRemainingBufferIfListening()
 		this.stopHotTimer()
 		this.emit("completed", this.fullOutput)
+		this.lastRetrievedIndex = this.fullOutput.length
+		this.trimRetrievedOutput()
 		this.emit("continue")
 		this.subprocess = undefined
 	}

--- a/src/integrations/terminal/TerminalProcess.ts
+++ b/src/integrations/terminal/TerminalProcess.ts
@@ -254,6 +254,8 @@ export class TerminalProcess extends BaseTerminalProcess {
 		// so that api request stalls to let diagnostics catch up").
 		this.stopHotTimer()
 		this.emit("completed", this.removeEscapeSequences(this.fullOutput))
+		this.lastRetrievedIndex = this.fullOutput.length
+		this.trimRetrievedOutput()
 		this.emit("continue")
 	}
 


### PR DESCRIPTION
## Summary
- avoid retaining large command output by trimming buffers in BaseTerminalProcess
- clear stored output when TerminalProcess and ExecaTerminalProcess finish running commands

## Testing
- `pnpm exec vitest run integrations/terminal/__tests__/TerminalProcess.spec.ts integrations/terminal/__tests__/ExecaTerminalProcess.spec.ts`
- `pnpm exec eslint integrations/terminal/BaseTerminalProcess.ts integrations/terminal/ExecaTerminalProcess.ts integrations/terminal/TerminalProcess.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b9a2189e148330b3b21e8c713050d6