### PR TITLE
ci: refresh contrib.rocks cache workflow

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -14,14 +14,32 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Bump cacheBust in README
+      - name: Bump cacheBust in all README files
         run: |
           set -euo pipefail
-          TS=$(date +%s)
-          if grep -q 'cacheBust=' README.md; then
-            sed -i "s/cacheBust=[0-9]\+/cacheBust=${TS}/g" README.md
-          else
-            echo "cacheBust parameter not found in README.md" >&2
+          TS="$(date +%s)"
+          # Target only the root README.md and localized READMEs under locales/*/README.md
+          mapfile -t FILES < <(git ls-files README.md 'locales/*/README.md' || true)
+
+          if [ "${#FILES[@]}" -eq 0 ]; then
+            echo "No target README files found." >&2
+            exit 1
+          fi
+
+          UPDATED=0
+          for f in "${FILES[@]}"; do
+            if grep -q 'cacheBust=' "$f"; then
+              # Use portable sed in GNU environment of ubuntu-latest
+              sed -i -E "s/cacheBust=[0-9]+/cacheBust=${TS}/g" "$f"
+              echo "Updated cacheBust in $f"
+              UPDATED=1
+            else
+              echo "Warning: cacheBust parameter not found in $f" >&2
+            fi
+          done
+
+          if [ "$UPDATED" -eq 0 ]; then
+            echo "No files were updated. Ensure READMEs embed contrib.rocks with cacheBust param." >&2
             exit 1
           fi
 
@@ -39,11 +57,11 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore: refresh contrib.rocks image cache [skip ci]"
+          commit-message: "chore: refresh contrib.rocks image cache across all READMEs [skip ci]"
           committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           branch: refresh-contrib-cache
           delete-branch: true
-          title: "Refresh contrib.rocks image cache"
+          title: "Refresh contrib.rocks image cache (all READMEs)"
           body: |
-            Automated refresh of the contrib.rocks image cache by bumping the cacheBust parameter in README.md.
+            Automated refresh of the contrib.rocks image cache by bumping the cacheBust parameter in README.md and locales/*/README.md.
           base: main

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -1,46 +1,49 @@
-name: Update Contributors
+name: Update Contributors # Refresh contrib.rocks image cache
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
-  update-contributors:
+  refresh-contrib-cache:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write  # Needed for pushing changes.
-      pull-requests: write  # Needed for creating PRs.
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Node.js and pnpm
-        uses: ./.github/actions/setup-node-pnpm
-      - name: Disable Husky
+
+      - name: Bump cacheBust in README
         run: |
-          echo "HUSKY=0" >> $GITHUB_ENV
-          git config --global core.hooksPath /dev/null
-      - name: Update contributors and format
+          set -euo pipefail
+          TS=$(date +%s)
+          if grep -q 'cacheBust=' README.md; then
+            sed -i "s/cacheBust=[0-9]\+/cacheBust=${TS}/g" README.md
+          else
+            echo "cacheBust parameter not found in README.md" >&2
+            exit 1
+          fi
+
+      - name: Detect changes
+        id: changes
         run: |
-          pnpm update-contributors
-          npx prettier --write README.md locales/*/README.md
-          if git diff --quiet; then echo "changes=false" >> $GITHUB_OUTPUT; else echo "changes=true" >> $GITHUB_OUTPUT; fi
-        id: check-changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          if git diff --quiet; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Create Pull Request
-        if: steps.check-changes.outputs.changes == 'true'
+        if: steps.changes.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "docs: update contributors list [skip ci]"
+          commit-message: "chore: refresh contrib.rocks image cache [skip ci]"
           committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-          branch: update-contributors
+          branch: refresh-contrib-cache
           delete-branch: true
-          title: "Update contributors list"
+          title: "Refresh contrib.rocks image cache"
           body: |
-            Automated update of contributors list and related files
-
-            This PR was created automatically by a GitHub Action workflow and includes all changed files.
+            Automated refresh of the contrib.rocks image cache by bumping the cacheBust parameter in README.md.
           base: main

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -57,7 +57,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore: refresh contrib.rocks image cache across all READMEs [skip ci]"
+          commit-message: "docs: update contributors list [skip ci]"
           committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           branch: refresh-contrib-cache
           delete-branch: true


### PR DESCRIPTION
Relates to #8005 

Rewrite workflow to bump README cacheBust and open PR only when changed; add explicit permissions and simplify steps.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Updates GitHub Actions workflow to refresh contrib.rocks cache by modifying `cacheBust` in README files and creating a PR only if changes occur.
> 
>   - **Workflow Changes**:
>     - Renames job to `refresh-contrib-cache` in `update-contributors.yml`.
>     - Adds explicit permissions for `contents` and `pull-requests`.
>     - Simplifies steps by removing Node.js setup and Husky disablement.
>   - **Behavior**:
>     - Updates `cacheBust` parameter in `README.md` and `locales/*/README.md`.
>     - Creates a pull request only if changes are detected in README files.
>   - **Misc**:
>     - Changes branch name to `refresh-contrib-cache` for pull requests.
>     - Updates commit message and pull request title to reflect cache refresh.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for be7e7655499136101a66e807909e366557e89ee2. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->