### PR TITLE
fix: Fix the issue of Moonshot's maximum return token count being limited to 1024

### DIFF
--- a/src/api/providers/__tests__/moonshot.spec.ts
+++ b/src/api/providers/__tests__/moonshot.spec.ts
@@ -294,4 +294,66 @@ describe("MoonshotHandler", () => {
 			expect(result.cacheReadTokens).toBeUndefined()
 		})
 	})
+
+	describe("addMaxTokensIfNeeded", () => {
+		it("should always add max_tokens regardless of includeMaxTokens option", () => {
+			// Create a test subclass to access the protected method
+			class TestMoonshotHandler extends MoonshotHandler {
+				public testAddMaxTokensIfNeeded(requestOptions: any, modelInfo: any) {
+					this.addMaxTokensIfNeeded(requestOptions, modelInfo)
+				}
+			}
+
+			const testHandler = new TestMoonshotHandler(mockOptions)
+			const requestOptions: any = {}
+			const modelInfo = {
+				maxTokens: 32_000,
+			}
+
+			// Test with includeMaxTokens set to false - should still add max tokens
+			testHandler.testAddMaxTokensIfNeeded(requestOptions, modelInfo)
+
+			expect(requestOptions.max_tokens).toBe(32_000)
+		})
+
+		it("should use modelMaxTokens when provided", () => {
+			class TestMoonshotHandler extends MoonshotHandler {
+				public testAddMaxTokensIfNeeded(requestOptions: any, modelInfo: any) {
+					this.addMaxTokensIfNeeded(requestOptions, modelInfo)
+				}
+			}
+
+			const customMaxTokens = 5000
+			const testHandler = new TestMoonshotHandler({
+				...mockOptions,
+				modelMaxTokens: customMaxTokens,
+			})
+			const requestOptions: any = {}
+			const modelInfo = {
+				maxTokens: 32_000,
+			}
+
+			testHandler.testAddMaxTokensIfNeeded(requestOptions, modelInfo)
+
+			expect(requestOptions.max_tokens).toBe(customMaxTokens)
+		})
+
+		it("should fall back to modelInfo.maxTokens when modelMaxTokens is not provided", () => {
+			class TestMoonshotHandler extends MoonshotHandler {
+				public testAddMaxTokensIfNeeded(requestOptions: any, modelInfo: any) {
+					this.addMaxTokensIfNeeded(requestOptions, modelInfo)
+				}
+			}
+
+			const testHandler = new TestMoonshotHandler(mockOptions)
+			const requestOptions: any = {}
+			const modelInfo = {
+				maxTokens: 16_000,
+			}
+
+			testHandler.testAddMaxTokensIfNeeded(requestOptions, modelInfo)
+
+			expect(requestOptions.max_tokens).toBe(16_000)
+		})
+	})
 })

--- a/src/api/providers/moonshot.ts
+++ b/src/api/providers/moonshot.ts
@@ -1,4 +1,5 @@
-import { moonshotModels, moonshotDefaultModelId } from "@roo-code/types"
+import OpenAI from "openai"
+import { moonshotModels, moonshotDefaultModelId, type ModelInfo } from "@roo-code/types"
 
 import type { ApiHandlerOptions } from "../../shared/api"
 
@@ -35,5 +36,16 @@ export class MoonshotHandler extends OpenAiHandler {
 			cacheWriteTokens: 0,
 			cacheReadTokens: usage?.cached_tokens,
 		}
+	}
+
+	// Override to always include max_completion_tokens for Moonshot
+	protected override addMaxTokensIfNeeded(
+		requestOptions:
+			| OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming
+			| OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming,
+		modelInfo: ModelInfo,
+	): void {
+		// Moonshot use max_tokens instead of max_completion_tokens
+		requestOptions.max_tokens = this.options.modelMaxTokens || modelInfo.maxTokens
 	}
 }

--- a/src/api/providers/moonshot.ts
+++ b/src/api/providers/moonshot.ts
@@ -38,7 +38,7 @@ export class MoonshotHandler extends OpenAiHandler {
 		}
 	}
 
-	// Override to always include max_completion_tokens for Moonshot
+	// Override to always include max_tokens for Moonshot (not max_completion_tokens)
 	protected override addMaxTokensIfNeeded(
 		requestOptions:
 			| OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming

--- a/src/api/providers/moonshot.ts
+++ b/src/api/providers/moonshot.ts
@@ -45,7 +45,7 @@ export class MoonshotHandler extends OpenAiHandler {
 			| OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming,
 		modelInfo: ModelInfo,
 	): void {
-		// Moonshot use max_tokens instead of max_completion_tokens
+		// Moonshot uses max_tokens instead of max_completion_tokens
 		requestOptions.max_tokens = this.options.modelMaxTokens || modelInfo.maxTokens
 	}
 }

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -408,7 +408,7 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 	 * Note: max_tokens is deprecated in favor of max_completion_tokens as per OpenAI documentation
 	 * O3 family models handle max_tokens separately in handleO3FamilyMessage
 	 */
-	private addMaxTokensIfNeeded(
+	protected addMaxTokensIfNeeded(
 		requestOptions:
 			| OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming
 			| OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming,


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #6936 

### Description

<!--
Briefly summarize the changes in this PR and how they address the linked issue.
The issue should cover the "what" and "why"; this section should focus on:
- The "how": key implementation details, design choices, or trade-offs made.
- Anything specific reviewers should pay attention to in this PR.
-->

Moonshot uses `max_tokens` instead of OpenAI API's latest `max_completion_tokens` to control the maximum number of output tokens. Unlike other providers such as Qwen and DeepSeek, which default to the maximum possible value, Moonshot defaults to 1024. This causes responses to be truncated, leading to repeated retry attempts. To resolve this, I modified the method signature of `addMaxTokensIfNeeded` in the OpenAI-compatible provider, and then overrode it in the Moonshot implementation to ensure that request options send `max_tokens` instead of the newer `max_completion_tokens`.

### Test Procedure

<!--
Detail the steps to test your changes. This helps reviewers verify your work.
- How did you test this specific implementation? (e.g., unit tests, manual testing steps)
- How can reviewers reproduce your tests or verify the fix/feature?
- Include relevant testing environment details if applicable.
-->

I set a breakpoint in the `createMessage` method and inspected the value of `requestOptions`, confirming that `max_tokens` is correctly passed as an option.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [ ] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [ ] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).


### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->

Discord username: haha.w

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Moonshot's token limit by using `max_tokens` instead of `max_completion_tokens` in `addMaxTokensIfNeeded()` to prevent response truncation.
> 
>   - **Behavior**:
>     - Fixes Moonshot's token limit issue by using `max_tokens` instead of `max_completion_tokens` in `addMaxTokensIfNeeded()` in `moonshot.ts`.
>     - Ensures `max_tokens` is set in `requestOptions` to prevent response truncation.
>   - **Functions**:
>     - Changes `addMaxTokensIfNeeded()` in `openai.ts` to `protected` for overriding.
>     - Overrides `addMaxTokensIfNeeded()` in `MoonshotHandler` to use `max_tokens`.
>   - **Misc**:
>     - Imports `OpenAI` in `moonshot.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for dcbfe004362b725e53e3b4895c11329802da12b8. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->