### PR TITLE
Wrap code blocks by default

### DIFF
--- a/webview-ui/src/components/common/CodeBlock.tsx
+++ b/webview-ui/src/components/common/CodeBlock.tsx
@@ -219,7 +219,7 @@ const CodeBlock = memo(
 		rawSource,
 		language,
 		preStyle,
-		initialWordWrap = false,
+		initialWordWrap = true,
 		initialWindowShade = true,
 		collapsedHeight,
 		onLanguageChange,


### PR DESCRIPTION
This reverts a change from #7985 to the default wrapping setting for code blocks. IMO this looks better, at least for trying to see what commands it wants to run.

Before:
<img width="301" height="284" alt="Screenshot 2025-09-20 at 11 37 01 AM" src="https://github.com/user-attachments/assets/359300c0-6e7c-4d84-b8d0-40a205368e02" />

After:
<img width="302" height="182" alt="Screenshot 2025-09-20 at 11 36 26 AM" src="https://github.com/user-attachments/assets/1266ab74-0806-4449-9b8a-a0d17a5fe264" />
