### PR TITLE
Fix message queue re-queue loop in Task.ask()

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -845,9 +845,8 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			const message = this.messageQueueService.dequeueMessage()
 
 			if (message) {
-				setTimeout(async () => {
-					await this.submitUserMessage(message.text, message.images)
-				}, 0)
+				// Fulfill the ask directly to avoid re-queuing via the webview while sending is disabled
+				this.setMessageResponse(message.text, message.images)
 			}
 		}
 


### PR DESCRIPTION
## Summary

Fixes a regression where messages in the queue would fail to send during an ask operation, getting stuck in an infinite re-queue loop.

## Problem

When `Task.ask()` had queued messages to process, it would:
1. Dequeue a message
2. Call `submitUserMessage()` which posts an 'invoke: sendMessage' to the webview
3. The webview, with `sendingDisabled=true` during ask operations, would re-queue the message
4. This created an infinite loop where messages never actually got processed

## Solution

Replace the webview round-trip with a direct call to `setMessageResponse()` when processing queued messages. This:
- Bypasses the webview's disabled guard
- Immediately satisfies the pending ask operation
- Preserves checkpointing behavior via `handleWebviewAskResponse`

## Changes

- Modified `Task.ask()` to use `setMessageResponse()` instead of `submitUserMessage()` when processing queued messages

## Testing

The existing tests should verify that:
- Messages can be queued while an ask is pending
- Queued messages are properly drained when the ask completes
- No infinite loops occur in the queue processing