### PR TITLE
Bb/ux/message feed

### DIFF
--- a/webview-ui/src/components/chat/BrowserSessionRow.tsx
+++ b/webview-ui/src/components/chat/BrowserSessionRow.tsx
@@ -14,6 +14,7 @@ import { useExtensionState } from "@src/context/ExtensionStateContext"
 import CodeBlock, { CODE_BLOCK_BG_COLOR } from "../common/CodeBlock"
 import { ChatRowContent } from "./ChatRow"
 import { ProgressIndicator } from "./ProgressIndicator"
+import { Globe, Pointer, SquareTerminal } from "lucide-react"
 
 interface BrowserSessionRowProps {
 	messages: ClineMessage[]
@@ -237,51 +238,42 @@ const BrowserSessionRow = memo((props: BrowserSessionRowProps) => {
 	const [browserSessionRow, { height: rowHeight }] = useSize(
 		<div style={{ padding: "10px 6px 10px 15px", marginBottom: -10 }}>
 			<div style={{ display: "flex", alignItems: "center", gap: "10px", marginBottom: "10px" }}>
-				{isBrowsing ? (
-					<ProgressIndicator />
-				) : (
-					<span
-						className={`codicon codicon-inspect`}
-						style={{ color: "var(--vscode-foreground)", marginBottom: "-1.5px" }}></span>
-				)}
+				{isBrowsing ? <ProgressIndicator /> : <Pointer className="w-4" />}
 				<span style={{ fontWeight: "bold" }}>
 					<>{t("chat:browser.rooWantsToUse")}</>
 				</span>
 			</div>
 			<div
+				className="ml-6 mb-4 border-border"
 				style={{
-					borderRadius: 3,
-					border: "1px solid var(--vscode-editorGroup-border)",
+					borderRadius: 6,
 					overflow: "hidden",
 					backgroundColor: CODE_BLOCK_BG_COLOR,
-					marginBottom: 10,
 				}}>
 				{/* URL Bar */}
 				<div
 					style={{
-						margin: "5px auto",
-						width: "calc(100% - 10px)",
+						margin: "0px auto",
+						width: "calc(100%)",
 						boxSizing: "border-box", // includes padding in width calculation
-						backgroundColor: "var(--vscode-input-background)",
-						border: "1px solid var(--vscode-input-border)",
-						borderRadius: "4px",
-						padding: "3px 5px",
+						borderRadius: "4px 4px 0 0",
+						padding: "5px",
 						display: "flex",
 						alignItems: "center",
 						justifyContent: "center",
-						color: displayState.url
-							? "var(--vscode-input-foreground)"
-							: "var(--vscode-descriptionForeground)",
+						color: "var(--vscode-descriptionForeground)",
 						fontSize: "12px",
 					}}>
 					<div
 						style={{
+							cursor: "default",
 							textOverflow: "ellipsis",
 							overflow: "hidden",
 							whiteSpace: "nowrap",
 							width: "100%",
 							textAlign: "center",
 						}}>
+						<Globe className="w-3 inline -mt-0.5 mr-2 opacity-50" />
 						{displayState.url || "http"}
 					</div>
 				</div>
@@ -289,6 +281,7 @@ const BrowserSessionRow = memo((props: BrowserSessionRowProps) => {
 				{/* Screenshot Area */}
 				<div
 					data-testid="screenshot-container"
+					className="hover:opacity-90 transition-all"
 					style={{
 						width: "100%",
 						paddingBottom: `${aspectRatio}%`, // height/width ratio
@@ -341,27 +334,24 @@ const BrowserSessionRow = memo((props: BrowserSessionRowProps) => {
 					)}
 				</div>
 
-				<div style={{ width: "100%" }}>
-					<div
-						onClick={() => {
-							setConsoleLogsExpanded(!consoleLogsExpanded)
-						}}
-						style={{
-							display: "flex",
-							alignItems: "center",
-							gap: "4px",
-							width: "100%",
-							justifyContent: "flex-start",
-							cursor: "pointer",
-							padding: `9px 8px ${consoleLogsExpanded ? 0 : 8}px 8px`,
-						}}>
-						<span className={`codicon codicon-chevron-${consoleLogsExpanded ? "down" : "right"}`}></span>
-						<span style={{ fontSize: "0.8em" }}>{t("chat:browser.consoleLogs")}</span>
-					</div>
-					{consoleLogsExpanded && (
-						<CodeBlock source={displayState.consoleLogs || t("chat:browser.noNewLogs")} language="shell" />
-					)}
+				{/* Console Logs Accordion */}
+				<div
+					onClick={() => {
+						setConsoleLogsExpanded(!consoleLogsExpanded)
+					}}
+					className="flex items-center justify-between gap-2 text-vscode-editor-foreground/50 hover:text-vscode-editor-foreground transition-colors"
+					style={{
+						width: "100%",
+						cursor: "pointer",
+						padding: `9px 10px ${consoleLogsExpanded ? 0 : 8}px 10px`,
+					}}>
+					<SquareTerminal className="w-3" />
+					<span className="grow text-xs">{t("chat:browser.consoleLogs")}</span>
+					<span className={`codicon codicon-chevron-${consoleLogsExpanded ? "right" : "down"}`}></span>
 				</div>
+				{consoleLogsExpanded && (
+					<CodeBlock source={displayState.consoleLogs || t("chat:browser.noNewLogs")} language="shell" />
+				)}
 			</div>
 
 			{/* Action content with min height */}

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -47,6 +47,7 @@ import { McpExecution } from "./McpExecution"
 import { ChatTextArea } from "./ChatTextArea"
 import { MAX_IMAGES_PER_MESSAGE } from "./ChatView"
 import { useSelectedModel } from "../ui/hooks/useSelectedModel"
+import { Bot, CircleCheck, Eye, FileDiff, ListTree, PlugZap } from "lucide-react"
 
 interface ChatRowProps {
 	message: ClineMessage
@@ -287,7 +288,7 @@ export const ChatRowContent = ({
 							getIconSpan("error", errorColor)
 						)
 					) : cost !== null && cost !== undefined ? (
-						getIconSpan("check")
+						<CircleCheck className="w-4" />
 					) : apiRequestFailedMessage ? (
 						getIconSpan("error", errorColor)
 					) : (
@@ -304,7 +305,7 @@ export const ChatRowContent = ({
 							</span>
 						)
 					) : cost !== null && cost !== undefined ? (
-						<span style={{ color: normalColor, fontWeight: "bold" }}>{t("chat:apiRequest.title")}</span>
+						<span style={{ color: normalColor }}>{t("chat:apiRequest.title")}</span>
 					) : apiRequestFailedMessage ? (
 						<span style={{ color: errorColor, fontWeight: "bold" }}>{t("chat:apiRequest.failed")}</span>
 					) : (
@@ -366,7 +367,7 @@ export const ChatRowContent = ({
 					return (
 						<>
 							<div style={headerStyle}>
-								{toolIcon("diff")}
+								<FileDiff className="w-4" />
 								<span style={{ fontWeight: "bold" }}>
 									{t("chat:fileOperations.wantsToApplyBatchChanges")}
 								</span>
@@ -396,15 +397,17 @@ export const ChatRowContent = ({
 										: t("chat:fileOperations.wantsToEdit")}
 							</span>
 						</div>
-						<CodeAccordian
-							path={tool.path}
-							code={tool.content ?? tool.diff}
-							language="diff"
-							progressStatus={message.progressStatus}
-							isLoading={message.partial}
-							isExpanded={isExpanded}
-							onToggleExpand={handleToggleExpand}
-						/>
+						<div className="pl-6">
+							<CodeAccordian
+								path={tool.path}
+								code={tool.content ?? tool.diff}
+								language="diff"
+								progressStatus={message.progressStatus}
+								isLoading={message.partial}
+								isExpanded={isExpanded}
+								onToggleExpand={handleToggleExpand}
+							/>
+						</div>
 					</>
 				)
 			case "insertContent":
@@ -431,15 +434,17 @@ export const ChatRowContent = ({
 												})}
 							</span>
 						</div>
-						<CodeAccordian
-							path={tool.path}
-							code={tool.diff}
-							language="diff"
-							progressStatus={message.progressStatus}
-							isLoading={message.partial}
-							isExpanded={isExpanded}
-							onToggleExpand={handleToggleExpand}
-						/>
+						<div className="pl-6">
+							<CodeAccordian
+								path={tool.path}
+								code={tool.diff}
+								language="diff"
+								progressStatus={message.progressStatus}
+								isLoading={message.partial}
+								isExpanded={isExpanded}
+								onToggleExpand={handleToggleExpand}
+							/>
+						</div>
 					</>
 				)
 			case "searchAndReplace":
@@ -462,15 +467,17 @@ export const ChatRowContent = ({
 										: t("chat:fileOperations.didSearchReplace")}
 							</span>
 						</div>
-						<CodeAccordian
-							path={tool.path}
-							code={tool.diff}
-							language="diff"
-							progressStatus={message.progressStatus}
-							isLoading={message.partial}
-							isExpanded={isExpanded}
-							onToggleExpand={handleToggleExpand}
-						/>
+						<div className="pl-6">
+							<CodeAccordian
+								path={tool.path}
+								code={tool.diff}
+								language="diff"
+								progressStatus={message.progressStatus}
+								isLoading={message.partial}
+								isExpanded={isExpanded}
+								onToggleExpand={handleToggleExpand}
+							/>
+						</div>
 					</>
 				)
 			case "codebaseSearch": {
@@ -528,15 +535,17 @@ export const ChatRowContent = ({
 									: t("chat:fileOperations.wantsToCreate")}
 							</span>
 						</div>
-						<CodeAccordian
-							path={tool.path}
-							code={tool.content}
-							language={getLanguageFromPath(tool.path || "") || "log"}
-							isLoading={message.partial}
-							isExpanded={isExpanded}
-							onToggleExpand={handleToggleExpand}
-							onJumpToFile={() => vscode.postMessage({ type: "openFile", text: "./" + tool.path })}
-						/>
+						<div className="pl-6">
+							<CodeAccordian
+								path={tool.path}
+								code={tool.content}
+								language={getLanguageFromPath(tool.path || "") || "log"}
+								isLoading={message.partial}
+								isExpanded={isExpanded}
+								onToggleExpand={handleToggleExpand}
+								onJumpToFile={() => vscode.postMessage({ type: "openFile", text: "./" + tool.path })}
+							/>
+						</div>
 					</>
 				)
 			case "readFile":
@@ -547,7 +556,7 @@ export const ChatRowContent = ({
 					return (
 						<>
 							<div style={headerStyle}>
-								{toolIcon("files")}
+								<Eye className="w-4" />
 								<span style={{ fontWeight: "bold" }}>
 									{t("chat:fileOperations.wantsToReadMultiple")}
 								</span>
@@ -580,21 +589,23 @@ export const ChatRowContent = ({
 									: t("chat:fileOperations.didRead")}
 							</span>
 						</div>
-						<ToolUseBlock>
-							<ToolUseBlockHeader
-								onClick={() => vscode.postMessage({ type: "openFile", text: tool.content })}>
-								{tool.path?.startsWith(".") && <span>.</span>}
-								<span className="whitespace-nowrap overflow-hidden text-ellipsis text-left mr-2 rtl">
-									{removeLeadingNonAlphanumeric(tool.path ?? "") + "\u200E"}
-									{tool.reason}
-								</span>
-								<div style={{ flexGrow: 1 }}></div>
-								<span
-									className={`codicon codicon-link-external`}
-									style={{ fontSize: 13.5, margin: "1px 0" }}
-								/>
-							</ToolUseBlockHeader>
-						</ToolUseBlock>
+						<div className="pl-6">
+							<ToolUseBlock>
+								<ToolUseBlockHeader
+									onClick={() => vscode.postMessage({ type: "openFile", text: tool.content })}>
+									{tool.path?.startsWith(".") && <span>.</span>}
+									<span className="whitespace-nowrap overflow-hidden text-ellipsis text-left mr-2 rtl">
+										{removeLeadingNonAlphanumeric(tool.path ?? "") + "\u200E"}
+										{tool.reason}
+									</span>
+									<div style={{ flexGrow: 1 }}></div>
+									<span
+										className={`codicon codicon-link-external`}
+										style={{ fontSize: 13.5, margin: "1px 0" }}
+									/>
+								</ToolUseBlockHeader>
+							</ToolUseBlock>
+						</div>
 					</>
 				)
 			case "fetchInstructions":
@@ -604,20 +615,22 @@ export const ChatRowContent = ({
 							{toolIcon("file-code")}
 							<span style={{ fontWeight: "bold" }}>{t("chat:instructions.wantsToFetch")}</span>
 						</div>
-						<CodeAccordian
-							code={tool.content}
-							language="markdown"
-							isLoading={message.partial}
-							isExpanded={isExpanded}
-							onToggleExpand={handleToggleExpand}
-						/>
+						<div className="pl-6">
+							<CodeAccordian
+								code={tool.content}
+								language="markdown"
+								isLoading={message.partial}
+								isExpanded={isExpanded}
+								onToggleExpand={handleToggleExpand}
+							/>
+						</div>
 					</>
 				)
 			case "listFilesTopLevel":
 				return (
 					<>
 						<div style={headerStyle}>
-							{toolIcon("folder-opened")}
+							<ListTree className="w-4" />
 							<span style={{ fontWeight: "bold" }}>
 								{message.type === "ask"
 									? tool.isOutsideWorkspace
@@ -628,13 +641,15 @@ export const ChatRowContent = ({
 										: t("chat:directoryOperations.didViewTopLevel")}
 							</span>
 						</div>
-						<CodeAccordian
-							path={tool.path}
-							code={tool.content}
-							language="shell-session"
-							isExpanded={isExpanded}
-							onToggleExpand={handleToggleExpand}
-						/>
+						<div className="pl-6">
+							<CodeAccordian
+								path={tool.path}
+								code={tool.content}
+								language="shell-session"
+								isExpanded={isExpanded}
+								onToggleExpand={handleToggleExpand}
+							/>
+						</div>
 					</>
 				)
 			case "listFilesRecursive":
@@ -652,13 +667,15 @@ export const ChatRowContent = ({
 										: t("chat:directoryOperations.didViewRecursive")}
 							</span>
 						</div>
-						<CodeAccordian
-							path={tool.path}
-							code={tool.content}
-							language="shellsession"
-							isExpanded={isExpanded}
-							onToggleExpand={handleToggleExpand}
-						/>
+						<div className="pl-6">
+							<CodeAccordian
+								path={tool.path}
+								code={tool.content}
+								language="shellsession"
+								isExpanded={isExpanded}
+								onToggleExpand={handleToggleExpand}
+							/>
+						</div>
 					</>
 				)
 			case "listCodeDefinitionNames":
@@ -676,13 +693,15 @@ export const ChatRowContent = ({
 										: t("chat:directoryOperations.didViewDefinitions")}
 							</span>
 						</div>
-						<CodeAccordian
-							path={tool.path}
-							code={tool.content}
-							language="markdown"
-							isExpanded={isExpanded}
-							onToggleExpand={handleToggleExpand}
-						/>
+						<div className="pl-6">
+							<CodeAccordian
+								path={tool.path}
+								code={tool.content}
+								language="markdown"
+								isExpanded={isExpanded}
+								onToggleExpand={handleToggleExpand}
+							/>
+						</div>
 					</>
 				)
 			case "searchFiles":
@@ -714,13 +733,15 @@ export const ChatRowContent = ({
 								)}
 							</span>
 						</div>
-						<CodeAccordian
-							path={tool.path! + (tool.filePattern ? `/(${tool.filePattern})` : "")}
-							code={tool.content}
-							language="shellsession"
-							isExpanded={isExpanded}
-							onToggleExpand={handleToggleExpand}
-						/>
+						<div className="pl-6">
+							<CodeAccordian
+								path={tool.path! + (tool.filePattern ? `/(${tool.filePattern})` : "")}
+								code={tool.content}
+								language="shellsession"
+								isExpanded={isExpanded}
+								onToggleExpand={handleToggleExpand}
+							/>
+						</div>
 					</>
 				)
 			case "switchMode":
@@ -938,13 +959,15 @@ export const ChatRowContent = ({
 							</span>
 						</div>
 						{message.type === "ask" && (
-							<CodeAccordian
-								path={tool.path}
-								code={tool.content}
-								language="text"
-								isExpanded={isExpanded}
-								onToggleExpand={handleToggleExpand}
-							/>
+							<div className="pl-6">
+								<CodeAccordian
+									path={tool.path}
+									code={tool.content}
+									language="text"
+									isExpanded={isExpanded}
+									onToggleExpand={handleToggleExpand}
+								/>
+							</div>
 						)}
 					</>
 				)
@@ -1145,7 +1168,7 @@ export const ChatRowContent = ({
 							)}
 
 							{isExpanded && (
-								<div style={{ marginTop: "10px" }}>
+								<div className="ml-6" style={{ marginTop: "10px" }}>
 									<CodeAccordian
 										code={safeJsonParse<any>(message.text)?.request}
 										language="markdown"
@@ -1345,55 +1368,60 @@ export const ChatRowContent = ({
 											}}></span>
 										<span style={{ fontWeight: "bold" }}>{t("chat:slashCommand.didRun")}</span>
 									</div>
-									<ToolUseBlock>
-										<ToolUseBlockHeader
-											style={{
-												display: "flex",
-												flexDirection: "column",
-												alignItems: "flex-start",
-												gap: "4px",
-												padding: "10px 12px",
-											}}>
-											<div
+									<div className="pl-6">
+										<ToolUseBlock>
+											<ToolUseBlockHeader
 												style={{
 													display: "flex",
-													alignItems: "center",
-													gap: "8px",
-													width: "100%",
+													flexDirection: "column",
+													alignItems: "flex-start",
+													gap: "4px",
+													padding: "10px 12px",
 												}}>
-												<span
-													style={{ fontWeight: "500", fontSize: "var(--vscode-font-size)" }}>
-													/{slashCommandInfo.command}
-												</span>
-												{slashCommandInfo.args && (
-													<span
-														style={{
-															color: "var(--vscode-descriptionForeground)",
-															fontSize: "var(--vscode-font-size)",
-														}}>
-														{slashCommandInfo.args}
-													</span>
-												)}
-											</div>
-											{slashCommandInfo.description && (
 												<div
 													style={{
-														color: "var(--vscode-descriptionForeground)",
-														fontSize: "calc(var(--vscode-font-size) - 1px)",
+														display: "flex",
+														alignItems: "center",
+														gap: "8px",
+														width: "100%",
 													}}>
-													{slashCommandInfo.description}
+													<span
+														style={{
+															fontWeight: "500",
+															fontSize: "var(--vscode-font-size)",
+														}}>
+														/{slashCommandInfo.command}
+													</span>
+													{slashCommandInfo.args && (
+														<span
+															style={{
+																color: "var(--vscode-descriptionForeground)",
+																fontSize: "var(--vscode-font-size)",
+															}}>
+															{slashCommandInfo.args}
+														</span>
+													)}
 												</div>
-											)}
-											{slashCommandInfo.source && (
-												<div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
-													<VSCodeBadge
-														style={{ fontSize: "calc(var(--vscode-font-size) - 2px)" }}>
-														{slashCommandInfo.source}
-													</VSCodeBadge>
-												</div>
-											)}
-										</ToolUseBlockHeader>
-									</ToolUseBlock>
+												{slashCommandInfo.description && (
+													<div
+														style={{
+															color: "var(--vscode-descriptionForeground)",
+															fontSize: "calc(var(--vscode-font-size) - 1px)",
+														}}>
+														{slashCommandInfo.description}
+													</div>
+												)}
+												{slashCommandInfo.source && (
+													<div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+														<VSCodeBadge
+															style={{ fontSize: "calc(var(--vscode-font-size) - 2px)" }}>
+															{slashCommandInfo.source}
+														</VSCodeBadge>
+													</div>
+												)}
+											</ToolUseBlockHeader>
+										</ToolUseBlock>
+									</div>
 								</>
 							)
 						}

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -287,7 +287,7 @@ export const ChatRowContent = ({
 							getIconSpan("error", errorColor)
 						)
 					) : cost !== null && cost !== undefined ? (
-						getIconSpan("check", successColor)
+						getIconSpan("check")
 					) : apiRequestFailedMessage ? (
 						getIconSpan("error", errorColor)
 					) : (
@@ -1114,10 +1114,11 @@ export const ChatRowContent = ({
 								<div style={{ display: "flex", alignItems: "center", gap: "10px", flexGrow: 1 }}>
 									{icon}
 									{title}
-									<VSCodeBadge
-										style={{ opacity: cost !== null && cost !== undefined && cost > 0 ? 1 : 0 }}>
-										${Number(cost || 0)?.toFixed(4)}
-									</VSCodeBadge>
+								</div>
+								<div
+									className="text-xs text-vscode-dropdown-foreground border-vscode-dropdown-border/50 border px-1.5 py-0.5 rounded-lg"
+									style={{ opacity: cost !== null && cost !== undefined && cost > 0 ? 1 : 0 }}>
+									${Number(cost || 0)?.toFixed(4)}
 								</div>
 								<span className={`codicon codicon-chevron-${isExpanded ? "up" : "down"}`}></span>
 							</div>

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1270,7 +1270,7 @@ export const ChatRowContent = ({
 								{icon}
 								{title}
 							</div>
-							<div style={{ color: "var(--vscode-charts-green)", paddingTop: 10 }}>
+							<div className="border-l border-green-600/30 ml-2 pl-4 pb-1">
 								<Markdown markdown={message.text} />
 							</div>
 						</>

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -47,7 +47,7 @@ import { McpExecution } from "./McpExecution"
 import { ChatTextArea } from "./ChatTextArea"
 import { MAX_IMAGES_PER_MESSAGE } from "./ChatView"
 import { useSelectedModel } from "../ui/hooks/useSelectedModel"
-import { CircleCheck, Eye, FileDiff, ListTree } from "lucide-react"
+import { ChevronRight, ChevronDown, Eye, FileDiff, ListTree } from "lucide-react"
 
 interface ChatRowProps {
 	message: ClineMessage
@@ -288,7 +288,11 @@ export const ChatRowContent = ({
 							getIconSpan("error", errorColor)
 						)
 					) : cost !== null && cost !== undefined ? (
-						<CircleCheck className="w-4" />
+						isExpanded ? (
+							<ChevronDown className="w-4" />
+						) : (
+							<ChevronRight className="w-4" />
+						)
 					) : apiRequestFailedMessage ? (
 						getIconSpan("error", errorColor)
 					) : (
@@ -323,7 +327,17 @@ export const ChatRowContent = ({
 			default:
 				return [null, null]
 		}
-	}, [type, isCommandExecuting, message, isMcpServerResponding, apiReqCancelReason, cost, apiRequestFailedMessage, t])
+	}, [
+		type,
+		isCommandExecuting,
+		message,
+		isMcpServerResponding,
+		apiReqCancelReason,
+		cost,
+		apiRequestFailedMessage,
+		t,
+		isExpanded,
+	])
 
 	const headerStyle: React.CSSProperties = {
 		display: "flex",
@@ -890,6 +904,7 @@ export const ChatRowContent = ({
 							}}
 							onClick={handleToggleExpand}>
 							<ToolUseBlockHeader
+								className="group"
 								style={{
 									display: "flex",
 									alignItems: "center",
@@ -906,7 +921,8 @@ export const ChatRowContent = ({
 										</VSCodeBadge>
 									)}
 								</div>
-								<span className={`codicon codicon-chevron-${isExpanded ? "up" : "down"}`}></span>
+								<span
+									className={`codicon codicon-chevron-${isExpanded ? "up" : "down"} opacity-0 group-hover:opacity-100 transition-opacity duration-200`}></span>
 							</ToolUseBlockHeader>
 							{isExpanded && (slashCommandInfo.args || slashCommandInfo.description) && (
 								<div
@@ -1116,9 +1132,19 @@ export const ChatRowContent = ({
 						/>
 					)
 				case "api_req_started":
+					// Determine if the API request is in progress
+					const isApiRequestInProgress =
+						apiReqCancelReason === null &&
+						apiReqCancelReason === undefined &&
+						(cost === null || cost === undefined) &&
+						!apiRequestFailedMessage
+
 					return (
 						<>
 							<div
+								className={`group text-sm transition-opacity ${
+									isApiRequestInProgress ? "opacity-100" : "opacity-40 hover:opacity-100"
+								}`}
 								style={{
 									...headerStyle,
 									marginBottom:
@@ -1143,7 +1169,6 @@ export const ChatRowContent = ({
 									style={{ opacity: cost !== null && cost !== undefined && cost > 0 ? 1 : 0 }}>
 									${Number(cost || 0)?.toFixed(4)}
 								</div>
-								<span className={`codicon codicon-chevron-${isExpanded ? "up" : "down"}`}></span>
 							</div>
 							{(((cost === null || cost === undefined) && apiRequestFailedMessage) ||
 								apiReqStreamingFailedMessage) && (

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -47,7 +47,7 @@ import { McpExecution } from "./McpExecution"
 import { ChatTextArea } from "./ChatTextArea"
 import { MAX_IMAGES_PER_MESSAGE } from "./ChatView"
 import { useSelectedModel } from "../ui/hooks/useSelectedModel"
-import { Bot, CircleCheck, Eye, FileDiff, ListTree, PlugZap } from "lucide-react"
+import { CircleCheck, Eye, FileDiff, ListTree } from "lucide-react"
 
 interface ChatRowProps {
 	message: ClineMessage

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -45,7 +45,17 @@ import { McpExecution } from "./McpExecution"
 import { ChatTextArea } from "./ChatTextArea"
 import { MAX_IMAGES_PER_MESSAGE } from "./ChatView"
 import { useSelectedModel } from "../ui/hooks/useSelectedModel"
-import { ChevronRight, ChevronDown, Eye, FileDiff, ListTree, User, Edit, Trash2 } from "lucide-react"
+import {
+	ChevronRight,
+	ChevronDown,
+	Eye,
+	FileDiff,
+	ListTree,
+	User,
+	Edit,
+	Trash2,
+	MessageCircleQuestionMark,
+} from "lucide-react"
 import { cn } from "@/lib/utils"
 
 interface ChatRowProps {
@@ -303,10 +313,7 @@ export const ChatRowContent = ({
 				]
 			case "followup":
 				return [
-					<span
-						className="codicon codicon-question"
-						style={{ color: normalColor, marginBottom: "-1.5px" }}
-					/>,
+					<MessageCircleQuestionMark className="w-4" />,
 					<span style={{ color: normalColor, fontWeight: "bold" }}>{t("chat:questions.hasQuestion")}</span>,
 				]
 			default:
@@ -1472,18 +1479,18 @@ export const ChatRowContent = ({
 									{title}
 								</div>
 							)}
-							<div style={{ paddingTop: 10, paddingBottom: 15 }}>
+							<div className="flex flex-col gap-2 ml-6">
 								<Markdown
 									markdown={message.partial === true ? message?.text : followUpData?.question}
 								/>
+								<FollowUpSuggest
+									suggestions={followUpData?.suggest}
+									onSuggestionClick={onSuggestionClick}
+									ts={message?.ts}
+									onCancelAutoApproval={onFollowUpUnmount}
+									isAnswered={isFollowUpAnswered}
+								/>
 							</div>
-							<FollowUpSuggest
-								suggestions={followUpData?.suggest}
-								onSuggestionClick={onSuggestionClick}
-								ts={message?.ts}
-								onCancelAutoApproval={onFollowUpUnmount}
-								isAnswered={isFollowUpAnswered}
-							/>
 						</>
 					)
 				case "auto_approval_max_req_reached": {

--- a/webview-ui/src/components/chat/ErrorRow.tsx
+++ b/webview-ui/src/components/chat/ErrorRow.tsx
@@ -1,0 +1,141 @@
+import React, { useState, useCallback, memo } from "react"
+import { useTranslation } from "react-i18next"
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
+import { MessageCircleWarning } from "lucide-react"
+import { useCopyToClipboard } from "@src/utils/clipboard"
+import CodeBlock from "../common/CodeBlock"
+
+export interface ErrorRowProps {
+	type: "error" | "mistake_limit" | "api_failure" | "diff_error" | "streaming_failed" | "cancelled"
+	title?: string
+	message: string
+	showCopyButton?: boolean
+	expandable?: boolean
+	defaultExpanded?: boolean
+	additionalContent?: React.ReactNode
+	headerClassName?: string
+	messageClassName?: string
+}
+
+/**
+ * Unified error display component for all error types in the chat
+ */
+export const ErrorRow = memo(
+	({
+		type,
+		title,
+		message,
+		showCopyButton = false,
+		expandable = false,
+		defaultExpanded = false,
+		additionalContent,
+		headerClassName,
+		messageClassName,
+	}: ErrorRowProps) => {
+		const { t } = useTranslation()
+		const [isExpanded, setIsExpanded] = useState(defaultExpanded)
+		const [showCopySuccess, setShowCopySuccess] = useState(false)
+		const { copyWithFeedback } = useCopyToClipboard()
+
+		// Default titles for different error types
+		const getDefaultTitle = () => {
+			if (title) return title
+
+			switch (type) {
+				case "error":
+					return t("chat:error")
+				case "mistake_limit":
+					return t("chat:troubleMessage")
+				case "api_failure":
+					return t("chat:apiRequest.failed")
+				case "streaming_failed":
+					return t("chat:apiRequest.streamingFailed")
+				case "cancelled":
+					return t("chat:apiRequest.cancelled")
+				case "diff_error":
+					return t("chat:diffError.title")
+				default:
+					return null
+			}
+		}
+
+		const handleToggleExpand = useCallback(() => {
+			if (expandable) {
+				setIsExpanded(!isExpanded)
+			}
+		}, [expandable, isExpanded])
+
+		const handleCopy = useCallback(
+			async (e: React.MouseEvent) => {
+				e.stopPropagation()
+				const success = await copyWithFeedback(message)
+				if (success) {
+					setShowCopySuccess(true)
+					setTimeout(() => {
+						setShowCopySuccess(false)
+					}, 1000)
+				}
+			},
+			[message, copyWithFeedback],
+		)
+
+		const errorTitle = getDefaultTitle()
+
+		// For diff_error type with expandable content
+		if (type === "diff_error" && expandable) {
+			return (
+				<div className="mt-0 overflow-hidden mb-2">
+					<div
+						className={`font-normal text-vscode-editor-foreground flex items-center justify-between cursor-pointer ${
+							isExpanded ? "border-b border-vscode-editorGroup-border" : ""
+						}`}
+						onClick={handleToggleExpand}>
+						<div className="flex items-center gap-2 flex-grow">
+							<MessageCircleWarning className="w-4 text-vscode-errorForeground" />
+							<span className="font-bold">{errorTitle}</span>
+						</div>
+						<div className="flex items-center">
+							{showCopyButton && (
+								<VSCodeButton
+									appearance="icon"
+									className="p-0.75 h-6 mr-1 text-vscode-editor-foreground flex items-center justify-center bg-transparent"
+									onClick={handleCopy}>
+									<span className={`codicon codicon-${showCopySuccess ? "check" : "copy"}`} />
+								</VSCodeButton>
+							)}
+							<span className={`codicon codicon-chevron-${isExpanded ? "up" : "down"}`} />
+						</div>
+					</div>
+					{isExpanded && (
+						<div className="p-2 bg-vscode-editor-background border-t-0">
+							<CodeBlock source={message} language="xml" />
+						</div>
+					)}
+				</div>
+			)
+		}
+
+		// Standard error display
+		return (
+			<>
+				{errorTitle && (
+					<div className={headerClassName || "flex items-center gap-2 break-words"}>
+						<MessageCircleWarning className="w-4 text-vscode-errorForeground" />
+						<span className="text-vscode-errorForeground font-bold">{errorTitle}</span>
+					</div>
+				)}
+				<p
+					className={
+						messageClassName || "ml-6 my-0 whitespace-pre-wrap break-words text-vscode-errorForeground"
+					}>
+					{message}
+				</p>
+				{additionalContent}
+			</>
+		)
+	},
+)
+
+ErrorRow.displayName = "ErrorRow"
+
+export default ErrorRow

--- a/webview-ui/src/components/chat/FollowUpSuggest.tsx
+++ b/webview-ui/src/components/chat/FollowUpSuggest.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react"
-import { Edit } from "lucide-react"
+import { ClipboardCopy } from "lucide-react"
 
 import { Button, StandardTooltip } from "@/components/ui"
 
@@ -108,10 +108,12 @@ export const FollowUpSuggest = ({
 				const isFirstSuggestion = index === 0
 
 				return (
-					<div key={`${suggestion.answer}-${ts}`} className="w-full relative group">
+					<div
+						key={`${suggestion.answer}-${ts}`}
+						className="bg-vscode-editor-background rounded-sm w-full relative group">
 						<Button
 							variant="outline"
-							className="text-left whitespace-normal break-words w-full h-auto py-3 justify-start pr-8"
+							className="text-left whitespace-normal break-words w-full h-auto px-3 py-2 justify-start pr-8"
 							onClick={(event) => handleSuggestionClick(suggestion, event)}
 							aria-label={suggestion.answer}>
 							{suggestion.answer}
@@ -131,7 +133,7 @@ export const FollowUpSuggest = ({
 						)}
 						<StandardTooltip content={t("chat:followUpSuggest.copyToInput")}>
 							<div
-								className="absolute top-0 right-0 opacity-0 group-hover:opacity-100 transition-opacity"
+								className="absolute cursor-pointer top-2 right-3 opacity-0 group-hover:opacity-100 transition-opacity"
 								onClick={(e) => {
 									e.stopPropagation()
 									// Cancel the auto-approve timer when edit button is clicked
@@ -140,9 +142,7 @@ export const FollowUpSuggest = ({
 									// Simulate shift-click by directly calling the handler with shiftKey=true.
 									onSuggestionClick?.(suggestion, { ...e, shiftKey: true })
 								}}>
-								<Button variant="ghost" size="icon">
-									<Edit />
-								</Button>
+								<ClipboardCopy className="w-4" />
 							</div>
 						</StandardTooltip>
 					</div>

--- a/webview-ui/src/components/chat/ReasoningBlock.tsx
+++ b/webview-ui/src/components/chat/ReasoningBlock.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import MarkdownBlock from "../common/MarkdownBlock"
-import { Bot, BrainCircuit, Clock, Lightbulb } from "lucide-react"
+import { Bot, Clock } from "lucide-react"
 
 interface ReasoningBlockProps {
 	content: string

--- a/webview-ui/src/components/chat/ReasoningBlock.tsx
+++ b/webview-ui/src/components/chat/ReasoningBlock.tsx
@@ -37,7 +37,7 @@ export const ReasoningBlock = ({ content, isStreaming, isLast }: ReasoningBlockP
 	const secondsLabel = t("chat:reasoning.seconds", { count: seconds })
 
 	return (
-		<div className="py-1">
+		<div className="border-l border-vscode-descriptionForeground/20 ml-2 pl-4 pb-1 text-vscode-descriptionForeground">
 			<div className="flex items-center justify-between mb-2.5 pr-2">
 				<div className="flex items-center gap-2">
 					<Bot className="w-4" />
@@ -51,7 +51,7 @@ export const ReasoningBlock = ({ content, isStreaming, isLast }: ReasoningBlockP
 				)}
 			</div>
 			{(content?.trim()?.length ?? 0) > 0 && (
-				<div className="border-l border-vscode-descriptionForeground/20 ml-2 pl-4 pb-1 text-vscode-descriptionForeground">
+				<div>
 					<MarkdownBlock markdown={content} />
 				</div>
 			)}

--- a/webview-ui/src/components/chat/ReasoningBlock.tsx
+++ b/webview-ui/src/components/chat/ReasoningBlock.tsx
@@ -37,7 +37,7 @@ export const ReasoningBlock = ({ content, isStreaming, isLast }: ReasoningBlockP
 	const secondsLabel = t("chat:reasoning.seconds", { count: seconds })
 
 	return (
-		<div className="border-l border-vscode-descriptionForeground/20 ml-2 pl-4 pb-1 text-vscode-descriptionForeground">
+		<div>
 			<div className="flex items-center justify-between mb-2.5 pr-2">
 				<div className="flex items-center gap-2">
 					<Bot className="w-4" />
@@ -51,7 +51,7 @@ export const ReasoningBlock = ({ content, isStreaming, isLast }: ReasoningBlockP
 				)}
 			</div>
 			{(content?.trim()?.length ?? 0) > 0 && (
-				<div>
+				<div className="border-l border-vscode-descriptionForeground/20 ml-2 pl-4 pb-1 text-vscode-descriptionForeground">
 					<MarkdownBlock markdown={content} />
 				</div>
 			)}

--- a/webview-ui/src/components/chat/ReasoningBlock.tsx
+++ b/webview-ui/src/components/chat/ReasoningBlock.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import MarkdownBlock from "../common/MarkdownBlock"
-import { Clock, Lightbulb } from "lucide-react"
+import { Bot, BrainCircuit, Clock, Lightbulb } from "lucide-react"
 
 interface ReasoningBlockProps {
 	content: string
@@ -40,7 +40,7 @@ export const ReasoningBlock = ({ content, isStreaming, isLast }: ReasoningBlockP
 		<div className="py-1">
 			<div className="flex items-center justify-between mb-2.5 pr-2">
 				<div className="flex items-center gap-2">
-					<Lightbulb className="w-4" />
+					<Bot className="w-4" />
 					<span className="font-bold text-vscode-foreground">{t("chat:reasoning.thinking")}</span>
 				</div>
 				{elapsed > 0 && (

--- a/webview-ui/src/components/chat/ReasoningBlock.tsx
+++ b/webview-ui/src/components/chat/ReasoningBlock.tsx
@@ -51,7 +51,7 @@ export const ReasoningBlock = ({ content, isStreaming, isLast }: ReasoningBlockP
 				)}
 			</div>
 			{(content?.trim()?.length ?? 0) > 0 && (
-				<div className="px-3 italic text-vscode-descriptionForeground">
+				<div className="border-l border-vscode-descriptionForeground/20 ml-2 pl-4 pb-1 text-vscode-descriptionForeground">
 					<MarkdownBlock markdown={content} />
 				</div>
 			)}

--- a/webview-ui/src/components/common/CodeBlock.tsx
+++ b/webview-ui/src/components/common/CodeBlock.tsx
@@ -125,8 +125,8 @@ export const StyledPre = styled.div<{
 	max-height: ${({ windowshade, collapsedHeight }) =>
 		windowshade === "true" ? `${collapsedHeight || WINDOW_SHADE_SETTINGS.collapsedHeight}px` : "none"};
 	overflow-y: auto;
-	padding: 10px;
-	border-radius: 5px;
+	padding: 8px 3px;
+	border-radius: 6px;
 	${({ preStyle }) => preStyle && { ...preStyle }}
 
 	pre {
@@ -144,7 +144,7 @@ export const StyledPre = styled.div<{
 		white-space: ${({ wordwrap }) => (wordwrap === "false" ? "pre" : "pre-wrap")};
 		word-break: ${({ wordwrap }) => (wordwrap === "false" ? "normal" : "normal")};
 		overflow-wrap: ${({ wordwrap }) => (wordwrap === "false" ? "normal" : "break-word")};
-		font-size: var(--vscode-editor-font-size, var(--vscode-font-size, 12px));
+		font-size: 0.95em;
 		font-family: var(--vscode-editor-font-family);
 	}
 

--- a/webview-ui/src/components/common/CodeBlock.tsx
+++ b/webview-ui/src/components/common/CodeBlock.tsx
@@ -219,7 +219,7 @@ const CodeBlock = memo(
 		rawSource,
 		language,
 		preStyle,
-		initialWordWrap = true,
+		initialWordWrap = false,
 		initialWindowShade = true,
 		collapsedHeight,
 		onLanguageChange,

--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -92,6 +92,10 @@ const StyledMarkdown = styled.div`
 		line-height: 1.35em;
 	}
 
+	li {
+		margin: 0.5em 0;
+	}
+
 	ol,
 	ul {
 		padding-left: 2em;
@@ -116,11 +120,7 @@ const StyledMarkdown = styled.div`
 
 	p {
 		white-space: pre-wrap;
-		margin: 1em 0;
-	}
-
-	p + ul {
-		margin-top: -0.75em;
+		margin: 1em 0 0.25em;
 	}
 
 	/* Prevent layout shifts during streaming */
@@ -137,13 +137,11 @@ const StyledMarkdown = styled.div`
 
 	a {
 		color: var(--vscode-textLink-foreground);
-		text-decoration-line: underline;
-		text-decoration-style: dotted;
+		text-decoration: none;
 		text-decoration-color: var(--vscode-textLink-foreground);
 		&:hover {
 			color: var(--vscode-textLink-activeForeground);
-			text-decoration-style: solid;
-			text-decoration-color: var(--vscode-textLink-activeForeground);
+			text-decoration: underline;
 		}
 	}
 

--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -133,6 +133,7 @@ const StyledMarkdown = styled.div`
 	div:has(> pre) {
 		position: relative;
 		contain: layout style;
+		padding: 0.5em 1em;
 	}
 
 	a {
@@ -143,6 +144,17 @@ const StyledMarkdown = styled.div`
 			color: var(--vscode-textLink-activeForeground);
 			text-decoration: underline;
 		}
+	}
+
+	h2 {
+		font-size: 1.35em;
+		font-weight: 500;
+		margin: 1.35em 0 0.5em;
+	}
+
+	h3 {
+		font-size: 1.2em;
+		font-weight: 500;
 	}
 
 	/* Table styles for remark-gfm */

--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -16,12 +16,21 @@ interface MarkdownBlockProps {
 }
 
 const StyledMarkdown = styled.div`
+	* {
+		font-weight: 300;
+	}
+
+	strong {
+		font-weight: 600;
+	}
+
 	code:not(pre > code) {
 		font-family: var(--vscode-editor-font-family, monospace);
+		font-size: 0.85em;
 		filter: saturation(110%) brightness(95%);
 		color: var(--vscode-textPreformat-foreground) !important;
 		background-color: var(--vscode-textPreformat-background) !important;
-		padding: 0px 2px;
+		padding: 1px 2px;
 		white-space: pre-line;
 		word-break: break-word;
 		overflow-wrap: anywhere;
@@ -80,12 +89,12 @@ const StyledMarkdown = styled.div`
 	li,
 	ol,
 	ul {
-		line-height: 1.25;
+		line-height: 1.35em;
 	}
 
 	ol,
 	ul {
-		padding-left: 2.5em;
+		padding-left: 2em;
 		margin-left: 0;
 	}
 
@@ -95,15 +104,6 @@ const StyledMarkdown = styled.div`
 
 	ul {
 		list-style-type: disc;
-	}
-
-	/* Nested list styles */
-	ul ul {
-		list-style-type: circle;
-	}
-
-	ul ul ul {
-		list-style-type: square;
 	}
 
 	ol ol {
@@ -116,7 +116,11 @@ const StyledMarkdown = styled.div`
 
 	p {
 		white-space: pre-wrap;
-		margin: 0.5em 0;
+		margin: 1em 0;
+	}
+
+	p + ul {
+		margin-top: -0.75em;
 	}
 
 	/* Prevent layout shifts during streaming */

--- a/webview-ui/src/components/common/ToolUseBlock.tsx
+++ b/webview-ui/src/components/common/ToolUseBlock.tsx
@@ -1,7 +1,5 @@
 import { cn } from "@/lib/utils"
 
-import { CODE_BLOCK_BG_COLOR } from "./CodeBlock"
-
 export const ToolUseBlock = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
 	<div
 		className={cn("overflow-hidden rounded-md p-2 cursor-pointer bg-vscode-editor-background", className)}

--- a/webview-ui/src/components/common/ToolUseBlock.tsx
+++ b/webview-ui/src/components/common/ToolUseBlock.tsx
@@ -4,14 +4,14 @@ import { CODE_BLOCK_BG_COLOR } from "./CodeBlock"
 
 export const ToolUseBlock = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
 	<div
-		className={cn("overflow-hidden border border-vscode-border rounded-xs p-2 cursor-pointer", className)}
-		style={{
-			backgroundColor: CODE_BLOCK_BG_COLOR,
-		}}
+		className={cn("overflow-hidden rounded-md p-2 cursor-pointer bg-vscode-editor-background", className)}
 		{...props}
 	/>
 )
 
 export const ToolUseBlockHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-	<div className={cn("flex items-center select-none text-vscode-descriptionForeground", className)} {...props} />
+	<div
+		className={cn("flex font-mono items-center select-none text-sm text-vscode-descriptionForeground", className)}
+		{...props}
+	/>
 )

--- a/webview-ui/src/i18n/locales/en/chat.json
+++ b/webview-ui/src/i18n/locales/en/chat.json
@@ -239,6 +239,9 @@
 	},
 	"response": "Response",
 	"arguments": "Arguments",
+	"feedback": {
+		"youSaid": "You said"
+	},
 	"mcp": {
 		"wantsToUseTool": "Roo wants to use a tool on the {{serverName}} MCP server:",
 		"wantsToAccessResource": "Roo wants to access a resource on the {{serverName}} MCP server:"


### PR DESCRIPTION
Redesigned may be too strong of a word, but this encompasses lots of tweaks to the message feed, mainly typographic in nature, but tweaking functionality ever so slightly. The main goals are to:

1. Establish a stronger visual hierarchy so users' eyes are drawn to what matters most
2. Create more visual structure so it's easier to follow the flow of messages without moving one's eyes horizontally much
3. Inject a little bit of personality through iconography and copy

This led to the following changes:
- Changes base type weight and size
- Much improved MarkdownBlock typography, notably when there are `code` spans, lists and headers
- Consistent type styles in MarkdownBlock for ReasoningBlock as well as others
- More distinctive user messages
- De-prioritization of API Request entries, in favor of the action/tool it actually entails
- More elegant task completion entries (no green yelling at your face)
- Several advanced utilities only shown on hover
- Consistent error messages

### Test Procedure

This doesn't change functionality. The way to test it is to have a long-ish conversation with Roo, triggering tools. I recommend trying:
- Something which requires reasoning
- An Ask which leads to a long-ish task completion message
- Using the browser
- Listing files
- Making small changes to files
- Asking to read a non-existent file to trigger an error

### Screenshots / Videos

I may include screenshots later, but it's a lot to capture in one go, and ultimately this is more about the feel than just the look.

### Documentation Updates

This may require updating screenshots throughout the docs, but no copy.