### PR TITLE
Add Z.ai coding plan support

### DIFF
--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -308,9 +308,13 @@ const sambaNovaSchema = apiModelIdProviderModelSchema.extend({
 	sambaNovaApiKey: z.string().optional(),
 })
 
+export const zaiApiLineSchema = z.enum(["international_coding", "international", "china_coding", "china"])
+
+export type ZaiApiLine = z.infer<typeof zaiApiLineSchema>
+
 const zaiSchema = apiModelIdProviderModelSchema.extend({
 	zaiApiKey: z.string().optional(),
-	zaiApiLine: z.union([z.literal("china"), z.literal("international")]).optional(),
+	zaiApiLine: zaiApiLineSchema.optional(),
 })
 
 const fireworksSchema = apiModelIdProviderModelSchema.extend({

--- a/packages/types/src/providers/zai.ts
+++ b/packages/types/src/providers/zai.ts
@@ -1,5 +1,5 @@
 import type { ModelInfo } from "../model.js"
-import { ZaiApiLine } from "../provider-settings.js" // kilocode_change
+import { ZaiApiLine } from "../provider-settings.js"
 
 // Z AI
 // https://docs.z.ai/guides/llm/glm-4.5
@@ -105,7 +105,6 @@ export const mainlandZAiModels = {
 
 export const ZAI_DEFAULT_TEMPERATURE = 0
 
-// kilocode_change start
 export const zaiApiLineConfigs = {
 	international_coding: {
 		name: "International Coding Plan",
@@ -116,4 +115,3 @@ export const zaiApiLineConfigs = {
 	china_coding: { name: "China Coding Plan", baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4", isChina: true },
 	china: { name: "China Standard", baseUrl: "https://open.bigmodel.cn/api/paas/v4", isChina: true },
 } satisfies Record<ZaiApiLine, { name: string; baseUrl: string; isChina: boolean }>
-// kilocode_change end

--- a/packages/types/src/providers/zai.ts
+++ b/packages/types/src/providers/zai.ts
@@ -1,4 +1,5 @@
 import type { ModelInfo } from "../model.js"
+import { ZaiApiLine } from "../provider-settings.js" // kilocode_change
 
 // Z AI
 // https://docs.z.ai/guides/llm/glm-4.5
@@ -103,3 +104,16 @@ export const mainlandZAiModels = {
 } as const satisfies Record<string, ModelInfo>
 
 export const ZAI_DEFAULT_TEMPERATURE = 0
+
+// kilocode_change start
+export const zaiApiLineConfigs = {
+	international_coding: {
+		name: "International Coding Plan",
+		baseUrl: "https://api.z.ai/api/coding/paas/v4",
+		isChina: false,
+	},
+	international: { name: "International Standard", baseUrl: "https://api.z.ai/api/paas/v4", isChina: false },
+	china_coding: { name: "China Coding Plan", baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4", isChina: true },
+	china: { name: "China Standard", baseUrl: "https://open.bigmodel.cn/api/paas/v4", isChina: true },
+} satisfies Record<ZaiApiLine, { name: string; baseUrl: string; isChina: boolean }>
+// kilocode_change end

--- a/src/api/providers/__tests__/zai.spec.ts
+++ b/src/api/providers/__tests__/zai.spec.ts
@@ -41,7 +41,11 @@ describe("ZAiHandler", () => {
 
 		it("should use the correct international Z AI base URL", () => {
 			new ZAiHandler({ zaiApiKey: "test-zai-api-key", zaiApiLine: "international" })
-			expect(OpenAI).toHaveBeenCalledWith(expect.objectContaining({ baseURL: "https://api.z.ai/api/paas/v4" }))
+			expect(OpenAI).toHaveBeenCalledWith(
+				expect.objectContaining({
+					baseURL: "https://api.z.ai/api/paas/v4",
+				}),
+			)
 		})
 
 		it("should use the provided API key for international", () => {
@@ -109,7 +113,11 @@ describe("ZAiHandler", () => {
 	describe("Default behavior", () => {
 		it("should default to international when no zaiApiLine is specified", () => {
 			const handlerDefault = new ZAiHandler({ zaiApiKey: "test-zai-api-key" })
-			expect(OpenAI).toHaveBeenCalledWith(expect.objectContaining({ baseURL: "https://api.z.ai/api/paas/v4" }))
+			expect(OpenAI).toHaveBeenCalledWith(
+				expect.objectContaining({
+					baseURL: "https://api.z.ai/api/coding/paas/v4",
+				}),
+			)
 
 			const model = handlerDefault.getModel()
 			expect(model.id).toBe(internationalZAiDefaultModelId)

--- a/src/api/providers/zai.ts
+++ b/src/api/providers/zai.ts
@@ -6,6 +6,7 @@ import {
 	type InternationalZAiModelId,
 	type MainlandZAiModelId,
 	ZAI_DEFAULT_TEMPERATURE,
+	zaiApiLineConfigs,
 } from "@roo-code/types"
 
 import type { ApiHandlerOptions } from "../../shared/api"
@@ -14,14 +15,14 @@ import { BaseOpenAiCompatibleProvider } from "./base-openai-compatible-provider"
 
 export class ZAiHandler extends BaseOpenAiCompatibleProvider<InternationalZAiModelId | MainlandZAiModelId> {
 	constructor(options: ApiHandlerOptions) {
-		const isChina = options.zaiApiLine === "china"
+		const isChina = zaiApiLineConfigs[options.zaiApiLine ?? "international_coding"].isChina
 		const models = isChina ? mainlandZAiModels : internationalZAiModels
 		const defaultModelId = isChina ? mainlandZAiDefaultModelId : internationalZAiDefaultModelId
 
 		super({
 			...options,
 			providerName: "Z AI",
-			baseURL: isChina ? "https://open.bigmodel.cn/api/paas/v4" : "https://api.z.ai/api/paas/v4",
+			baseURL: zaiApiLineConfigs[options.zaiApiLine ?? "international_coding"].baseUrl,
 			apiKey: options.zaiApiKey ?? "not-provided",
 			defaultProviderModelId: defaultModelId,
 			providerModels: models,

--- a/webview-ui/src/components/settings/providers/ZAi.tsx
+++ b/webview-ui/src/components/settings/providers/ZAi.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from "react"
 import { VSCodeTextField, VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react"
 
-import type { ProviderSettings } from "@roo-code/types"
+import { zaiApiLineConfigs, zaiApiLineSchema, type ProviderSettings } from "@roo-code/types"
 
 import { useAppTranslation } from "@src/i18n/TranslationContext"
 import { VSCodeButtonLink } from "@src/components/common/VSCodeButtonLink"
@@ -33,15 +33,17 @@ export const ZAi = ({ apiConfiguration, setApiConfigurationField }: ZAiProps) =>
 			<div>
 				<label className="block font-medium mb-1">{t("settings:providers.zaiEntrypoint")}</label>
 				<VSCodeDropdown
-					value={apiConfiguration.zaiApiLine || "international"}
+					value={apiConfiguration.zaiApiLine || zaiApiLineSchema.enum.international_coding}
 					onChange={handleInputChange("zaiApiLine")}
 					className={cn("w-full")}>
-					<VSCodeOption value="international" className="p-2">
-						api.z.ai
-					</VSCodeOption>
-					<VSCodeOption value="china" className="p-2">
-						open.bigmodel.cn
-					</VSCodeOption>
+					{zaiApiLineSchema.options.map((zaiApiLine) => {
+						const config = zaiApiLineConfigs[zaiApiLine]
+						return (
+							<VSCodeOption key={zaiApiLine} value={zaiApiLine} className="p-2">
+								{config.name} ({config.baseUrl})
+							</VSCodeOption>
+						)
+					})}
 				</VSCodeDropdown>
 				<div className="text-xs text-vscode-descriptionForeground mt-1">
 					{t("settings:providers.zaiEntrypointDescription")}
@@ -62,7 +64,7 @@ export const ZAi = ({ apiConfiguration, setApiConfigurationField }: ZAiProps) =>
 				{!apiConfiguration?.zaiApiKey && (
 					<VSCodeButtonLink
 						href={
-							apiConfiguration.zaiApiLine === "china"
+							zaiApiLineConfigs[apiConfiguration.zaiApiLine ?? "international_coding"].isChina
 								? "https://open.bigmodel.cn/console/overview"
 								: "https://z.ai/manage-apikey/apikey-list"
 						}


### PR DESCRIPTION
Adds support for Z.ai's coding plan subscription tiers (International and China).

Pulled from downstream PR Kilo-Org/kilocode#2402. Thanks @chrarnoldus.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for Z.ai's new coding plan subscription tiers, updating schemas, configurations, and tests to handle international and China options.
> 
>   - **Behavior**:
>     - Adds support for Z.ai's new coding plan subscription tiers (`international_coding`, `china_coding`) in `provider-settings.ts` and `zai.ts`.
>     - Updates `ZAiHandler` in `zai.ts` to use `zaiApiLineConfigs` for determining base URL and region.
>     - Defaults to `international_coding` if `zaiApiLine` is not specified.
>   - **Configuration**:
>     - Introduces `zaiApiLineSchema` and `zaiApiLineConfigs` in `provider-settings.ts` to manage Z.ai API lines.
>     - Updates `zaiApiLine` handling in `ZAi.tsx` to reflect new subscription tiers.
>   - **Testing**:
>     - Updates tests in `zai.spec.ts` to cover new subscription tiers and default behavior.
>     - Ensures correct API key and base URL usage in tests for both international and China configurations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 40d615591e7449cf962826165530ef24b97c0cbd. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->