### PR TITLE
Fix Groq context window display

### DIFF
--- a/src/api/providers/__tests__/groq.spec.ts
+++ b/src/api/providers/__tests__/groq.spec.ts
@@ -149,7 +149,7 @@ describe("GroqHandler", () => {
 		expect(firstChunk.done).toBe(false)
 		expect(firstChunk.value).toMatchObject({
 			type: "usage",
-			inputTokens: 100, // Full token count, no longer subtracting cached tokens
+			inputTokens: 100,
 			outputTokens: 50,
 			cacheWriteTokens: 0,
 			cacheReadTokens: 30,

--- a/src/api/providers/__tests__/groq.spec.ts
+++ b/src/api/providers/__tests__/groq.spec.ts
@@ -149,7 +149,7 @@ describe("GroqHandler", () => {
 		expect(firstChunk.done).toBe(false)
 		expect(firstChunk.value).toMatchObject({
 			type: "usage",
-			inputTokens: 70, // 100 total - 30 cached
+			inputTokens: 100, // Full token count, no longer subtracting cached tokens
 			outputTokens: 50,
 			cacheWriteTokens: 0,
 			cacheReadTokens: 30,

--- a/src/api/providers/groq.ts
+++ b/src/api/providers/groq.ts
@@ -66,20 +66,9 @@ export class GroqHandler extends BaseOpenAiCompatibleProvider<GroqModelId> {
 		// Calculate cost using OpenAI-compatible cost calculation
 		const totalCost = calculateApiCostOpenAI(info, inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens)
 
-		// Calculate non-cached input tokens for proper reporting
-		const nonCachedInputTokens = Math.max(0, inputTokens - cacheReadTokens - cacheWriteTokens)
-
-		console.log("usage", {
-			inputTokens: nonCachedInputTokens,
-			outputTokens,
-			cacheWriteTokens,
-			cacheReadTokens,
-			totalCost,
-		})
-
 		yield {
 			type: "usage",
-			inputTokens: nonCachedInputTokens,
+			inputTokens,
 			outputTokens,
 			cacheWriteTokens,
 			cacheReadTokens,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix `GroqHandler` to report full input token count without subtracting cached tokens.
> 
>   - **Behavior**:
>     - `GroqHandler` in `groq.ts` now reports full `inputTokens` without subtracting cached tokens in `yieldUsage()`.
>     - Updates test in `groq.spec.ts` to expect full `inputTokens` count in `createMessage` test.
>   - **Tests**:
>     - Modify `createMessage should handle cached tokens in usage data` test in `groq.spec.ts` to expect `inputTokens: 100` instead of `70`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 417a40ff848b94077949d1e94cf2de91a54f2c1b. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->