### PR TITLE
fix: reduce CodeBlock button z-index to prevent overlap with popovers

### DIFF
--- a/webview-ui/src/components/common/CodeBlock.tsx
+++ b/webview-ui/src/components/common/CodeBlock.tsx
@@ -74,7 +74,7 @@ const CodeBlockButtonWrapper = styled.div`
 	top: var(--copy-button-top);
 	right: var(--copy-button-right, 8px);
 	height: auto;
-	z-index: 100;
+	z-index: 40;
 	background: ${CODE_BLOCK_BG_COLOR}${WRAPPER_ALPHA};
 	overflow: visible;
 	pointer-events: none;


### PR DESCRIPTION
## Description

This PR fixes an issue where the CodeBlock language dropdown and copy button were appearing above popovers and other overlay elements.

## Problem
The `CodeBlockButtonWrapper` component had a `z-index: 100`, which was higher than the standard popover z-index of 50 used throughout the application.

## Solution
- Changed the z-index from 100 to 40 in `webview-ui/src/components/common/CodeBlock.tsx`
- This ensures the buttons remain visible and functional above regular content
- They now properly stay below popovers and other overlay elements (z-index: 50)
- The UI layering hierarchy is maintained correctly

## Testing
- ✅ All existing CodeBlock tests pass successfully
- ✅ Type checking passes
- ✅ Linting passes
- ✅ Verified no other components have similar high z-index issues

Fixes #7703