### PR TITLE
Correct tool use suggestion to improve model adherence to suggestion

### DIFF
--- a/src/core/tools/multiApplyDiffTool.ts
+++ b/src/core/tools/multiApplyDiffTool.ts
@@ -463,7 +463,7 @@ Error: ${failPart.error}
 Suggested fixes:
 1. Verify the search content exactly matches the file content (including whitespace and case)
 2. Check for correct indentation and line endings
-3. Use the read_file tool to verify the current file content
+3. Use the read_file tool to verify the file's current contents
 4. Consider breaking complex changes into smaller diffs
 5. Ensure start_line parameter matches the actual content location
 ${errorDetails ? `\nDetailed error information:\n${errorDetails}\n` : ""}
@@ -476,7 +476,7 @@ Unable to apply diffs to file: ${absolutePath}
 Error: ${diffResult.error}
 
 Recovery suggestions:
-1. Use the read_file tool to verify the current file content
+1. Use the read_file tool to verify the file's current contents
 2. Verify the diff format matches the expected search/replace pattern
 3. Check that the search content exactly matches what's in the file
 4. Consider using line numbers with start_line parameter

--- a/src/core/tools/multiApplyDiffTool.ts
+++ b/src/core/tools/multiApplyDiffTool.ts
@@ -463,7 +463,7 @@ Error: ${failPart.error}
 Suggested fixes:
 1. Verify the search content exactly matches the file content (including whitespace and case)
 2. Check for correct indentation and line endings
-3. Use <read_file> to see the current file content
+3. Use the read_file tool to verify the current file content
 4. Consider breaking complex changes into smaller diffs
 5. Ensure start_line parameter matches the actual content location
 ${errorDetails ? `\nDetailed error information:\n${errorDetails}\n` : ""}
@@ -476,7 +476,7 @@ Unable to apply diffs to file: ${absolutePath}
 Error: ${diffResult.error}
 
 Recovery suggestions:
-1. Use <read_file> to examine the current file content
+1. Use the read_file tool to verify the current file content
 2. Verify the diff format matches the expected search/replace pattern
 3. Check that the search content exactly matches what's in the file
 4. Consider using line numbers with start_line parameter


### PR DESCRIPTION
Intended to fix situations where Roo sometimes gives up trying to apply edits on a file after failures even though it has not tried to reread and verify the current condition of said file. 

<img width="662" height="355" alt="image" src="https://github.com/user-attachments/assets/61443048-342c-4b1f-9f98-ed5ae05cdad5" />

In this specific example Roo simply moved on after trying twice to make edits and failing but never reread the file to see if the edits were failing do to an incorrect understanding of the files current condition. 


<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Corrects tool use suggestion in `multiApplyDiffTool.ts` for clarity by replacing `<read_file>` with `the read_file tool`.
> 
>   - **Behavior**:
>     - Corrects tool use suggestion in `multiApplyDiffTool.ts` to replace `<read_file>` with `the read_file tool` for clarity.
>     - Changes occur in error message suggestions at lines 463 and 476.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7b5fbbddb60417dd9c538739b0d5d328a09aed18. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->