### PR TITLE
Support Qwen3-Coder-480B-A35B-Instruct on Google Vertex AI

### DIFF
--- a/packages/types/src/providers/vertex.ts
+++ b/packages/types/src/providers/vertex.ts
@@ -295,7 +295,7 @@ export const vertexModels = {
 		description: "Meta Llama 4 Maverick 17B Instruct model, 128K context.",
 	},
 	"qwen/qwen3-coder-480b-a35b-instruct-maas": {
-		maxTokens: 65_536,
+		maxTokens: 32_768,
 		contextWindow: 262_144,
 		supportsImages: false,
 		supportsPromptCache: false,

--- a/packages/types/src/providers/vertex.ts
+++ b/packages/types/src/providers/vertex.ts
@@ -294,6 +294,15 @@ export const vertexModels = {
 		outputPrice: 1.15,
 		description: "Meta Llama 4 Maverick 17B Instruct model, 128K context.",
 	},
+	"qwen/qwen3-coder-480b-a35b-instruct-maas": {
+		maxTokens: 65_536,
+		contextWindow: 262_144,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 1,
+		outputPrice: 4,
+		description: "Qwen 3 Coder 480B Instruct",
+	},
 } as const satisfies Record<string, ModelInfo>
 
 export const VERTEX_REGIONS = [
@@ -306,6 +315,7 @@ export const VERTEX_REGIONS = [
 	{ value: "us-west2", label: "us-west2" },
 	{ value: "us-west3", label: "us-west3" },
 	{ value: "us-west4", label: "us-west4" },
+	{ value: "us-south1", label: "us-south1" },
 	{ value: "northamerica-northeast1", label: "northamerica-northeast1" },
 	{ value: "northamerica-northeast2", label: "northamerica-northeast2" },
 	{ value: "southamerica-east1", label: "southamerica-east1" },


### PR DESCRIPTION
### Description

Support Qwen3-Coder-480B-A35B-Instruct on Google Vertex AI
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for `qwen/qwen3-coder-480b-a35b-instruct-maas` model and `us-south1` region in Vertex AI configuration.
> 
>   - **Models**:
>     - Add `qwen/qwen3-coder-480b-a35b-instruct-maas` to `vertexModels` in `vertex.ts` with 65,536 max tokens, 262,144 context window, input price 1, output price 4.
>   - **Regions**:
>     - Add `us-south1` to `VERTEX_REGIONS` in `vertex.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4c5d79e3cbec363fd0692422ba6bd310927ea7a6. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->