### PR TITLE
removing user hint when refreshing models

### DIFF
--- a/webview-ui/src/components/settings/providers/Requesty.tsx
+++ b/webview-ui/src/components/settings/providers/Requesty.tsx
@@ -36,8 +36,6 @@ export const Requesty = ({
 }: RequestyProps) => {
 	const { t } = useAppTranslation()
 
-	const [didRefetch, setDidRefetch] = useState<boolean>()
-
 	const [requestyEndpointSelected, setRequestyEndpointSelected] = useState(!!apiConfiguration.requestyBaseUrl)
 
 	// This ensures that the "Use custom URL" checkbox is hidden when the user deletes the URL.
@@ -131,18 +129,12 @@ export const Requesty = ({
 				onClick={() => {
 					vscode.postMessage({ type: "flushRouterModels", text: "requesty" })
 					refetchRouterModels()
-					setDidRefetch(true)
 				}}>
 				<div className="flex items-center gap-2">
 					<span className="codicon codicon-refresh" />
 					{t("settings:providers.refreshModels.label")}
 				</div>
 			</Button>
-			{didRefetch && (
-				<div className="flex items-center text-vscode-errorForeground">
-					{t("settings:providers.refreshModels.hint")}
-				</div>
-			)}
 			<ModelPicker
 				apiConfiguration={apiConfiguration}
 				setApiConfigurationField={setApiConfigurationField}


### PR DESCRIPTION
### Description

Previously we showed a hint to the user to go back to the home screen (which would trigger a refetch of /models in a previous Roo version). But now the button alone works, so no need for this warning

### Test Procedure
1. Select Requesty as a provider
2. Check models list
3. Create a new policy on the Requesty UI
4. Click the models refresh button in Roo
5. Check that the new policy appears.

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos
#### Previously
<img width="262" height="450" alt="Screenshot 2025-09-05 at 17 04 31" src="https://github.com/user-attachments/assets/f512bf1d-a583-43c3-a01b-3bee559a6f77" />

#### Now
https://github.com/user-attachments/assets/7073088b-856c-424d-97c6-9dc0cc51ef88
