### PR TITLE
feat: add Qwen3 Next 80B A3B models to chutes provider

### DIFF
--- a/packages/types/src/providers/chutes.ts
+++ b/packages/types/src/providers/chutes.ts
@@ -32,6 +32,8 @@ export type ChutesModelId =
 	| "moonshotai/Kimi-K2-Instruct-75k"
 	| "moonshotai/Kimi-K2-Instruct-0905"
 	| "Qwen/Qwen3-235B-A22B-Thinking-2507"
+	| "Qwen/Qwen3-Next-80B-A3B-Instruct"
+	| "Qwen/Qwen3-Next-80B-A3B-Thinking"
 
 export const chutesDefaultModelId: ChutesModelId = "deepseek-ai/DeepSeek-R1-0528"
 
@@ -307,5 +309,25 @@ export const chutesModels = {
 		inputPrice: 0.077968332,
 		outputPrice: 0.31202496,
 		description: "Qwen3 235B A22B Thinking 2507 model with 262K context window.",
+	},
+	"Qwen/Qwen3-Next-80B-A3B-Instruct": {
+		maxTokens: 32768,
+		contextWindow: 131072,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0,
+		outputPrice: 0,
+		description:
+			"Fast, stable instruction-tuned model optimized for complex tasks, RAG, and tool use without thinking traces.",
+	},
+	"Qwen/Qwen3-Next-80B-A3B-Thinking": {
+		maxTokens: 32768,
+		contextWindow: 131072,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0,
+		outputPrice: 0,
+		description:
+			"Reasoning-first model with structured thinking traces for multi-step problems, math proofs, and code synthesis.",
 	},
 } as const satisfies Record<string, ModelInfo>


### PR DESCRIPTION
## Summary

This PR adds two new Qwen3 Next models to the chutes provider:

### Models Added

1. **Qwen3-Next-80B-A3B-Instruct**
   - Fast, stable instruction-tuned model optimized for complex tasks, RAG, and tool use without thinking traces
   - Context window: 131,072 tokens
   - Max tokens: 32,768

2. **Qwen3-Next-80B-A3B-Thinking**
   - Reasoning-first model with structured thinking traces for multi-step problems, math proofs, and code synthesis
   - Context window: 131,072 tokens
   - Max tokens: 32,768

### Pricing
Both models are set to /bin/sh input/output pricing, following the existing pattern where most chutes models (28 out of 31) have zero pricing.

### Testing
- ✅ All chutes provider tests pass
- ✅ TypeScript compilation successful
- ✅ Pre-commit hooks pass

### Changes
- Added model IDs to `ChutesModelId` type
- Added model configurations to `chutesModels` object with appropriate descriptions
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Qwen3 Next 80B A3B models to chutes provider with specific configurations and zero pricing.
> 
>   - **Models Added**:
>     - `Qwen/Qwen3-Next-80B-A3B-Instruct` and `Qwen/Qwen3-Next-80B-A3B-Thinking` added to `ChutesModelId` in `chutes.ts`.
>     - Configurations for both models added to `chutesModels` with context window of 131,072 tokens and max tokens of 32,768.
>     - Both models have zero input/output pricing.
>   - **Testing**:
>     - All chutes provider tests pass.
>     - TypeScript compilation successful.
>     - Pre-commit hooks pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 825a0be7215efe5542ad87199b1d33158c596335. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->