### PR TITLE
feat: Bring back a way to temporarily and globally pause auto-approve without losing your toggle state

### DIFF
--- a/webview-ui/src/components/chat/AutoApproveDropdown.tsx
+++ b/webview-ui/src/components/chat/AutoApproveDropdown.tsx
@@ -148,9 +148,6 @@ export const AutoApproveDropdown = ({ disabled = false, triggerClassName = "" }:
 
 	// Split settings into two columns
 	const settingsArray = Object.values(autoApproveSettingsConfig)
-	const halfLength = Math.ceil(settingsArray.length / 2)
-	const firstColumn = settingsArray.slice(0, halfLength)
-	const secondColumn = settingsArray.slice(halfLength)
 
 	return (
 		<Popover open={open} onOpenChange={setOpen} data-testid="auto-approve-dropdown-root">
@@ -179,7 +176,7 @@ export const AutoApproveDropdown = ({ disabled = false, triggerClassName = "" }:
 				align="start"
 				sideOffset={4}
 				container={portalContainer}
-				className="p-0 overflow-hidden min-w-96 max-w-9/10"
+				className="p-0 overflow-hidden min-w-90 max-w-9/10"
 				onOpenAutoFocus={(e) => e.preventDefault()}>
 				<div className="flex flex-col w-full">
 					{/* Header with description */}
@@ -197,66 +194,29 @@ export const AutoApproveDropdown = ({ disabled = false, triggerClassName = "" }:
 							{t("chat:autoApprove.description")}
 						</p>
 					</div>
-
-					{/* Two-column layout for approval options */}
-					<div className="p-3">
-						<div className="grid grid-cols-2 gap-x-4 gap-y-2">
-							{/* First Column */}
-							<div className="space-y-2">
-								{firstColumn.map(({ key, labelKey, descriptionKey, icon }) => {
-									const isEnabled = toggles[key]
-									return (
-										<StandardTooltip key={key} content={t(descriptionKey)}>
-											<button
-												onClick={() => onAutoApproveToggle(key, !isEnabled)}
-												className={cn(
-													"w-full flex items-center gap-2 px-2 py-1.5 rounded text-xs text-left",
-													"transition-all duration-150",
-													"hover:bg-vscode-list-hoverBackground",
-													isEnabled
-														? "bg-vscode-button-background text-vscode-button-foreground"
-														: "bg-transparent text-vscode-foreground opacity-70 hover:opacity-100",
-												)}
-												data-testid={`auto-approve-${key}`}>
-												<span className={`codicon codicon-${icon} text-sm flex-shrink-0`} />
-												<span className="flex-1 truncate">{t(labelKey)}</span>
-												{isEnabled && (
-													<span className="codicon codicon-check text-xs flex-shrink-0" />
-												)}
-											</button>
-										</StandardTooltip>
-									)
-								})}
-							</div>
-
-							{/* Second Column */}
-							<div className="space-y-2">
-								{secondColumn.map(({ key, labelKey, descriptionKey, icon }) => {
-									const isEnabled = toggles[key]
-									return (
-										<StandardTooltip key={key} content={t(descriptionKey)}>
-											<button
-												onClick={() => onAutoApproveToggle(key, !isEnabled)}
-												className={cn(
-													"w-full flex items-center gap-2 px-2 py-1.5 rounded text-xs text-left",
-													"transition-all duration-150",
-													"hover:bg-vscode-list-hoverBackground",
-													isEnabled
-														? "bg-vscode-button-background text-vscode-button-foreground"
-														: "bg-transparent text-vscode-foreground opacity-70 hover:opacity-100",
-												)}
-												data-testid={`auto-approve-${key}`}>
-												<span className={`codicon codicon-${icon} text-sm flex-shrink-0`} />
-												<span className="flex-1 truncate">{t(labelKey)}</span>
-												{isEnabled && (
-													<span className="codicon codicon-check text-xs flex-shrink-0" />
-												)}
-											</button>
-										</StandardTooltip>
-									)
-								})}
-							</div>
-						</div>
+					<div className="grid grid-cols-2 gap-x-2 gap-y-2 p-3">
+						{settingsArray.map(({ key, labelKey, descriptionKey, icon }) => {
+							const isEnabled = toggles[key]
+							return (
+								<StandardTooltip key={key} content={t(descriptionKey)}>
+									<button
+										onClick={() => onAutoApproveToggle(key, !isEnabled)}
+										className={cn(
+											"flex items-center gap-2 px-2 py-2 rounded text-sm text-left",
+											"transition-all duration-150",
+											"opacity-100 hover:opacity-70",
+											"cursor-pointer",
+											isEnabled
+												? "bg-vscode-button-background text-vscode-button-foreground"
+												: "bg-vscode-button-background/15 text-vscode-foreground hover:bg-vscode-list-hoverBackground",
+										)}
+										data-testid={`auto-approve-${key}`}>
+										<span className={`codicon codicon-${icon} text-sm flex-shrink-0`} />
+										<span className="flex-1 truncate">{t(labelKey)}</span>
+									</button>
+								</StandardTooltip>
+							)
+						})}
 					</div>
 
 					{/* Bottom bar with Select All/None buttons */}

--- a/webview-ui/src/components/settings/AutoApproveSettings.tsx
+++ b/webview-ui/src/components/settings/AutoApproveSettings.tsx
@@ -4,7 +4,7 @@ import { X, CheckCheck } from "lucide-react"
 import { useAppTranslation } from "@/i18n/TranslationContext"
 import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
 import { vscode } from "@/utils/vscode"
-import { Button, Input, Slider, StandardTooltip } from "@/components/ui"
+import { Button, Input, Slider } from "@/components/ui"
 
 import { SetCachedStateField } from "./types"
 import { SectionHeader } from "./SectionHeader"
@@ -88,7 +88,7 @@ export const AutoApproveSettings = ({
 
 	const toggles = useAutoApprovalToggles()
 
-	const { hasEnabledOptions, effectiveAutoApprovalEnabled } = useAutoApprovalState(toggles, autoApprovalEnabled)
+	const { effectiveAutoApprovalEnabled } = useAutoApprovalState(toggles, autoApprovalEnabled)
 
 	const handleAddCommand = () => {
 		const currentCommands = allowedCommands ?? []
@@ -124,32 +124,16 @@ export const AutoApproveSettings = ({
 			<Section>
 				<div className="space-y-4">
 					<div>
-						{!hasEnabledOptions ? (
-							<StandardTooltip content={t("settings:autoApprove.selectOptionsFirst")}>
-								<VSCodeCheckbox
-									checked={effectiveAutoApprovalEnabled}
-									disabled={!hasEnabledOptions}
-									aria-label={t("settings:autoApprove.disabledAriaLabel")}
-									onChange={() => {
-										// Do nothing when no options are enabled
-										return
-									}}>
-									<span className="font-medium">{t("settings:autoApprove.enabled")}</span>
-								</VSCodeCheckbox>
-							</StandardTooltip>
-						) : (
-							<VSCodeCheckbox
-								checked={effectiveAutoApprovalEnabled}
-								disabled={!hasEnabledOptions}
-								aria-label={t("settings:autoApprove.toggleAriaLabel")}
-								onChange={() => {
-									const newValue = !(autoApprovalEnabled ?? false)
-									setAutoApprovalEnabled(newValue)
-									vscode.postMessage({ type: "autoApprovalEnabled", bool: newValue })
-								}}>
-								<span className="font-medium">{t("settings:autoApprove.enabled")}</span>
-							</VSCodeCheckbox>
-						)}
+						<VSCodeCheckbox
+							checked={effectiveAutoApprovalEnabled}
+							aria-label={t("settings:autoApprove.toggleAriaLabel")}
+							onChange={() => {
+								const newValue = !(autoApprovalEnabled ?? false)
+								setAutoApprovalEnabled(newValue)
+								vscode.postMessage({ type: "autoApprovalEnabled", bool: newValue })
+							}}>
+							<span className="font-medium">{t("settings:autoApprove.enabled")}</span>
+						</VSCodeCheckbox>
 						<div className="text-vscode-descriptionForeground text-sm mt-1">
 							{t("settings:autoApprove.description")}
 						</div>

--- a/webview-ui/src/hooks/__tests__/useAutoApprovalState.spec.ts
+++ b/webview-ui/src/hooks/__tests__/useAutoApprovalState.spec.ts
@@ -124,7 +124,7 @@ describe("useAutoApprovalState", () => {
 			expect(result.current.effectiveAutoApprovalEnabled).toBe(false)
 		})
 
-		it("should return false when autoApprovalEnabled is true but no toggles are enabled", () => {
+		it("should return true when autoApprovalEnabled is true but no toggles are enabled", () => {
 			const toggles = {
 				alwaysAllowReadOnly: false,
 				alwaysAllowWrite: false,
@@ -140,7 +140,7 @@ describe("useAutoApprovalState", () => {
 
 			const { result } = renderHook(() => useAutoApprovalState(toggles, true))
 
-			expect(result.current.effectiveAutoApprovalEnabled).toBe(false)
+			expect(result.current.effectiveAutoApprovalEnabled).toBe(true)
 		})
 
 		it("should return true when autoApprovalEnabled is true and at least one toggle is enabled", () => {
@@ -217,7 +217,7 @@ describe("useAutoApprovalState", () => {
 			rerender({ toggles: newToggles, autoApprovalEnabled: true })
 
 			expect(result.current.hasEnabledOptions).toBe(false)
-			expect(result.current.effectiveAutoApprovalEnabled).toBe(false)
+			expect(result.current.effectiveAutoApprovalEnabled).toBe(true)
 		})
 
 		it("should recompute effectiveAutoApprovalEnabled when autoApprovalEnabled changes", () => {
@@ -263,7 +263,7 @@ describe("useAutoApprovalState", () => {
 			const { result } = renderHook(() => useAutoApprovalState(toggles, true))
 
 			expect(result.current.hasEnabledOptions).toBe(false)
-			expect(result.current.effectiveAutoApprovalEnabled).toBe(false)
+			expect(result.current.effectiveAutoApprovalEnabled).toBe(true)
 		})
 
 		it("should handle mixed truthy/falsy values correctly", () => {

--- a/webview-ui/src/hooks/useAutoApprovalState.ts
+++ b/webview-ui/src/hooks/useAutoApprovalState.ts
@@ -19,8 +19,8 @@ export function useAutoApprovalState(toggles: AutoApprovalToggles, autoApprovalE
 	}, [toggles])
 
 	const effectiveAutoApprovalEnabled = useMemo(() => {
-		return hasEnabledOptions && (autoApprovalEnabled ?? false)
-	}, [hasEnabledOptions, autoApprovalEnabled])
+		return autoApprovalEnabled ?? false
+	}, [autoApprovalEnabled])
 
 	return {
 		hasEnabledOptions,

--- a/webview-ui/src/i18n/locales/ca/chat.json
+++ b/webview-ui/src/i18n/locales/ca/chat.json
@@ -258,7 +258,8 @@
 		"triggerLabel_zero": "Sense aprovació automàtica",
 		"triggerLabel_one": "1 aprovació automàtica",
 		"triggerLabel_other": "{{count}} aprovacions automàtiques",
-		"triggerLabelAll": "YOLO"
+		"triggerLabelAll": "YOLO",
+		"triggerLabelOff": "Auto-approve desactivat"
 	},
 	"reasoning": {
 		"thinking": "Pensant",

--- a/webview-ui/src/i18n/locales/de/chat.json
+++ b/webview-ui/src/i18n/locales/de/chat.json
@@ -258,7 +258,8 @@
 		"triggerLabel_zero": "Keine automatische Genehmigung",
 		"triggerLabel_one": "1 automatisch genehmigt",
 		"triggerLabel_other": "{{count}} automatisch genehmigt",
-		"triggerLabelAll": "YOLO"
+		"triggerLabelAll": "YOLO",
+		"triggerLabelOff": "Automatische Genehmigung aus"
 	},
 	"reasoning": {
 		"thinking": "Denke nach",

--- a/webview-ui/src/i18n/locales/en/chat.json
+++ b/webview-ui/src/i18n/locales/en/chat.json
@@ -279,7 +279,8 @@
 		"selectOptionsFirst": "Select at least one option below to enable auto-approval",
 		"toggleAriaLabel": "Toggle auto-approval",
 		"disabledAriaLabel": "Auto-approval disabled - select options first",
-		"triggerLabel_zero": "No auto-approve",
+		"triggerLabelOff": "Auto-approve off",
+		"triggerLabel_zero": "0 auto-approve",
 		"triggerLabel_one": "1 auto-approved",
 		"triggerLabel_other": "{{count}} auto-approved",
 		"triggerLabelAll": "YOLO"

--- a/webview-ui/src/i18n/locales/es/chat.json
+++ b/webview-ui/src/i18n/locales/es/chat.json
@@ -258,7 +258,8 @@
 		"triggerLabel_zero": "Sin aprobación automática",
 		"triggerLabel_one": "1 aprobado automáticamente",
 		"triggerLabel_other": "{{count}} aprobados automáticamente",
-		"triggerLabelAll": "YOLO"
+		"triggerLabelAll": "YOLO",
+		"triggerLabelOff": "Auto-aprobar desactivado"
 	},
 	"reasoning": {
 		"thinking": "Pensando",

--- a/webview-ui/src/i18n/locales/fr/chat.json
+++ b/webview-ui/src/i18n/locales/fr/chat.json
@@ -258,7 +258,8 @@
 		"triggerLabel_zero": "Pas d'approbation automatique",
 		"triggerLabel_one": "1 approuvé automatiquement",
 		"triggerLabel_other": "{{count}} approuvés automatiquement",
-		"triggerLabelAll": "YOLO"
+		"triggerLabelAll": "YOLO",
+		"triggerLabelOff": "Approbation automatique désactivée"
 	},
 	"reasoning": {
 		"thinking": "Réflexion",

--- a/webview-ui/src/i18n/locales/hi/chat.json
+++ b/webview-ui/src/i18n/locales/hi/chat.json
@@ -258,7 +258,8 @@
 		"triggerLabel_zero": "कोई स्वतः-अनुमोदन नहीं",
 		"triggerLabel_one": "1 स्वतः-अनुमोदित",
 		"triggerLabel_other": "{{count}} स्वतः-अनुमोदित",
-		"triggerLabelAll": "योलो"
+		"triggerLabelAll": "योलो",
+		"triggerLabelOff": "स्वतः-अनुमोदन बंद"
 	},
 	"reasoning": {
 		"thinking": "विचार कर रहा है",

--- a/webview-ui/src/i18n/locales/id/chat.json
+++ b/webview-ui/src/i18n/locales/id/chat.json
@@ -285,7 +285,8 @@
 		"triggerLabel_zero": "Tidak ada persetujuan otomatis",
 		"triggerLabel_one": "1 disetujui otomatis",
 		"triggerLabel_other": "{{count}} disetujui otomatis",
-		"triggerLabelAll": "YOLO"
+		"triggerLabelAll": "YOLO",
+		"triggerLabelOff": "Persetujuan otomatis nonaktif"
 	},
 	"announcement": {
 		"title": "🎉 Roo Code {{version}} Dirilis",

--- a/webview-ui/src/i18n/locales/it/chat.json
+++ b/webview-ui/src/i18n/locales/it/chat.json
@@ -258,7 +258,8 @@
 		"triggerLabel_zero": "Nessuna approvazione automatica",
 		"triggerLabel_one": "1 approvato automaticamente",
 		"triggerLabel_other": "{{count}} approvati automaticamente",
-		"triggerLabelAll": "YOLO"
+		"triggerLabelAll": "YOLO",
+		"triggerLabelOff": "Approvazione automatica disattivata"
 	},
 	"reasoning": {
 		"thinking": "Sto pensando",

--- a/webview-ui/src/i18n/locales/ja/chat.json
+++ b/webview-ui/src/i18n/locales/ja/chat.json
@@ -258,7 +258,8 @@
 		"triggerLabel_zero": "自動承認なし",
 		"triggerLabel_one": "1件自動承認済み",
 		"triggerLabel_other": "{{count}}件自動承認済み",
-		"triggerLabelAll": "YOLO"
+		"triggerLabelAll": "YOLO",
+		"triggerLabelOff": "自動承認オフ"
 	},
 	"reasoning": {
 		"thinking": "考え中",

--- a/webview-ui/src/i18n/locales/ko/chat.json
+++ b/webview-ui/src/i18n/locales/ko/chat.json
@@ -258,7 +258,8 @@
 		"triggerLabel_zero": "자동 승인 없음",
 		"triggerLabel_one": "1개 자동 승인됨",
 		"triggerLabel_other": "{{count}}개 자동 승인됨",
-		"triggerLabelAll": "욜로"
+		"triggerLabelAll": "욜로",
+		"triggerLabelOff": "자동 승인 꺼짐"
 	},
 	"reasoning": {
 		"thinking": "생각 중",

--- a/webview-ui/src/i18n/locales/nl/chat.json
+++ b/webview-ui/src/i18n/locales/nl/chat.json
@@ -258,7 +258,8 @@
 		"triggerLabel_zero": "Geen automatische goedkeuring",
 		"triggerLabel_one": "1 automatisch goedgekeurd",
 		"triggerLabel_other": "{{count}} automatisch goedgekeurd",
-		"triggerLabelAll": "YOLO"
+		"triggerLabelAll": "YOLO",
+		"triggerLabelOff": "Automatisch goedkeuren uit"
 	},
 	"announcement": {
 		"title": "🎉 Roo Code {{version}} uitgebracht",

--- a/webview-ui/src/i18n/locales/pl/chat.json
+++ b/webview-ui/src/i18n/locales/pl/chat.json
@@ -260,7 +260,8 @@
 		"triggerLabel_few": "{{count}} automatycznie zaakceptowane",
 		"triggerLabel_many": "{{count}} automatycznie zaakceptowanych",
 		"triggerLabel_other": "{{count}} automatycznie zaakceptowanych",
-		"triggerLabelAll": "YOLO"
+		"triggerLabelAll": "YOLO",
+		"triggerLabelOff": "Automatyczne zatwierdzanie wyłączone"
 	},
 	"reasoning": {
 		"thinking": "Myślenie",

--- a/webview-ui/src/i18n/locales/pt-BR/chat.json
+++ b/webview-ui/src/i18n/locales/pt-BR/chat.json
@@ -258,7 +258,8 @@
 		"triggerLabel_zero": "Nenhuma aprovação automática",
 		"triggerLabel_one": "1 aprovado automaticamente",
 		"triggerLabel_other": "{{count}} aprovados automaticamente",
-		"triggerLabelAll": "YOLO"
+		"triggerLabelAll": "YOLO",
+		"triggerLabelOff": "Aprovação automática desativada"
 	},
 	"reasoning": {
 		"thinking": "Pensando",

--- a/webview-ui/src/i18n/locales/ru/chat.json
+++ b/webview-ui/src/i18n/locales/ru/chat.json
@@ -260,7 +260,8 @@
 		"triggerLabel_few": "{{count}} авто-утверждено",
 		"triggerLabel_many": "{{count}} авто-утверждено",
 		"triggerLabel_other": "{{count}} авто-утверждено",
-		"triggerLabelAll": "YOLO"
+		"triggerLabelAll": "YOLO",
+		"triggerLabelOff": "Авто-утверждение выкл"
 	},
 	"announcement": {
 		"title": "🎉 Выпущен Roo Code {{version}}",

--- a/webview-ui/src/i18n/locales/tr/chat.json
+++ b/webview-ui/src/i18n/locales/tr/chat.json
@@ -258,7 +258,8 @@
 		"triggerLabel_zero": "Otomatik onay yok",
 		"triggerLabel_one": "1 otomatik onaylandı",
 		"triggerLabel_other": "{{count}} otomatik onaylandı",
-		"triggerLabelAll": "YOLO"
+		"triggerLabelAll": "YOLO",
+		"triggerLabelOff": "Otomatik onay kapalı"
 	},
 	"reasoning": {
 		"thinking": "Düşünüyor",

--- a/webview-ui/src/i18n/locales/vi/chat.json
+++ b/webview-ui/src/i18n/locales/vi/chat.json
@@ -258,7 +258,8 @@
 		"triggerLabel_zero": "Không có tự động phê duyệt",
 		"triggerLabel_one": "1 được tự động phê duyệt",
 		"triggerLabel_other": "{{count}} được tự động phê duyệt",
-		"triggerLabelAll": "YOLO"
+		"triggerLabelAll": "YOLO",
+		"triggerLabelOff": "Tự động phê duyệt tắt"
 	},
 	"reasoning": {
 		"thinking": "Đang suy nghĩ",

--- a/webview-ui/src/i18n/locales/zh-CN/chat.json
+++ b/webview-ui/src/i18n/locales/zh-CN/chat.json
@@ -258,7 +258,8 @@
 		"triggerLabel_zero": "无自动批准",
 		"triggerLabel_one": "1 个自动批准",
 		"triggerLabel_other": "{{count}} 个自动批准",
-		"triggerLabelAll": "人生只有一次"
+		"triggerLabelAll": "人生只有一次",
+		"triggerLabelOff": "自动批准已关闭"
 	},
 	"reasoning": {
 		"thinking": "思考中",

--- a/webview-ui/src/i18n/locales/zh-TW/chat.json
+++ b/webview-ui/src/i18n/locales/zh-TW/chat.json
@@ -282,7 +282,8 @@
 		"triggerLabel_zero": "無自動核准",
 		"triggerLabel_one": "1 個自動核准",
 		"triggerLabel_other": "{{count}} 個自動核准",
-		"triggerLabelAll": "人生只有一次"
+		"triggerLabelAll": "人生只有一次",
+		"triggerLabelOff": "自動批准已關閉"
 	},
 	"announcement": {
 		"title": "🎉 Roo Code {{version}} 已發布",


### PR DESCRIPTION
As it says on the tin. We heard user feedback and are acting on it.

### Description

1. Adds an "Enabled" switch to the auto-approve dropdown, toggling the global auto-approve setting, without changing the toggle selection
2. Selecting "None" doesn't affect this (aka you can have it enabled _and_ with nothing selected, usually when clearing your selection and picking only a couple)
3. The UI reacts to this state accordingly

In doing this, I saw that the existing code made it a requirement to have at least one toggle checked in order to enable/disable auto-approve, basically coupling the global setting and the specific toggle selection. I found that counter-intuitive and something which made #2 above impossible, so I lifted that requirement (and updated tests accordingly).

### Test Procedure

1. Open the auto-approve dropdown
2. Play around with the switch and action toggles
3. Play around with select all/none
4. Make sure Roo respects the auto-approve selection

### Screenshots / Videos

Off, Closed:
<img width="370" alt="Screenshot 2025-09-16 at 13 25 26" src="https://github.com/user-attachments/assets/e4f00fb2-385e-4e3c-87ef-70ee5e3f28bf" />

Off, Open:
<img width="370"  alt="Screenshot 2025-09-16 at 13 25 32" src="https://github.com/user-attachments/assets/dad9dde0-fec8-487c-94ed-f6c4f38b2631" />

On, No Selection, Open:
<img width="370" alt="Screenshot 2025-09-16 at 13 25 41" src="https://github.com/user-attachments/assets/20637d00-8772-4321-abcc-d57ebe5a5b88" />

On, Partial Selection, Open:
<img width="370" alt="Screenshot 2025-09-16 at 13 25 48" src="https://github.com/user-attachments/assets/b4fea6ec-a2a1-4aa4-9e8a-896c6f42ecc2" />

On, Full Selection, Open:
<img width="370" alt="Screenshot 2025-09-16 at 13 25 54" src="https://github.com/user-attachments/assets/8e09a032-1f89-4342-b172-cad8a73ee124" />

Off, Partial Selection, Open:
<img width="370" alt="Screenshot 2025-09-16 at 13 26 03" src="https://github.com/user-attachments/assets/7aafe215-4fe5-484b-be15-299d9853d8c5" />


### Documentation Updates

Unsure, this might need doc changes in terms of overall behavior.
Most likely for screenshots.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a global "Enabled" switch to `AutoApproveDropdown.tsx` for pausing auto-approve without losing toggle states, with UI and logic updates.
> 
>   - **Behavior**:
>     - Adds "Enabled" switch in `AutoApproveDropdown.tsx` to toggle global auto-approve without changing toggle selections.
>     - Allows "None" selection with auto-approve enabled.
>     - UI updates to reflect new state management.
>   - **Logic**:
>     - Decouples global auto-approve state from individual toggle selections in `useAutoApprovalState.ts`.
>     - Updates tests in `useAutoApprovalState.spec.ts` to reflect new logic.
>   - **Translations**:
>     - Updates translation files to include new labels for auto-approve states.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0c4905cdb5fad7bd75de6bcc8a05ea4ec5dfcc0d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->