### PR TITLE
bug: Incorrect copy for "Run" command when approving execution

### DIFF
--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -232,7 +232,9 @@ export const ChatRowContent = ({
 					) : (
 						<TerminalSquare className="size-4" aria-label="Terminal icon" />
 					),
-					<span style={{ color: normalColor, fontWeight: "bold" }}>{t("chat:runCommand.title")}</span>,
+					<span style={{ color: normalColor, fontWeight: "bold" }}>
+						{t("chat:commandExecution.running")}
+					</span>,
 				]
 			case "use_mcp_server":
 				const mcpServerUse = safeJsonParse<ClineAskUseMcpServer>(message.text)

--- a/webview-ui/src/i18n/locales/ca/chat.json
+++ b/webview-ui/src/i18n/locales/ca/chat.json
@@ -205,6 +205,7 @@
 	"commandExecution": {
 		"running": "Corrent",
 		"abort": "Avortar",
+		"running": "En execució",
 		"pid": "PID: {{pid}}",
 		"exitStatus": "S'ha sortit amb l'estat {{exitCode}}",
 		"manageCommands": "Comandes aprovades automàticament",

--- a/webview-ui/src/i18n/locales/de/chat.json
+++ b/webview-ui/src/i18n/locales/de/chat.json
@@ -205,6 +205,7 @@
 	"commandExecution": {
 		"running": "Wird ausgeführt",
 		"abort": "Abbrechen",
+		"running": "Wird ausgeführt",
 		"pid": "PID: {{pid}}",
 		"exitStatus": "Beendet mit Status {{exitCode}}",
 		"manageCommands": "Automatisch genehmigte Befehle",

--- a/webview-ui/src/i18n/locales/en/chat.json
+++ b/webview-ui/src/i18n/locales/en/chat.json
@@ -222,8 +222,8 @@
 	},
 	"commandOutput": "Command Output",
 	"commandExecution": {
-		"running": "Running",
 		"abort": "Abort",
+		"running": "Running",
 		"pid": "PID: {{pid}}",
 		"exitStatus": "Exited with status {{exitCode}}",
 		"manageCommands": "Auto-approved commands",

--- a/webview-ui/src/i18n/locales/en/chat.json
+++ b/webview-ui/src/i18n/locales/en/chat.json
@@ -69,7 +69,7 @@
 		}
 	},
 	"runCommand": {
-		"title": "Command",
+		"title": "Run",
 		"tooltip": "Execute this command"
 	},
 	"proceedWhileRunning": {

--- a/webview-ui/src/i18n/locales/es/chat.json
+++ b/webview-ui/src/i18n/locales/es/chat.json
@@ -205,6 +205,7 @@
 	"commandExecution": {
 		"running": "Corriendo",
 		"abort": "Abortar",
+		"running": "Ejecutando",
 		"pid": "PID: {{pid}}",
 		"exitStatus": "Salió con el estado {{exitCode}}",
 		"manageCommands": "Comandos aprobados automáticamente",

--- a/webview-ui/src/i18n/locales/fr/chat.json
+++ b/webview-ui/src/i18n/locales/fr/chat.json
@@ -205,6 +205,7 @@
 	"commandExecution": {
 		"running": "En cours",
 		"abort": "Abandonner",
+		"running": "En cours d'exécution",
 		"pid": "PID : {{pid}}",
 		"exitStatus": "Terminé avec le statut {{exitCode}}",
 		"manageCommands": "Commandes approuvées automatiquement",

--- a/webview-ui/src/i18n/locales/hi/chat.json
+++ b/webview-ui/src/i18n/locales/hi/chat.json
@@ -205,6 +205,7 @@
 	"commandExecution": {
 		"running": "चल रहा है",
 		"abort": "रद्द करें",
+		"running": "चल रहा है",
 		"pid": "पीआईडी: {{pid}}",
 		"exitStatus": "{{exitCode}} स्थिति के साथ बाहर निकल गया",
 		"manageCommands": "स्वतः-अनुमोदित कमांड",

--- a/webview-ui/src/i18n/locales/id/chat.json
+++ b/webview-ui/src/i18n/locales/id/chat.json
@@ -227,6 +227,7 @@
 	"commandExecution": {
 		"running": "Sedang berjalan",
 		"abort": "Batalkan",
+		"running": "Menjalankan",
 		"pid": "PID: {{pid}}",
 		"exitStatus": "Keluar dengan status {{exitCode}}",
 		"manageCommands": "Perintah yang disetujui secara otomatis",

--- a/webview-ui/src/i18n/locales/it/chat.json
+++ b/webview-ui/src/i18n/locales/it/chat.json
@@ -205,6 +205,7 @@
 	"commandExecution": {
 		"running": "In esecuzione",
 		"abort": "Interrompi",
+		"running": "In esecuzione",
 		"pid": "PID: {{pid}}",
 		"exitStatus": "Uscito con stato {{exitCode}}",
 		"manageCommands": "Comandi approvati automaticamente",

--- a/webview-ui/src/i18n/locales/ja/chat.json
+++ b/webview-ui/src/i18n/locales/ja/chat.json
@@ -205,6 +205,7 @@
 	"commandExecution": {
 		"running": "実行中",
 		"abort": "中止",
+		"running": "実行中",
 		"pid": "PID: {{pid}}",
 		"exitStatus": "ステータス {{exitCode}} で終了しました",
 		"manageCommands": "自動承認されたコマンド",

--- a/webview-ui/src/i18n/locales/ko/chat.json
+++ b/webview-ui/src/i18n/locales/ko/chat.json
@@ -205,6 +205,7 @@
 	"commandExecution": {
 		"running": "실행 중",
 		"abort": "중단",
+		"running": "실행 중",
 		"pid": "PID: {{pid}}",
 		"exitStatus": "상태 {{exitCode}}(으)로 종료됨",
 		"manageCommands": "자동 승인된 명령",

--- a/webview-ui/src/i18n/locales/nl/chat.json
+++ b/webview-ui/src/i18n/locales/nl/chat.json
@@ -200,6 +200,7 @@
 	"commandExecution": {
 		"running": "Lopend",
 		"abort": "Afbreken",
+		"running": "Lopend",
 		"pid": "PID: {{pid}}",
 		"exitStatus": "Afgesloten met status {{exitCode}}",
 		"manageCommands": "Automatisch goedgekeurde commando's",

--- a/webview-ui/src/i18n/locales/pl/chat.json
+++ b/webview-ui/src/i18n/locales/pl/chat.json
@@ -205,6 +205,7 @@
 	"commandExecution": {
 		"running": "Wykonywanie",
 		"abort": "Przerwij",
+		"running": "Uruchomiony",
 		"pid": "PID: {{pid}}",
 		"exitStatus": "Zakończono ze statusem {{exitCode}}",
 		"manageCommands": "Polecenia zatwierdzone automatycznie",

--- a/webview-ui/src/i18n/locales/ru/chat.json
+++ b/webview-ui/src/i18n/locales/ru/chat.json
@@ -200,6 +200,7 @@
 	"commandExecution": {
 		"running": "Выполняется",
 		"abort": "Прервать",
+		"running": "Выполняется",
 		"pid": "PID: {{pid}}",
 		"exitStatus": "Завершено со статусом {{exitCode}}",
 		"manageCommands": "Управление разрешениями команд",

--- a/webview-ui/src/i18n/locales/tr/chat.json
+++ b/webview-ui/src/i18n/locales/tr/chat.json
@@ -205,6 +205,7 @@
 	"commandExecution": {
 		"running": "Çalışıyor",
 		"abort": "İptal Et",
+		"running": "Çalışıyor",
 		"pid": "PID: {{pid}}",
 		"exitStatus": "{{exitCode}} durumuyla çıkıldı",
 		"manageCommands": "Komut İzinlerini Yönet",

--- a/webview-ui/src/i18n/locales/vi/chat.json
+++ b/webview-ui/src/i18n/locales/vi/chat.json
@@ -205,6 +205,7 @@
 	"commandExecution": {
 		"running": "Đang chạy",
 		"abort": "Hủy bỏ",
+		"running": "Đang chạy",
 		"pid": "PID: {{pid}}",
 		"exitStatus": "Đã thoát với trạng thái {{exitCode}}",
 		"manageCommands": "Quản lý quyền lệnh",

--- a/webview-ui/src/i18n/locales/zh-CN/chat.json
+++ b/webview-ui/src/i18n/locales/zh-CN/chat.json
@@ -205,6 +205,7 @@
 	"commandExecution": {
 		"running": "正在运行",
 		"abort": "中止",
+		"running": "运行中",
 		"pid": "PID: {{pid}}",
 		"exitStatus": "已退出，状态码 {{exitCode}}",
 		"manageCommands": "管理命令权限",

--- a/webview-ui/src/i18n/locales/zh-TW/chat.json
+++ b/webview-ui/src/i18n/locales/zh-TW/chat.json
@@ -224,6 +224,7 @@
 	"commandExecution": {
 		"running": "正在執行",
 		"abort": "中止",
+		"running": "執行中",
 		"pid": "PID: {{pid}}",
 		"exitStatus": "已結束，狀態碼 {{exitCode}}",
 		"manageCommands": "管理命令權限",


### PR DESCRIPTION
This was happening because the incorrect key was being used in two places.

<img width="487" height="196" alt="image" src="https://github.com/user-attachments/assets/8519f1d0-682b-4d30-bc8b-475b6b4b059b" />