### PR TITLE
fix: prevent countdown timer from showing in history for answered follow-up questions

### DIFF
--- a/packages/types/src/message.ts
+++ b/packages/types/src/message.ts
@@ -214,6 +214,7 @@ export const clineMessageSchema = z.object({
 	contextCondense: contextCondenseSchema.optional(),
 	isProtected: z.boolean().optional(),
 	apiProtocol: z.union([z.literal("openai"), z.literal("anthropic")]).optional(),
+	isAnswered: z.boolean().optional(),
 	metadata: z
 		.object({
 			gpt5: z

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -887,6 +887,24 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 		this.askResponse = askResponse
 		this.askResponseText = text
 		this.askResponseImages = images
+
+		// Mark the last follow-up question as answered
+		if (askResponse === "messageResponse" || askResponse === "yesButtonClicked") {
+			// Find the last unanswered follow-up message using findLastIndex
+			const lastFollowUpIndex = findLastIndex(
+				this.clineMessages,
+				(msg) => msg.type === "ask" && msg.ask === "followup" && !msg.isAnswered,
+			)
+
+			if (lastFollowUpIndex !== -1) {
+				// Mark this follow-up as answered
+				this.clineMessages[lastFollowUpIndex].isAnswered = true
+				// Save the updated messages
+				this.saveClineMessages().catch((error) => {
+					console.error("Failed to save answered follow-up state:", error)
+				})
+			}
+		}
 	}
 
 	public approveAsk({ text, images }: { text?: string; images?: string[] } = {}) {

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -1499,7 +1499,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 					onSuggestionClick={handleSuggestionClickInRow} // This was already stabilized
 					onBatchFileResponse={handleBatchFileResponse}
 					onFollowUpUnmount={handleFollowUpUnmount}
-					isFollowUpAnswered={messageOrGroup.ts === currentFollowUpTs}
+					isFollowUpAnswered={messageOrGroup.isAnswered === true || messageOrGroup.ts === currentFollowUpTs}
 					editable={
 						messageOrGroup.type === "ask" &&
 						messageOrGroup.ask === "tool" &&


### PR DESCRIPTION
## Description

This PR fixes issue #7624 where the countdown timer for follow-up questions incorrectly reappears when viewing task history, even for questions that have already been answered.

## Problem

When a user answers a follow-up question and later returns to view the task history, the countdown timer would reappear on the already-answered question. This was happening because the "answered" state was only tracked locally in the React component state and wasn't persisted with the message data.

## Solution

The fix persists the answered state of follow-up questions by:
1. Adding an `isAnswered` field to the `ClineMessage` type to persist the follow-up answer state
2. Updating `Task.handleWebviewAskResponse` to mark follow-up questions as answered when a response is received
3. Modifying `ChatView` to pass the persisted `isAnswered` state to the `FollowUpSuggest` component
4. The `FollowUpSuggest` component now uses this persisted state to hide the countdown for answered questions

## Changes Made

- **packages/types/src/message.ts**: Added `isAnswered?` field to `ClineMessage` type
- **src/core/task/Task.ts**: Updated `handleWebviewAskResponse` to find and mark the last unanswered follow-up message as answered using `findLastIndex` utility
- **webview-ui/src/components/chat/ChatView.tsx**: Modified to pass the persisted `isAnswered` state from the message data to the `FollowUpSuggest` component

## Testing

The implementation has been tested and confirmed to work correctly. The countdown timer no longer appears for answered follow-up questions when viewing task history.

Fixes #7624
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue #7624 by persisting the answered state of follow-up questions to prevent countdown timer from reappearing in task history.
> 
>   - **Behavior**:
>     - Fixes issue #7624 by persisting the answered state of follow-up questions to prevent countdown timer from reappearing in task history.
>     - `FollowUpSuggest` component now hides countdown for answered questions using persisted state.
>   - **Data Structure**:
>     - Adds `isAnswered?` field to `ClineMessage` type in `message.ts` to track answered state.
>   - **Logic Updates**:
>     - Updates `Task.handleWebviewAskResponse` in `Task.ts` to mark follow-up questions as answered when a response is received.
>     - Modifies `ChatView` in `ChatView.tsx` to pass `isAnswered` state to `FollowUpSuggest` component.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 746e9c33a65650f6ca542ad556e91a5b02972eb1. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->