### PR TITLE
Bust cache in generated image preview

### DIFF
--- a/src/core/tools/__tests__/generateImageTool.test.ts
+++ b/src/core/tools/__tests__/generateImageTool.test.ts
@@ -209,7 +209,12 @@ describe("generateImageTool", () => {
 			if (sayCall) {
 				const imageData = JSON.parse(sayCall[1])
 				expect(imageData.imageUri).toMatch(/\?t=\d+$/)
-				expect(imageData.imagePath).toBe("/test/workspace/test-image.png")
+				// Handle both Unix and Windows path separators
+				const expectedPath =
+					process.platform === "win32"
+						? "\\test\\workspace\\test-image.png"
+						: "/test/workspace/test-image.png"
+				expect(imageData.imagePath).toBe(expectedPath)
 			}
 		})
 	})

--- a/src/core/tools/__tests__/generateImageTool.test.ts
+++ b/src/core/tools/__tests__/generateImageTool.test.ts
@@ -163,6 +163,55 @@ describe("generateImageTool", () => {
 			expect(mockGenerateImage).toHaveBeenCalled()
 			expect(mockPushToolResult).toHaveBeenCalled()
 		})
+
+		it("should add cache-busting parameter to image URI", async () => {
+			const completeBlock: ToolUse = {
+				type: "tool_use",
+				name: "generate_image",
+				params: {
+					prompt: "Generate a test image",
+					path: "test-image.png",
+				},
+				partial: false,
+			}
+
+			// Mock convertToWebviewUri to return a test URI
+			const mockWebviewUri = "https://file+.vscode-resource.vscode-cdn.net/test/workspace/test-image.png"
+			mockCline.providerRef.deref().convertToWebviewUri = vi.fn().mockReturnValue(mockWebviewUri)
+
+			// Mock the OpenRouterHandler generateImage method
+			const mockGenerateImage = vi.fn().mockResolvedValue({
+				success: true,
+				imageData: "data:image/png;base64,fakebase64data",
+			})
+
+			vi.mocked(OpenRouterHandler).mockImplementation(
+				() =>
+					({
+						generateImage: mockGenerateImage,
+					}) as any,
+			)
+
+			await generateImageTool(
+				mockCline as Task,
+				completeBlock,
+				mockAskApproval,
+				mockHandleError,
+				mockPushToolResult,
+				mockRemoveClosingTag,
+			)
+
+			// Check that cline.say was called with image data containing cache-busting parameter
+			expect(mockCline.say).toHaveBeenCalledWith("image", expect.stringMatching(/"imageUri":"[^"]+\?t=\d+"/))
+
+			// Verify the imageUri contains the cache-busting parameter
+			const sayCall = mockCline.say.mock.calls.find((call: any[]) => call[0] === "image")
+			if (sayCall) {
+				const imageData = JSON.parse(sayCall[1])
+				expect(imageData.imageUri).toMatch(/\?t=\d+$/)
+				expect(imageData.imagePath).toBe("/test/workspace/test-image.png")
+			}
+		})
 	})
 
 	describe("missing parameters", () => {

--- a/src/core/tools/generateImageTool.ts
+++ b/src/core/tools/generateImageTool.ts
@@ -244,7 +244,11 @@ export async function generateImageTool(
 			const fullImagePath = path.join(cline.cwd, finalPath)
 
 			// Convert to webview URI if provider is available
-			const imageUri = provider?.convertToWebviewUri?.(fullImagePath) ?? vscode.Uri.file(fullImagePath).toString()
+			let imageUri = provider?.convertToWebviewUri?.(fullImagePath) ?? vscode.Uri.file(fullImagePath).toString()
+
+			// Add cache-busting parameter to prevent browser caching issues
+			const cacheBuster = Date.now()
+			imageUri = imageUri.includes("?") ? `${imageUri}&t=${cacheBuster}` : `${imageUri}?t=${cacheBuster}`
 
 			// Send the image with the webview URI
 			await cline.say("image", JSON.stringify({ imageUri, imagePath: fullImagePath }))

--- a/src/core/tools/generateImageTool.ts
+++ b/src/core/tools/generateImageTool.ts
@@ -241,9 +241,7 @@ export async function generateImageTool(
 
 			// Get the webview URI for the image
 			const provider = cline.providerRef.deref()
-			// Use forward slashes for consistency across platforms in the imagePath
 			const fullImagePath = path.join(cline.cwd, finalPath)
-			const normalizedImagePath = fullImagePath.replace(/\\/g, "/")
 
 			// Convert to webview URI if provider is available
 			let imageUri = provider?.convertToWebviewUri?.(fullImagePath) ?? vscode.Uri.file(fullImagePath).toString()
@@ -252,8 +250,8 @@ export async function generateImageTool(
 			const cacheBuster = Date.now()
 			imageUri = imageUri.includes("?") ? `${imageUri}&t=${cacheBuster}` : `${imageUri}?t=${cacheBuster}`
 
-			// Send the image with the webview URI (use normalized path for consistency)
-			await cline.say("image", JSON.stringify({ imageUri, imagePath: normalizedImagePath }))
+			// Send the image with the webview URI
+			await cline.say("image", JSON.stringify({ imageUri, imagePath: fullImagePath }))
 			pushToolResult(formatResponse.toolResult(getReadablePath(cline.cwd, finalPath)))
 
 			return

--- a/src/core/tools/generateImageTool.ts
+++ b/src/core/tools/generateImageTool.ts
@@ -241,7 +241,9 @@ export async function generateImageTool(
 
 			// Get the webview URI for the image
 			const provider = cline.providerRef.deref()
+			// Use forward slashes for consistency across platforms in the imagePath
 			const fullImagePath = path.join(cline.cwd, finalPath)
+			const normalizedImagePath = fullImagePath.replace(/\\/g, "/")
 
 			// Convert to webview URI if provider is available
 			let imageUri = provider?.convertToWebviewUri?.(fullImagePath) ?? vscode.Uri.file(fullImagePath).toString()
@@ -250,8 +252,8 @@ export async function generateImageTool(
 			const cacheBuster = Date.now()
 			imageUri = imageUri.includes("?") ? `${imageUri}&t=${cacheBuster}` : `${imageUri}?t=${cacheBuster}`
 
-			// Send the image with the webview URI
-			await cline.say("image", JSON.stringify({ imageUri, imagePath: fullImagePath }))
+			// Send the image with the webview URI (use normalized path for consistency)
+			await cline.say("image", JSON.stringify({ imageUri, imagePath: normalizedImagePath }))
 			pushToolResult(formatResponse.toolResult(getReadablePath(cline.cwd, finalPath)))
 
 			return


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds cache-busting parameter to image URIs in `generateImageTool.ts` to prevent browser caching issues, with tests verifying the change.
> 
>   - **Behavior**:
>     - Adds cache-busting parameter to image URIs in `generateImageTool.ts` to prevent browser caching issues.
>     - Uses current timestamp as cache-busting parameter.
>   - **Tests**:
>     - Adds test in `generateImageTool.test.ts` to verify cache-busting parameter is added to image URI.
>     - Ensures `mockCline.say` is called with image data containing cache-busting parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d40af13a7b2c7300a1ea756a758f6a290970613e. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->