### PR TITLE
Terminal settings: Use Inline Terminal + clearer blurbs

### DIFF
--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -623,51 +623,51 @@
 		},
 		"outputLineLimit": {
 			"label": "Terminal output limit",
-			"description": "Maximum number of lines to include in terminal output when executing commands. When exceeded lines will be removed from the middle, saving tokens. <0>Learn more</0>"
+			"description": "Keeps the beginning and end of command output and drops the middle when needed to stay under the limit. Lower to save tokens; raise if you need more middle content. <0>Learn more</0>"
 		},
 		"outputCharacterLimit": {
 			"label": "Terminal character limit",
-			"description": "Maximum number of characters to include in terminal output when executing commands. This limit takes precedence over the line limit to prevent memory issues from extremely long lines. When exceeded, output will be truncated. <0>Learn more</0>"
+			"description": "Hard cap on output size. Keeps the beginning and end and omits the middle if needed. Overrides the line limit to prevent memory issues from very long lines. <0>Learn more</0>"
 		},
 		"shellIntegrationTimeout": {
 			"label": "Terminal shell integration timeout",
-			"description": "Maximum time to wait for shell integration to initialize before executing commands. For users with long shell startup times, this value may need to be increased if you see \"Shell Integration Unavailable\" errors in the terminal. <0>Learn more</0>"
+			"description": "How long to wait for VS Code shell integration before running commands. Increase if you see 'Shell Integration Unavailable' errors. Only applies when using the VS Code terminal. <0>Learn more</0>"
 		},
 		"shellIntegrationDisabled": {
-			"label": "Disable terminal shell integration",
-			"description": "Enable this if terminal commands aren't working correctly or you see 'Shell Integration Unavailable' errors. This uses a simpler method to run commands, bypassing some advanced terminal features. <0>Learn more</0>"
+			"label": "Use Inline Terminal (recommended)",
+			"description": "Run commands in a background process and stream output in chat (outside the VS Code terminal). Avoids shell profiles and shell integration, improving reliability and preventing 'Shell Integration Unavailable' errors. Recommended. <0>Learn more</0>"
 		},
 		"commandDelay": {
 			"label": "Terminal command delay",
-			"description": "Delay in milliseconds to add after command execution. The default setting of 0 disables the delay completely. This can help ensure command output is fully captured in terminals with timing issues. In most terminals it is implemented by setting `PROMPT_COMMAND='sleep N'` and Powershell appends `start-sleep` to the end of each command. Originally was workaround for VSCode bug#237208 and may not be needed. <0>Learn more</0>"
+			"description": "Adds a small delay after each command to help VS Code terminals flush all output. Set to 0 to disable. Workaround for terminal timing issues; usually not needed. <0>Learn more</0>"
 		},
 		"compressProgressBar": {
 			"label": "Compress progress bar output",
-			"description": "When enabled, processes terminal output with carriage returns (\\r) to simulate how a real terminal would display content. This removes intermediate progress bar states, retaining only the final state, which conserves context space for more relevant information. <0>Learn more</0>"
+			"description": "Recommended. Processes carriage returns (\\r) and backspaces (\\b) so progress bars and spinners render like a real terminal and only the final state is kept. Saves tokens; disable only when you need to inspect intermediate updates. <0>Learn more</0>"
 		},
 		"powershellCounter": {
 			"label": "Enable PowerShell counter workaround",
-			"description": "When enabled, adds a counter to PowerShell commands to ensure proper command execution. This helps with PowerShell terminals that might have issues with command output capture. <0>Learn more</0>"
+			"description": "Adds a small counter to PowerShell commands to work around missing output or repeated-command issues on some setups. <0>Learn more</0>"
 		},
 		"zshClearEolMark": {
 			"label": "Clear ZSH EOL mark",
-			"description": "When enabled, clears the ZSH end-of-line mark by setting PROMPT_EOL_MARK=''. This prevents issues with command output interpretation when output ends with special characters like '%'. <0>Learn more</0>"
+			"description": "Clears ZSH's end-of-line mark (%) so output is parsed correctly. <0>Learn more</0>"
 		},
 		"zshOhMy": {
 			"label": "Enable Oh My Zsh integration",
-			"description": "When enabled, sets ITERM_SHELL_INTEGRATION_INSTALLED=Yes to enable Oh My Zsh shell integration features. Applying this setting might require restarting the IDE. <0>Learn more</0>"
+			"description": "Enables Oh My Zsh shell integration detection. May require restarting the IDE. <0>Learn more</0>"
 		},
 		"zshP10k": {
 			"label": "Enable Powerlevel10k integration",
-			"description": "When enabled, sets POWERLEVEL9K_TERM_SHELL_INTEGRATION=true to enable Powerlevel10k shell integration features. <0>Learn more</0>"
+			"description": "Enables Powerlevel10k shell integration detection. <0>Learn more</0>"
 		},
 		"zdotdir": {
 			"label": "Enable ZDOTDIR handling",
-			"description": "When enabled, creates a temporary directory for ZDOTDIR to handle zsh shell integration properly. This ensures VSCode shell integration works correctly with zsh while preserving your zsh configuration. <0>Learn more</0>"
+			"description": "Uses a temporary ZDOTDIR so VS Code shell integration works with zsh while preserving your config. <0>Learn more</0>"
 		},
 		"inheritEnv": {
 			"label": "Inherit environment variables",
-			"description": "When enabled, the terminal will inherit environment variables from VSCode's parent process, such as user-profile-defined shell integration settings. This directly toggles VSCode global setting `terminal.integrated.inheritEnv`. <0>Learn more</0>"
+			"description": "Let the terminal inherit environment variables from the parent VS Code process. Toggles VS Code setting 'terminal.integrated.inheritEnv'. <0>Learn more</0>"
 		}
 	},
 	"advancedSettings": {


### PR DESCRIPTION
Summary
- Rename the setting label to “Use Inline Terminal (recommended)” to reflect actual behavior (execa-based background runner) and fit UI constraints.
- Clarify terminal blurbs with code-accurate, user-facing descriptions:
  - Output/character limits keep head+tail and omit middle when needed.
  - Shell integration timeout applies only to VS Code terminal path.
  - Command delay describes timing workaround context.
  - Progress bar compression explains CR (\r) and BS (\b) handling to render like a real terminal and keep final state.
  - PowerShell counter notes repeated-command/missing-output cases.
- English locale only (other locales unchanged for now).

Implementation references
- Decision switch: src/core/tools/executeCommandTool.ts
- Inline runner: src/integrations/terminal/ExecaTerminal.ts
- VS Code terminal route: src/integrations/terminal/Terminal.ts, src/integrations/terminal/TerminalProcess.ts
- Compression pipeline: src/integrations/terminal/BaseTerminal.ts (processCarriageReturns/processBackspaces) and src/integrations/misc/extract-text.ts

Tests
- webview-ui test suite passing locally.

Follow-ups
- Propagate blurbs to non-English locales after copy review.
