### PR TITLE
chore: add changeset for v3.28.11

### DIFF
--- a/.changeset/v3.28.11.md
+++ b/.changeset/v3.28.11.md
@@ -1,0 +1,6 @@
+---
+"roo-cline": patch
+---
+
+- Fix: Correct AWS Bedrock Claude Sonnet 4.5 model identifier (#8371 by @sunhyung, PR by @app/roomote)
+- Fix: Correct Claude Sonnet 4.5 model ID format (thanks @daniel-lxs!)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds changeset for v3.28.11 to fix AWS Bedrock Claude Sonnet 4.5 model identifier and ID format.
> 
>   - **Changeset**:
>     - Adds `.changeset/v3.28.11.md` for version v3.28.11.
>     - Fixes AWS Bedrock Claude Sonnet 4.5 model identifier.
>     - Corrects Claude Sonnet 4.5 model ID format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c604c95655d443a45a6a22a713fee0310da92653. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->