### PR TITLE
feat(ui): adjust roo font size

### DIFF
--- a/packages/types/src/vscode.ts
+++ b/packages/types/src/vscode.ts
@@ -54,6 +54,8 @@ export const commandIds = [
 	"acceptInput",
 	"focusPanel",
 	"toggleAutoApprove",
+	"increaseFontSize",
+	"decreaseFontSize",
 ] as const
 
 export type CommandId = (typeof commandIds)[number]

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -233,6 +233,38 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 			action: "toggleAutoApprove",
 		})
 	},
+	increaseFontSize: async () => {
+		const config = vscode.workspace.getConfiguration(Package.name)
+		const currentMultiplier = config.get<number>("fontSizeMultiplier") || 1.0
+		const newMultiplier = Math.min(currentMultiplier + 0.1, 3.0)
+
+		await config.update("fontSizeMultiplier", newMultiplier, vscode.ConfigurationTarget.Global)
+
+		const visibleProvider = getVisibleProviderOrLog(outputChannel)
+		if (visibleProvider) {
+			visibleProvider.postMessageToWebview({
+				type: "action",
+				action: "fontSizeChanged",
+				fontSizeMultiplier: newMultiplier,
+			})
+		}
+	},
+	decreaseFontSize: async () => {
+		const config = vscode.workspace.getConfiguration(Package.name)
+		const currentMultiplier = config.get<number>("fontSizeMultiplier") || 1.0
+		const newMultiplier = Math.max(currentMultiplier - 0.1, 0.5)
+
+		await config.update("fontSizeMultiplier", newMultiplier, vscode.ConfigurationTarget.Global)
+
+		const visibleProvider = getVisibleProviderOrLog(outputChannel)
+		if (visibleProvider) {
+			visibleProvider.postMessageToWebview({
+				type: "action",
+				action: "fontSizeChanged",
+				fontSizeMultiplier: newMultiplier,
+			})
+		}
+	},
 })
 
 export const openClineInNewTab = async ({ context, outputChannel }: Omit<RegisterCommandOptions, "provider">) => {

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1817,6 +1817,10 @@ export class ClineProvider
 			featureRoomoteControlEnabled,
 		} = await this.getState()
 
+		// Get font size multiplier from VSCode settings
+		const fontSizeMultiplier =
+			vscode.workspace.getConfiguration(Package.name).get<number>("fontSizeMultiplier") || 1.0
+
 		let cloudOrganizations: CloudOrganizationMembership[] = []
 
 		try {
@@ -1964,6 +1968,7 @@ export class ClineProvider
 			openRouterImageGenerationSelectedModel,
 			openRouterUseMiddleOutTransform,
 			featureRoomoteControlEnabled,
+			fontSizeMultiplier,
 		}
 	}
 
@@ -2195,6 +2200,8 @@ export class ClineProvider
 					return false
 				}
 			})(),
+			fontSizeMultiplier:
+				vscode.workspace.getConfiguration(Package.name).get<number>("fontSizeMultiplier") || 1.0,
 		}
 	}
 

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -557,6 +557,7 @@ describe("ClineProvider", () => {
 			remoteControlEnabled: false,
 			taskSyncEnabled: false,
 			featureRoomoteControlEnabled: false,
+			fontSizeMultiplier: 1,
 		}
 
 		const message: ExtensionMessage = {

--- a/src/package.json
+++ b/src/package.json
@@ -179,6 +179,16 @@
 				"command": "roo-cline.toggleAutoApprove",
 				"title": "%command.toggleAutoApprove.title%",
 				"category": "%configuration.title%"
+			},
+			{
+				"command": "roo-cline.increaseFontSize",
+				"title": "%command.increaseFontSize.title%",
+				"category": "%configuration.title%"
+			},
+			{
+				"command": "roo-cline.decreaseFontSize",
+				"title": "%command.decreaseFontSize.title%",
+				"category": "%configuration.title%"
 			}
 		],
 		"menus": {
@@ -429,6 +439,13 @@
 					"minimum": 1,
 					"maximum": 200,
 					"description": "%settings.codeIndex.embeddingBatchSize.description%"
+				},
+				"roo-cline.fontSizeMultiplier": {
+					"type": "number",
+					"default": 1,
+					"minimum": 0.5,
+					"maximum": 3,
+					"description": "%settings.fontSizeMultiplier.description%"
 				}
 			}
 		}

--- a/src/package.nls.json
+++ b/src/package.nls.json
@@ -27,6 +27,8 @@
 	"command.terminal.explainCommand.title": "Explain This Command",
 	"command.acceptInput.title": "Accept Input/Suggestion",
 	"command.toggleAutoApprove.title": "Toggle Auto-Approve",
+	"command.increaseFontSize.title": "Increase Font Size",
+	"command.decreaseFontSize.title": "Decrease Font Size",
 	"configuration.title": "Roo Code",
 	"commands.allowedCommands.description": "Commands that can be auto-executed when 'Always approve execute operations' is enabled",
 	"commands.deniedCommands.description": "Command prefixes that will be automatically denied without asking for approval. In case of conflicts with allowed commands, the longest prefix match takes precedence. Add * to deny all commands.",
@@ -42,5 +44,6 @@
 	"settings.useAgentRules.description": "Enable loading of AGENTS.md files for agent-specific rules (see https://agent-rules.org/)",
 	"settings.apiRequestTimeout.description": "Maximum time in seconds to wait for API responses (0 = no timeout, 1-3600s, default: 600s). Higher values are recommended for local providers like LM Studio and Ollama that may need more processing time.",
 	"settings.newTaskRequireTodos.description": "Require todos parameter when creating new tasks with the new_task tool",
-	"settings.codeIndex.embeddingBatchSize.description": "The batch size for embedding operations during code indexing. Adjust this based on your API provider's limits. Default is 60."
+	"settings.codeIndex.embeddingBatchSize.description": "The batch size for embedding operations during code indexing. Adjust this based on your API provider's limits. Default is 60.",
+	"settings.fontSizeMultiplier.description": "Font size multiplier for the RooCode interface. Adjusts all font sizes proportionally (0.5-3.0, default: 1.0)"
 }

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -140,6 +140,7 @@ export interface ExtensionMessage {
 		| "focusInput"
 		| "switchTab"
 		| "toggleAutoApprove"
+		| "fontSizeChanged"
 	invoke?: "newChat" | "sendMessage" | "primaryButtonClick" | "secondaryButtonClick" | "setChatBoxMessage"
 	state?: ExtensionState
 	images?: string[]
@@ -205,6 +206,7 @@ export interface ExtensionMessage {
 	queuedMessages?: QueuedMessage[]
 	list?: string[] // For dismissedUpsells
 	organizationId?: string | null // For organizationSwitchResult
+	fontSizeMultiplier?: number // For fontSizeChanged action
 }
 
 export type ExtensionState = Pick<
@@ -353,6 +355,7 @@ export type ExtensionState = Pick<
 	remoteControlEnabled: boolean
 	taskSyncEnabled: boolean
 	featureRoomoteControlEnabled: boolean
+	fontSizeMultiplier: number
 }
 
 export interface ClineSayTool {

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -79,6 +79,7 @@ const App = () => {
 		cloudOrganizations,
 		renderContext,
 		mdmCompliant,
+		fontSizeMultiplier,
 	} = useExtensionState()
 
 	// Create a persistent state manager
@@ -140,6 +141,15 @@ const App = () => {
 			const message: ExtensionMessage = e.data
 
 			if (message.type === "action" && message.action) {
+				// Handle fontSizeChanged action
+				if (message.action === "fontSizeChanged" && message.fontSizeMultiplier !== undefined) {
+					document.documentElement.style.setProperty(
+						"--roo-font-size-multiplier",
+						message.fontSizeMultiplier.toString(),
+					)
+					return
+				}
+
 				// Handle switchTab action with tab parameter
 				if (message.action === "switchTab" && message.tab) {
 					const targetTab = message.tab as Tab
@@ -223,6 +233,13 @@ const App = () => {
 		// Log initialization for debugging
 		console.debug("App initialized with source map support")
 	}, [])
+
+	// Initialize font size multiplier when the component mounts or when it changes
+	useEffect(() => {
+		if (fontSizeMultiplier !== undefined) {
+			document.documentElement.style.setProperty("--roo-font-size-multiplier", fontSizeMultiplier.toString())
+		}
+	}, [fontSizeMultiplier])
 
 	// Focus the WebView when non-interactive content is clicked (only in editor/tab mode)
 	useAddNonInteractiveClickListener(

--- a/webview-ui/src/components/chat/BrowserSessionRow.tsx
+++ b/webview-ui/src/components/chat/BrowserSessionRow.tsx
@@ -262,7 +262,7 @@ const BrowserSessionRow = memo((props: BrowserSessionRowProps) => {
 						alignItems: "center",
 						justifyContent: "center",
 						color: "var(--vscode-descriptionForeground)",
-						fontSize: "12px",
+						fontSize: "calc(12px * var(--roo-font-size-multiplier, 1))",
 					}}>
 					<div
 						style={{
@@ -318,7 +318,10 @@ const BrowserSessionRow = memo((props: BrowserSessionRowProps) => {
 							}}>
 							<span
 								className="codicon codicon-globe"
-								style={{ fontSize: "80px", color: "var(--vscode-descriptionForeground)" }}
+								style={{
+									fontSize: "calc(80px * var(--roo-font-size-multiplier, 1))",
+									color: "var(--vscode-descriptionForeground)",
+								}}
 							/>
 						</div>
 					)}

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -277,7 +277,11 @@ export const ChatRowContent = ({
 						}}>
 						<span
 							className={`codicon codicon-${iconName}`}
-							style={{ color, fontSize: 16, marginBottom: "-1.5px" }}
+							style={{
+								color,
+								fontSize: "calc(16px * var(--roo-font-size-multiplier, 1))",
+								marginBottom: "-1.5px",
+							}}
 						/>
 					</div>
 				)
@@ -821,7 +825,7 @@ export const ChatRowContent = ({
 									backgroundColor: "var(--vscode-badge-background)",
 									borderBottom: "1px solid var(--vscode-editorGroup-border)",
 									fontWeight: "bold",
-									fontSize: "var(--vscode-font-size)",
+									fontSize: "calc(var(--vscode-font-size) * var(--roo-font-size-multiplier, 1))",
 									color: "var(--vscode-badge-foreground)",
 									display: "flex",
 									alignItems: "center",
@@ -858,7 +862,7 @@ export const ChatRowContent = ({
 									backgroundColor: "var(--vscode-badge-background)",
 									borderBottom: "1px solid var(--vscode-editorGroup-border)",
 									fontWeight: "bold",
-									fontSize: "var(--vscode-font-size)",
+									fontSize: "calc(var(--vscode-font-size) * var(--roo-font-size-multiplier, 1))",
 									color: "var(--vscode-badge-foreground)",
 									display: "flex",
 									alignItems: "center",
@@ -904,11 +908,20 @@ export const ChatRowContent = ({
 									padding: "10px 12px",
 								}}>
 								<div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-									<span style={{ fontWeight: "500", fontSize: "var(--vscode-font-size)" }}>
+									<span
+										style={{
+											fontWeight: "500",
+											fontSize:
+												"calc(var(--vscode-font-size) * var(--roo-font-size-multiplier, 1))",
+										}}>
 										/{slashCommandInfo.command}
 									</span>
 									{slashCommandInfo.source && (
-										<VSCodeBadge style={{ fontSize: "calc(var(--vscode-font-size) - 2px)" }}>
+										<VSCodeBadge
+											style={{
+												fontSize:
+													"calc((var(--vscode-font-size) - 2px) * var(--roo-font-size-multiplier, 1))",
+											}}>
 											{slashCommandInfo.source}
 										</VSCodeBadge>
 									)}
@@ -1014,7 +1027,7 @@ export const ChatRowContent = ({
 										backgroundColor: "var(--vscode-badge-background)",
 										borderBottom: "1px solid var(--vscode-editorGroup-border)",
 										fontWeight: "bold",
-										fontSize: "var(--vscode-font-size)",
+										fontSize: "calc(var(--vscode-font-size) * var(--roo-font-size-multiplier, 1))",
 										color: "var(--vscode-badge-foreground)",
 										display: "flex",
 										alignItems: "center",
@@ -1326,7 +1339,8 @@ export const ChatRowContent = ({
 													<span
 														style={{
 															fontWeight: "500",
-															fontSize: "var(--vscode-font-size)",
+															fontSize:
+																"calc(var(--vscode-font-size) * var(--roo-font-size-multiplier, 1))",
 														}}>
 														/{slashCommandInfo.command}
 													</span>
@@ -1334,7 +1348,8 @@ export const ChatRowContent = ({
 														<span
 															style={{
 																color: "var(--vscode-descriptionForeground)",
-																fontSize: "var(--vscode-font-size)",
+																fontSize:
+																	"calc(var(--vscode-font-size) * var(--roo-font-size-multiplier, 1))",
 															}}>
 															{slashCommandInfo.args}
 														</span>
@@ -1344,7 +1359,8 @@ export const ChatRowContent = ({
 													<div
 														style={{
 															color: "var(--vscode-descriptionForeground)",
-															fontSize: "calc(var(--vscode-font-size) - 1px)",
+															fontSize:
+																"calc((var(--vscode-font-size) - 1px) * var(--roo-font-size-multiplier, 1))",
 														}}>
 														{slashCommandInfo.description}
 													</div>
@@ -1352,7 +1368,10 @@ export const ChatRowContent = ({
 												{slashCommandInfo.source && (
 													<div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
 														<VSCodeBadge
-															style={{ fontSize: "calc(var(--vscode-font-size) - 2px)" }}>
+															style={{
+																fontSize:
+																	"calc((var(--vscode-font-size) - 2px) * var(--roo-font-size-multiplier, 1))",
+															}}>
 															{slashCommandInfo.source}
 														</VSCodeBadge>
 													</div>

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -3,7 +3,7 @@ import { useDeepCompareEffect, useEvent, useMount } from "react-use"
 import debounce from "debounce"
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso"
 import removeMd from "remove-markdown"
-import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import useSound from "use-sound"
 import { LRUCache } from "lru-cache"
 import { Trans, useTranslation } from "react-i18next"
@@ -37,7 +37,7 @@ import { useExtensionState } from "@src/context/ExtensionStateContext"
 import { useSelectedModel } from "@src/components/ui/hooks/useSelectedModel"
 import RooHero from "@src/components/welcome/RooHero"
 import RooTips from "@src/components/welcome/RooTips"
-import { StandardTooltip } from "@src/components/ui"
+import { Button, StandardTooltip } from "@src/components/ui"
 import { useAutoApprovalState } from "@src/hooks/useAutoApprovalState"
 import { useAutoApprovalToggles } from "@src/hooks/useAutoApprovalToggles"
 import { CloudUpsellDialog } from "@src/components/cloud/CloudUpsellDialog"
@@ -1900,15 +1900,15 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 							}`}>
 							{showScrollToBottom ? (
 								<StandardTooltip content={t("chat:scrollToBottom")}>
-									<VSCodeButton
-										appearance="secondary"
+									<Button
+										variant="secondary"
 										className="flex-[2]"
 										onClick={() => {
 											scrollToBottomSmooth()
 											disableAutoScrollRef.current = false
 										}}>
 										<span className="codicon codicon-chevron-down"></span>
-									</VSCodeButton>
+									</Button>
 								</StandardTooltip>
 							) : (
 								<>
@@ -1935,13 +1935,13 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 																				? t("chat:proceedWhileRunning.tooltip")
 																				: undefined
 											}>
-											<VSCodeButton
-												appearance="primary"
+											<Button
+												variant="default"
 												disabled={!enableButtons}
 												className={secondaryButtonText ? "flex-1 mr-[6px]" : "flex-[2] mr-0"}
 												onClick={() => handlePrimaryButtonClick(inputValue, selectedImages)}>
 												{primaryButtonText}
-											</VSCodeButton>
+											</Button>
 										</StandardTooltip>
 									)}
 									{(secondaryButtonText || isStreaming) && (
@@ -1957,13 +1957,13 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 																? t("chat:terminate.tooltip")
 																: undefined
 											}>
-											<VSCodeButton
-												appearance="secondary"
+											<Button
+												variant="secondary"
 												disabled={!enableButtons && !(isStreaming && !didClickCancel)}
-												className={isStreaming ? "flex-[2] ml-0" : "flex-1 ml-[6px]"}
+												className={isStreaming ? "flex-[2] ml-0" : "flex-1 ml-[px]"}
 												onClick={() => handleSecondaryButtonClick(inputValue, selectedImages)}>
 												{isStreaming ? t("chat:cancel.title") : secondaryButtonText}
-											</VSCodeButton>
+											</Button>
 										</StandardTooltip>
 									)}
 								</>

--- a/webview-ui/src/components/chat/CodeIndexPopover.tsx
+++ b/webview-ui/src/components/chat/CodeIndexPopover.tsx
@@ -7,8 +7,8 @@ import {
 	VSCodeDropdown,
 	VSCodeOption,
 	VSCodeLink,
-	VSCodeCheckbox,
 } from "@vscode/webview-ui-toolkit/react"
+import { Checkbox } from "@/components/ui/checkbox"
 import * as ProgressPrimitive from "@radix-ui/react-progress"
 import { AlertTriangle } from "lucide-react"
 
@@ -577,11 +577,13 @@ export const CodeIndexPopover: React.FC<CodeIndexPopoverProps> = ({
 						{/* Enable/Disable Toggle */}
 						<div className="mb-4">
 							<div className="flex items-center gap-2">
-								<VSCodeCheckbox
+								<Checkbox
 									checked={currentSettings.codebaseIndexEnabled}
-									onChange={(e: any) => updateSetting("codebaseIndexEnabled", e.target.checked)}>
-									<span className="font-medium">{t("settings:codeIndex.enableLabel")}</span>
-								</VSCodeCheckbox>
+									onCheckedChange={(checked) =>
+										updateSetting("codebaseIndexEnabled", checked === true)
+									}
+								/>
+								<span className="font-medium">{t("settings:codeIndex.enableLabel")}</span>
 								<StandardTooltip content={t("settings:codeIndex.enableDescription")}>
 									<span className="codicon codicon-info text-xs text-vscode-descriptionForeground cursor-help" />
 								</StandardTooltip>

--- a/webview-ui/src/components/chat/ContextCondenseRow.tsx
+++ b/webview-ui/src/components/chat/ContextCondenseRow.tsx
@@ -31,7 +31,11 @@ export const ContextCondenseRow = ({ cost, prevContextTokens, newContextTokens, 
 					}}>
 					<span
 						className={`codicon codicon-check`}
-						style={{ color: "var(--vscode-charts-green)", fontSize: 16, marginBottom: "-1.5px" }}
+						style={{
+							color: "var(--vscode-charts-green)",
+							fontSize: "calc(16px * var(--roo-font-size-multiplier, 1))",
+							marginBottom: "-1.5px",
+						}}
 					/>
 				</div>
 				<div className="flex items-center gap-2 flex-grow">

--- a/webview-ui/src/components/chat/ContextMenu.tsx
+++ b/webview-ui/src/components/chat/ContextMenu.tsx
@@ -402,7 +402,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
 											style={{
 												marginRight: "6px",
 												flexShrink: 0,
-												fontSize: "14px",
+												fontSize: "calc(14px * var(--roo-font-size-multiplier, 1))",
 												marginTop: 0,
 											}}
 										/>
@@ -415,7 +415,11 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
 								!option.value && (
 									<i
 										className="codicon codicon-chevron-right"
-										style={{ fontSize: "10px", flexShrink: 0, marginLeft: 8 }}
+										style={{
+											fontSize: "calc(10px * var(--roo-font-size-multiplier, 1))",
+											flexShrink: 0,
+											marginLeft: 8,
+										}}
 									/>
 								)}
 						</div>

--- a/webview-ui/src/components/chat/FollowUpSuggest.tsx
+++ b/webview-ui/src/components/chat/FollowUpSuggest.tsx
@@ -127,7 +127,10 @@ export const FollowUpSuggest = ({
 						</Button>
 						{suggestion.mode && (
 							<div className="absolute bottom-0 right-0 text-[10px] bg-vscode-badge-background text-vscode-badge-foreground px-1 py-0.5 border border-vscode-badge-background flex items-center gap-0.5">
-								<span className="codicon codicon-arrow-right" style={{ fontSize: "8px" }} />
+								<span
+									className="codicon codicon-arrow-right"
+									style={{ fontSize: "calc(8px * var(--roo-font-size-multiplier, 1))" }}
+								/>
 								{suggestion.mode}
 							</div>
 						)}

--- a/webview-ui/src/components/chat/IconButton.tsx
+++ b/webview-ui/src/components/chat/IconButton.tsx
@@ -40,7 +40,7 @@ export const IconButton: React.FC<IconButtonProps> = ({
 			)}
 			disabled={disabled}
 			onClick={!disabled ? onClick : undefined}
-			style={{ fontSize: 16.5, ...style }}
+			style={{ fontSize: "calc(16.5px * var(--roo-font-size-multiplier, 1))", ...style }}
 			{...props}>
 			<span className={cn("codicon", iconClass, isLoading && "codicon-modifier-spin")} />
 		</Button>

--- a/webview-ui/src/components/chat/TodoListDisplay.tsx
+++ b/webview-ui/src/components/chat/TodoListDisplay.tsx
@@ -65,7 +65,7 @@ export function TodoListDisplay({ todos }: { todos: any[] }) {
 						marginRight: 8,
 						marginLeft: 2,
 						flexShrink: 0,
-						fontSize: 14,
+						fontSize: "calc(14px * var(--roo-font-size-multiplier, 1))",
 					}}
 				/>
 			)
@@ -163,13 +163,13 @@ export function TodoListDisplay({ todos }: { todos: any[] }) {
 						className="codicon codicon-checklist"
 						style={{
 							color: "var(--vscode-descriptionForeground)",
-							fontSize: 12,
+							fontSize: "calc(12px * var(--roo-font-size-multiplier, 1))",
 						}}
 					/>
 					<span
 						style={{
 							color: "var(--vscode-descriptionForeground)",
-							fontSize: 12,
+							fontSize: "calc(12px * var(--roo-font-size-multiplier, 1))",
 							fontWeight: 500,
 						}}>
 						{completedCount}/{totalCount}
@@ -224,11 +224,17 @@ export function TodoListDisplay({ todos }: { todos: any[] }) {
 									className="codicon codicon-checklist"
 									style={{ color: "var(--vscode-foreground)" }}
 								/>
-								<span style={{ fontWeight: "bold", fontSize: 14 }}>Todo List</span>
+								<span
+									style={{
+										fontWeight: "bold",
+										fontSize: "calc(14px * var(--roo-font-size-multiplier, 1))",
+									}}>
+									Todo List
+								</span>
 								<span
 									style={{
 										color: "var(--vscode-descriptionForeground)",
-										fontSize: 13,
+										fontSize: "calc(13px * var(--roo-font-size-multiplier, 1))",
 										fontWeight: 500,
 									}}>
 									{completedCount}/{totalCount}
@@ -237,7 +243,7 @@ export function TodoListDisplay({ todos }: { todos: any[] }) {
 							<span
 								className="codicon codicon-chevron-up"
 								style={{
-									fontSize: 14,
+									fontSize: "calc(14px * var(--roo-font-size-multiplier, 1))",
 									opacity: 0.7,
 									cursor: "pointer",
 									padding: "4px",

--- a/webview-ui/src/components/common/CodeAccordian.tsx
+++ b/webview-ui/src/components/common/CodeAccordian.tsx
@@ -73,7 +73,7 @@ const CodeAccordian = ({
 					{onJumpToFile && path && (
 						<span
 							className="codicon codicon-link-external mr-1"
-							style={{ fontSize: 13.5 }}
+							style={{ fontSize: "calc(13.5px * var(--roo-font-size-multiplier, 1))" }}
 							onClick={(e) => {
 								e.stopPropagation()
 								onJumpToFile()

--- a/webview-ui/src/components/common/CodeBlock.tsx
+++ b/webview-ui/src/components/common/CodeBlock.tsx
@@ -142,7 +142,7 @@ export const StyledPre = styled.div<{
 		white-space: ${({ wordwrap }) => (wordwrap === "false" ? "pre" : "pre-wrap")};
 		word-break: ${({ wordwrap }) => (wordwrap === "false" ? "normal" : "normal")};
 		overflow-wrap: ${({ wordwrap }) => (wordwrap === "false" ? "normal" : "break-word")};
-		font-size: 0.95em;
+		font-size: calc(0.95em * var(--roo-font-size-multiplier, 1));
 		font-family: var(--vscode-editor-font-family);
 	}
 

--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -26,7 +26,7 @@ const StyledMarkdown = styled.div`
 
 	code:not(pre > code) {
 		font-family: var(--vscode-editor-font-family, monospace);
-		font-size: 0.85em;
+		font-size: calc(0.85em * var(--roo-font-size-multiplier, 1));
 		filter: saturation(110%) brightness(95%);
 		color: var(--vscode-textPreformat-foreground) !important;
 		background-color: var(--vscode-textPreformat-background) !important;
@@ -46,7 +46,7 @@ const StyledMarkdown = styled.div`
 
 	/* KaTeX styling */
 	.katex {
-		font-size: 1.1em;
+		font-size: calc(1.1em * var(--roo-font-size-multiplier, 1));
 		color: var(--vscode-editor-foreground);
 		font-family: KaTeX_Main, "Times New Roman", serif;
 		line-height: 1.2;
@@ -83,7 +83,7 @@ const StyledMarkdown = styled.div`
 		"Helvetica Neue",
 		sans-serif;
 
-	font-size: var(--vscode-font-size, 13px);
+	font-size: calc(var(--vscode-font-size, 13px) * var(--roo-font-size-multiplier, 1));
 
 	p,
 	li,
@@ -147,19 +147,19 @@ const StyledMarkdown = styled.div`
 	}
 
 	h1 {
-		font-size: 1.65em;
+		font-size: calc(1.65em * var(--roo-font-size-multiplier, 1));
 		font-weight: 700;
 		margin: 1.35em 0 0.5em;
 	}
 
 	h2 {
-		font-size: 1.35em;
+		font-size: calc(1.35em * var(--roo-font-size-multiplier, 1));
 		font-weight: 500;
 		margin: 1.35em 0 0.5em;
 	}
 
 	h3 {
-		font-size: 1.2em;
+		font-size: calc(1.2em * var(--roo-font-size-multiplier, 1));
 		font-weight: 500;
 	}
 

--- a/webview-ui/src/components/common/MermaidBlock.tsx
+++ b/webview-ui/src/components/common/MermaidBlock.tsx
@@ -49,7 +49,7 @@ mermaid.initialize({
 	suppressErrorRendering: true,
 	themeVariables: {
 		...MERMAID_THEME,
-		fontSize: "16px",
+		fontSize: "calc(16px * var(--roo-font-size-multiplier, 1))",
 		fontFamily: "var(--vscode-font-family, 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif)",
 
 		// Additional styling
@@ -163,7 +163,7 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
 						style={{
 							borderBottom: isErrorExpanded ? "1px solid var(--vscode-editorGroup-border)" : "none",
 							fontWeight: "normal",
-							fontSize: "var(--vscode-font-size)",
+							fontSize: "calc(var(--vscode-font-size) * var(--roo-font-size-multiplier, 1))",
 							color: "var(--vscode-editor-foreground)",
 							display: "flex",
 							alignItems: "center",
@@ -183,7 +183,7 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
 								style={{
 									color: "var(--vscode-editorWarning-foreground)",
 									opacity: 0.8,
-									fontSize: 16,
+									fontSize: "calc(16px * var(--roo-font-size-multiplier, 1))",
 									marginBottom: "-1.5px",
 								}}></span>
 							<span style={{ fontWeight: "bold" }}>{t("common:mermaid.render_error")}</span>
@@ -289,7 +289,7 @@ const LoadingMessage = styled.div`
 	padding: 8px 0;
 	color: var(--vscode-descriptionForeground);
 	font-style: italic;
-	font-size: 0.9em;
+	font-size: calc(0.9em * var(--roo-font-size-multiplier, 1));
 `
 
 const CopyButton = styled.button`

--- a/webview-ui/src/components/common/MermaidButton.tsx
+++ b/webview-ui/src/components/common/MermaidButton.tsx
@@ -205,7 +205,12 @@ export function MermaidButton({ containerRef, code, isLoading, svgToPng, childre
 							className="w-full min-h-[200px] bg-vscode-editor-background text-vscode-editor-foreground border border-vscode-editorGroup-border rounded-[3px] p-2 font-mono resize-y outline-none"
 							readOnly
 							value={code}
-							style={{ height: "100%", minHeight: "unset", fontSize: "var(--vscode-editor-font-size)" }}
+							style={{
+								height: "100%",
+								minHeight: "unset",
+								fontSize:
+									"calc(var(--vscode-editor-font-size, var(--vscode-font-size)) * var(--roo-font-size-multiplier, 1))",
+							}}
 						/>
 					)}
 				</div>

--- a/webview-ui/src/components/common/Thumbnails.tsx
+++ b/webview-ui/src/components/common/Thumbnails.tsx
@@ -85,7 +85,7 @@ const Thumbnails = ({ images, style, setImages, onHeightChange }: ThumbnailsProp
 								className="codicon codicon-close"
 								style={{
 									color: "var(--vscode-foreground)",
-									fontSize: 10,
+									fontSize: "calc(10px * var(--roo-font-size-multiplier, 1))",
 									fontWeight: "bold",
 								}}></span>
 						</div>

--- a/webview-ui/src/components/mcp/McpEnabledToggle.tsx
+++ b/webview-ui/src/components/mcp/McpEnabledToggle.tsx
@@ -1,28 +1,26 @@
-import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
-import { FormEvent } from "react"
 import { useExtensionState } from "@src/context/ExtensionStateContext"
 import { useAppTranslation } from "@src/i18n/TranslationContext"
 import { vscode } from "@src/utils/vscode"
+import { Checkbox } from "@/components/ui/checkbox"
 
 const McpEnabledToggle = () => {
 	const { mcpEnabled, setMcpEnabled } = useExtensionState()
 	const { t } = useAppTranslation()
 
-	const handleChange = (e: Event | FormEvent<HTMLElement>) => {
-		const target = ("target" in e ? e.target : null) as HTMLInputElement | null
-		if (!target) return
-		setMcpEnabled(target.checked)
-		vscode.postMessage({ type: "mcpEnabled", bool: target.checked })
+	const handleChange = (checked: boolean) => {
+		setMcpEnabled(checked)
+		vscode.postMessage({ type: "mcpEnabled", bool: checked })
 	}
 
 	return (
 		<div style={{ marginBottom: "20px" }}>
-			<VSCodeCheckbox checked={mcpEnabled} onChange={handleChange}>
+			<div className="flex items-center space-x-2">
+				<Checkbox checked={mcpEnabled} onCheckedChange={handleChange} />
 				<span style={{ fontWeight: "500" }}>{t("mcp:enableToggle.title")}</span>
-			</VSCodeCheckbox>
+			</div>
 			<p
 				style={{
-					fontSize: "12px",
+					fontSize: "calc(12px * var(--roo-font-size-multiplier, 1))",
 					marginTop: "5px",
 					color: "var(--vscode-descriptionForeground)",
 				}}>

--- a/webview-ui/src/components/mcp/McpResourceRow.tsx
+++ b/webview-ui/src/components/mcp/McpResourceRow.tsx
@@ -25,7 +25,7 @@ const McpResourceRow = ({ item }: McpResourceRowProps) => {
 			</div>
 			<div
 				style={{
-					fontSize: "12px",
+					fontSize: "calc(12px * var(--roo-font-size-multiplier, 1))",
 					opacity: 0.8,
 					margin: "4px 0",
 				}}>
@@ -39,7 +39,7 @@ const McpResourceRow = ({ item }: McpResourceRowProps) => {
 			</div>
 			<div
 				style={{
-					fontSize: "12px",
+					fontSize: "calc(12px * var(--roo-font-size-multiplier, 1))",
 				}}>
 				<span style={{ opacity: 0.8 }}>Returns </span>
 				<code

--- a/webview-ui/src/components/mcp/McpToolRow.tsx
+++ b/webview-ui/src/components/mcp/McpToolRow.tsx
@@ -1,10 +1,9 @@
-import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
-
 import { McpTool } from "@roo/mcp"
 
 import { useAppTranslation } from "@src/i18n/TranslationContext"
 import { vscode } from "@src/utils/vscode"
 import { StandardTooltip, ToggleSwitch } from "@/components/ui"
+import { Checkbox } from "@/components/ui/checkbox"
 
 type McpToolRowProps = {
 	tool: McpTool
@@ -71,15 +70,16 @@ const McpToolRow = ({ tool, serverName, serverSource, alwaysAllowMcp, isInChatCo
 					<div className="flex items-center gap-4 flex-shrink-0">
 						{/* Always Allow checkbox - only show when tool is enabled */}
 						{alwaysAllowMcp && isToolEnabled && (
-							<VSCodeCheckbox
-								checked={tool.alwaysAllow}
-								onChange={handleAlwaysAllowChange}
-								data-tool={tool.name}
-								className="text-xs">
+							<div className="flex items-center space-x-2 text-xs">
+								<Checkbox
+									checked={tool.alwaysAllow}
+									onCheckedChange={handleAlwaysAllowChange}
+									data-tool={tool.name}
+								/>
 								<span className="text-vscode-descriptionForeground whitespace-nowrap">
 									{t("mcp:tool.alwaysAllow")}
 								</span>
-							</VSCodeCheckbox>
+							</div>
 						)}
 
 						{/* Enabled toggle switch - only show in settings context */}

--- a/webview-ui/src/components/mcp/McpView.tsx
+++ b/webview-ui/src/components/mcp/McpView.tsx
@@ -2,12 +2,12 @@ import React, { useState } from "react"
 import { Trans } from "react-i18next"
 import {
 	VSCodeButton,
-	VSCodeCheckbox,
 	VSCodeLink,
 	VSCodePanels,
 	VSCodePanelTab,
 	VSCodePanelView,
 } from "@vscode/webview-ui-toolkit/react"
+import { Checkbox } from "@/components/ui/checkbox"
 
 import { McpServer } from "@roo/mcp"
 
@@ -60,7 +60,7 @@ const McpView = ({ onDone }: McpViewProps) => {
 				<div
 					style={{
 						color: "var(--vscode-foreground)",
-						fontSize: "13px",
+						fontSize: "calc(13px * var(--roo-font-size-multiplier, 1))",
 						marginBottom: "10px",
 						marginTop: "5px",
 					}}>
@@ -78,17 +78,20 @@ const McpView = ({ onDone }: McpViewProps) => {
 				{mcpEnabled && (
 					<>
 						<div style={{ marginBottom: 15 }}>
-							<VSCodeCheckbox
-								checked={enableMcpServerCreation}
-								onChange={(e: any) => {
-									setEnableMcpServerCreation(e.target.checked)
-									vscode.postMessage({ type: "enableMcpServerCreation", bool: e.target.checked })
-								}}>
+							<div className="flex items-center space-x-2">
+								<Checkbox
+									checked={enableMcpServerCreation}
+									onCheckedChange={(checked) => {
+										const isChecked = checked === true
+										setEnableMcpServerCreation(isChecked)
+										vscode.postMessage({ type: "enableMcpServerCreation", bool: isChecked })
+									}}
+								/>
 								<span style={{ fontWeight: "500" }}>{t("mcp:enableServerCreation.title")}</span>
-							</VSCodeCheckbox>
+							</div>
 							<div
 								style={{
-									fontSize: "12px",
+									fontSize: "calc(12px * var(--roo-font-size-multiplier, 1))",
 									marginTop: "5px",
 									color: "var(--vscode-descriptionForeground)",
 								}}>
@@ -178,7 +181,7 @@ const McpView = ({ onDone }: McpViewProps) => {
 						<div
 							style={{
 								marginTop: "15px",
-								fontSize: "12px",
+								fontSize: "calc(12px * var(--roo-font-size-multiplier, 1))",
 								color: "var(--vscode-descriptionForeground)",
 							}}>
 							<VSCodeLink
@@ -297,7 +300,7 @@ const ServerRow = ({ server, alwaysAllowMcp }: { server: McpServer; alwaysAllowM
 							style={{
 								marginLeft: "8px",
 								padding: "1px 6px",
-								fontSize: "11px",
+								fontSize: "calc(11px * var(--roo-font-size-multiplier, 1))",
 								borderRadius: "4px",
 								background: "var(--vscode-badge-background)",
 								color: "var(--vscode-badge-foreground)",
@@ -314,7 +317,9 @@ const ServerRow = ({ server, alwaysAllowMcp }: { server: McpServer; alwaysAllowM
 						size="icon"
 						onClick={() => setShowDeleteConfirm(true)}
 						style={{ marginRight: "8px" }}>
-						<span className="codicon codicon-trash" style={{ fontSize: "14px" }}></span>
+						<span
+							className="codicon codicon-trash"
+							style={{ fontSize: "calc(14px * var(--roo-font-size-multiplier, 1))" }}></span>
 					</Button>
 					<Button
 						variant="ghost"
@@ -322,7 +327,9 @@ const ServerRow = ({ server, alwaysAllowMcp }: { server: McpServer; alwaysAllowM
 						onClick={handleRestart}
 						disabled={server.status === "connecting"}
 						style={{ marginRight: "8px" }}>
-						<span className="codicon codicon-refresh" style={{ fontSize: "14px" }}></span>
+						<span
+							className="codicon codicon-refresh"
+							style={{ fontSize: "calc(14px * var(--roo-font-size-multiplier, 1))" }}></span>
 					</Button>
 				</div>
 				<div
@@ -357,7 +364,7 @@ const ServerRow = ({ server, alwaysAllowMcp }: { server: McpServer; alwaysAllowM
 							style={{
 								background: "var(--vscode-textCodeBlock-background)",
 								padding: "0 10px 10px 10px",
-								fontSize: "13px",
+								fontSize: "calc(13px * var(--roo-font-size-multiplier, 1))",
 								borderRadius: "0 0 4px 4px",
 							}}>
 							<VSCodePanels style={{ marginBottom: "10px" }}>
@@ -431,7 +438,11 @@ const ServerRow = ({ server, alwaysAllowMcp }: { server: McpServer; alwaysAllowM
 
 								{server.instructions && (
 									<VSCodePanelView id="instructions-view">
-										<div style={{ padding: "10px 0", fontSize: "12px" }}>
+										<div
+											style={{
+												padding: "10px 0",
+												fontSize: "calc(12px * var(--roo-font-size-multiplier, 1))",
+											}}>
 											<div className="opacity-80 whitespace-pre-wrap break-words">
 												{server.instructions}
 											</div>
@@ -495,7 +506,7 @@ const ServerRow = ({ server, alwaysAllowMcp }: { server: McpServer; alwaysAllowM
 								</div>
 								<span
 									style={{
-										fontSize: "12px",
+										fontSize: "calc(12px * var(--roo-font-size-multiplier, 1))",
 										color: "var(--vscode-descriptionForeground)",
 										display: "block",
 									}}>
@@ -508,7 +519,7 @@ const ServerRow = ({ server, alwaysAllowMcp }: { server: McpServer; alwaysAllowM
 					!server.disabled && (
 						<div
 							style={{
-								fontSize: "13px",
+								fontSize: "calc(13px * var(--roo-font-size-multiplier, 1))",
 								background: "var(--vscode-textCodeBlock-background)",
 								borderRadius: "0 0 4px 4px",
 								width: "100%",

--- a/webview-ui/src/components/modes/ModesView.tsx
+++ b/webview-ui/src/components/modes/ModesView.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect, useMemo, useCallback, useRef } from "react"
 import {
-	VSCodeCheckbox,
 	VSCodeRadioGroup,
 	VSCodeRadio,
 	VSCodeTextArea,
 	VSCodeLink,
 	VSCodeTextField,
 } from "@vscode/webview-ui-toolkit/react"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Trans } from "react-i18next"
 import { ChevronDown, X, Upload, Download } from "lucide-react"
 
@@ -1021,32 +1021,45 @@ const ModesView = ({ onDone }: ModesViewProps) => {
 											: currentMode?.groups?.some((g) => getGroupName(g) === group)
 
 										return (
-											<VSCodeCheckbox
-												key={group}
-												checked={isGroupEnabled}
-												onChange={handleGroupChange(group, Boolean(isCustomMode), customMode)}
-												disabled={!isCustomMode}>
-												{t(`prompts:tools.toolNames.${group}`)}
-												{group === "edit" && (
-													<div className="text-xs text-vscode-descriptionForeground mt-0.5">
-														{t("prompts:tools.allowedFiles")}{" "}
-														{(() => {
-															const currentMode = getCurrentMode()
-															const editGroup = currentMode?.groups?.find(
-																(g) =>
-																	Array.isArray(g) &&
-																	g[0] === "edit" &&
-																	g[1]?.fileRegex,
-															)
-															if (!Array.isArray(editGroup)) return t("prompts:allFiles")
-															return (
-																editGroup[1].description ||
-																`/${editGroup[1].fileRegex}/`
-															)
-														})()}
-													</div>
-												)}
-											</VSCodeCheckbox>
+											<div key={group} className="flex items-start space-x-2">
+												<Checkbox
+													checked={isGroupEnabled}
+													onCheckedChange={(checked) => {
+														const event = {
+															target: { checked: checked === true },
+														} as any
+														handleGroupChange(
+															group,
+															Boolean(isCustomMode),
+															customMode,
+														)(event)
+													}}
+													disabled={!isCustomMode}
+												/>
+												<div className="flex-1">
+													<span>{t(`prompts:tools.toolNames.${group}`)}</span>
+													{group === "edit" && (
+														<div className="text-xs text-vscode-descriptionForeground mt-0.5">
+															{t("prompts:tools.allowedFiles")}{" "}
+															{(() => {
+																const currentMode = getCurrentMode()
+																const editGroup = currentMode?.groups?.find(
+																	(g) =>
+																		Array.isArray(g) &&
+																		g[0] === "edit" &&
+																		g[1]?.fileRegex,
+																)
+																if (!Array.isArray(editGroup))
+																	return t("prompts:allFiles")
+																return (
+																	editGroup[1].description ||
+																	`/${editGroup[1].fileRegex}/`
+																)
+															})()}
+														</div>
+													)}
+												</div>
+											</div>
 										)
 									})}
 								</div>
@@ -1458,7 +1471,7 @@ const ModesView = ({ onDone }: ModesViewProps) => {
 								</div>
 								<div
 									style={{
-										fontSize: "13px",
+										fontSize: "calc(13px * var(--roo-font-size-multiplier, 1))",
 										color: "var(--vscode-descriptionForeground)",
 										marginBottom: "8px",
 									}}>
@@ -1519,23 +1532,22 @@ const ModesView = ({ onDone }: ModesViewProps) => {
 								</div>
 								<div className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-2">
 									{availableGroups.map((group) => (
-										<VSCodeCheckbox
-											key={group}
-											checked={newModeGroups.some((g) => getGroupName(g) === group)}
-											onChange={(e: Event | React.FormEvent<HTMLElement>) => {
-												const target =
-													(e as CustomEvent)?.detail?.target || (e.target as HTMLInputElement)
-												const checked = target.checked
-												if (checked) {
-													setNewModeGroups([...newModeGroups, group])
-												} else {
-													setNewModeGroups(
-														newModeGroups.filter((g) => getGroupName(g) !== group),
-													)
-												}
-											}}>
-											{t(`prompts:tools.toolNames.${group}`)}
-										</VSCodeCheckbox>
+										<div key={group} className="flex items-center space-x-2">
+											<Checkbox
+												checked={newModeGroups.some((g) => getGroupName(g) === group)}
+												onCheckedChange={(checked) => {
+													const isChecked = checked === true
+													if (isChecked) {
+														setNewModeGroups([...newModeGroups, group])
+													} else {
+														setNewModeGroups(
+															newModeGroups.filter((g) => getGroupName(g) !== group),
+														)
+													}
+												}}
+											/>
+											<span>{t(`prompts:tools.toolNames.${group}`)}</span>
+										</div>
 									))}
 								</div>
 								{groupsError && (

--- a/webview-ui/src/components/settings/About.tsx
+++ b/webview-ui/src/components/settings/About.tsx
@@ -2,7 +2,8 @@ import { HTMLAttributes } from "react"
 import { useAppTranslation } from "@/i18n/TranslationContext"
 import { Trans } from "react-i18next"
 import { Info, Download, Upload, TriangleAlert } from "lucide-react"
-import { VSCodeCheckbox, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeLink } from "@vscode/webview-ui-toolkit/react"
+import { Checkbox } from "@/components/ui/checkbox"
 
 import type { TelemetrySetting } from "@roo-code/types"
 
@@ -39,14 +40,16 @@ export const About = ({ telemetrySetting, setTelemetrySetting, className, ...pro
 
 			<Section>
 				<div>
-					<VSCodeCheckbox
-						checked={telemetrySetting !== "disabled"}
-						onChange={(e: any) => {
-							const checked = e.target.checked === true
-							setTelemetrySetting(checked ? "enabled" : "disabled")
-						}}>
-						{t("settings:footer.telemetry.label")}
-					</VSCodeCheckbox>
+					<div className="flex items-center space-x-2">
+						<Checkbox
+							checked={telemetrySetting !== "disabled"}
+							onCheckedChange={(checked) => {
+								const isChecked = checked === true
+								setTelemetrySetting(isChecked ? "enabled" : "disabled")
+							}}
+						/>
+						<span>{t("settings:footer.telemetry.label")}</span>
+					</div>
 					<p className="text-vscode-descriptionForeground text-sm mt-0">
 						<Trans
 							i18nKey="settings:footer.telemetry.description"

--- a/webview-ui/src/components/settings/AutoApproveSettings.tsx
+++ b/webview-ui/src/components/settings/AutoApproveSettings.tsx
@@ -4,9 +4,9 @@ import { Trans } from "react-i18next"
 import { Package } from "@roo/package"
 
 import { useAppTranslation } from "@/i18n/TranslationContext"
-import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
 import { vscode } from "@/utils/vscode"
 import { Button, Input, Slider } from "@/components/ui"
+import { Checkbox } from "@/components/ui/checkbox"
 
 import { SetCachedStateField } from "./types"
 import { SectionHeader } from "./SectionHeader"
@@ -125,16 +125,18 @@ export const AutoApproveSettings = ({
 
 			<Section>
 				<div className="space-y-4">
-					<VSCodeCheckbox
-						checked={effectiveAutoApprovalEnabled}
-						aria-label={t("settings:autoApprove.toggleAriaLabel")}
-						onChange={() => {
-							const newValue = !(autoApprovalEnabled ?? false)
-							setAutoApprovalEnabled(newValue)
-							vscode.postMessage({ type: "autoApprovalEnabled", bool: newValue })
-						}}>
+					<div className="flex items-center space-x-2">
+						<Checkbox
+							checked={effectiveAutoApprovalEnabled}
+							aria-label={t("settings:autoApprove.toggleAriaLabel")}
+							onCheckedChange={() => {
+								const newValue = !(autoApprovalEnabled ?? false)
+								setAutoApprovalEnabled(newValue)
+								vscode.postMessage({ type: "autoApprovalEnabled", bool: newValue })
+							}}
+						/>
 						<span className="font-medium">{t("settings:autoApprove.enabled")}</span>
-					</VSCodeCheckbox>
+					</div>
 					<div className="text-vscode-descriptionForeground text-sm mt-1">
 						<p>{t("settings:autoApprove.description")}</p>
 						<p>
@@ -191,16 +193,18 @@ export const AutoApproveSettings = ({
 							<div>{t("settings:autoApprove.readOnly.label")}</div>
 						</div>
 						<div>
-							<VSCodeCheckbox
-								checked={alwaysAllowReadOnlyOutsideWorkspace}
-								onChange={(e: any) =>
-									setCachedStateField("alwaysAllowReadOnlyOutsideWorkspace", e.target.checked)
-								}
-								data-testid="always-allow-readonly-outside-workspace-checkbox">
+							<div className="flex items-center space-x-2">
+								<Checkbox
+									checked={alwaysAllowReadOnlyOutsideWorkspace}
+									onCheckedChange={(checked) =>
+										setCachedStateField("alwaysAllowReadOnlyOutsideWorkspace", checked === true)
+									}
+									data-testid="always-allow-readonly-outside-workspace-checkbox"
+								/>
 								<span className="font-medium">
 									{t("settings:autoApprove.readOnly.outsideWorkspace.label")}
 								</span>
-							</VSCodeCheckbox>
+							</div>
 							<div className="text-vscode-descriptionForeground text-sm mt-1">
 								{t("settings:autoApprove.readOnly.outsideWorkspace.description")}
 							</div>
@@ -215,29 +219,33 @@ export const AutoApproveSettings = ({
 							<div>{t("settings:autoApprove.write.label")}</div>
 						</div>
 						<div>
-							<VSCodeCheckbox
-								checked={alwaysAllowWriteOutsideWorkspace}
-								onChange={(e: any) =>
-									setCachedStateField("alwaysAllowWriteOutsideWorkspace", e.target.checked)
-								}
-								data-testid="always-allow-write-outside-workspace-checkbox">
+							<div className="flex items-center space-x-2">
+								<Checkbox
+									checked={alwaysAllowWriteOutsideWorkspace}
+									onCheckedChange={(checked) =>
+										setCachedStateField("alwaysAllowWriteOutsideWorkspace", checked === true)
+									}
+									data-testid="always-allow-write-outside-workspace-checkbox"
+								/>
 								<span className="font-medium">
 									{t("settings:autoApprove.write.outsideWorkspace.label")}
 								</span>
-							</VSCodeCheckbox>
+							</div>
 							<div className="text-vscode-descriptionForeground text-sm mt-1">
 								{t("settings:autoApprove.write.outsideWorkspace.description")}
 							</div>
 						</div>
 						<div>
-							<VSCodeCheckbox
-								checked={alwaysAllowWriteProtected}
-								onChange={(e: any) =>
-									setCachedStateField("alwaysAllowWriteProtected", e.target.checked)
-								}
-								data-testid="always-allow-write-protected-checkbox">
+							<div className="flex items-center space-x-2">
+								<Checkbox
+									checked={alwaysAllowWriteProtected}
+									onCheckedChange={(checked) =>
+										setCachedStateField("alwaysAllowWriteProtected", checked === true)
+									}
+									data-testid="always-allow-write-protected-checkbox"
+								/>
 								<span className="font-medium">{t("settings:autoApprove.write.protected.label")}</span>
-							</VSCodeCheckbox>
+							</div>
 							<div className="text-vscode-descriptionForeground text-sm mt-1 mb-3">
 								{t("settings:autoApprove.write.protected.description")}
 							</div>

--- a/webview-ui/src/components/settings/BrowserSettings.tsx
+++ b/webview-ui/src/components/settings/BrowserSettings.tsx
@@ -1,4 +1,4 @@
-import { VSCodeButton, VSCodeCheckbox, VSCodeTextField, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeButton, VSCodeTextField, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import { SquareMousePointer } from "lucide-react"
 import { HTMLAttributes, useEffect, useMemo, useState } from "react"
 import { Trans } from "react-i18next"
@@ -7,6 +7,7 @@ import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectVa
 import { useAppTranslation } from "@/i18n/TranslationContext"
 import { vscode } from "@/utils/vscode"
 import { buildDocLink } from "@src/utils/docLinks"
+import { Checkbox } from "@/components/ui/checkbox"
 
 import { Section } from "./Section"
 import { SectionHeader } from "./SectionHeader"
@@ -108,11 +109,13 @@ export const BrowserSettings = ({
 
 			<Section>
 				<div>
-					<VSCodeCheckbox
-						checked={browserToolEnabled}
-						onChange={(e: any) => setCachedStateField("browserToolEnabled", e.target.checked)}>
+					<div className="flex items-center space-x-2">
+						<Checkbox
+							checked={browserToolEnabled}
+							onCheckedChange={(checked) => setCachedStateField("browserToolEnabled", checked === true)}
+						/>
 						<span className="font-medium">{t("settings:browser.enable.label")}</span>
-					</VSCodeCheckbox>
+					</div>
 					<div className="text-vscode-descriptionForeground text-sm mt-1">
 						<Trans i18nKey="settings:browser.enable.description">
 							<VSCodeLink
@@ -169,19 +172,22 @@ export const BrowserSettings = ({
 						</div>
 
 						<div>
-							<VSCodeCheckbox
-								checked={remoteBrowserEnabled}
-								onChange={(e: any) => {
-									// Update the global state - remoteBrowserEnabled now means "enable remote browser connection".
-									setCachedStateField("remoteBrowserEnabled", e.target.checked)
+							<div className="flex items-center space-x-2">
+								<Checkbox
+									checked={remoteBrowserEnabled}
+									onCheckedChange={(checked) => {
+										const isChecked = checked === true
+										// Update the global state - remoteBrowserEnabled now means "enable remote browser connection".
+										setCachedStateField("remoteBrowserEnabled", isChecked)
 
-									if (!e.target.checked) {
-										// If disabling remote browser, clear the custom URL.
-										setCachedStateField("remoteBrowserHost", undefined)
-									}
-								}}>
+										if (!isChecked) {
+											// If disabling remote browser, clear the custom URL.
+											setCachedStateField("remoteBrowserHost", undefined)
+										}
+									}}
+								/>
 								<label className="block font-medium mb-1">{t("settings:browser.remote.label")}</label>
-							</VSCodeCheckbox>
+							</div>
 							<div className="text-vscode-descriptionForeground text-sm mt-1">
 								{t("settings:browser.remote.description")}
 							</div>

--- a/webview-ui/src/components/settings/CheckpointSettings.tsx
+++ b/webview-ui/src/components/settings/CheckpointSettings.tsx
@@ -1,9 +1,10 @@
 import { HTMLAttributes } from "react"
 import { useAppTranslation } from "@/i18n/TranslationContext"
-import { VSCodeCheckbox, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import { GitBranch } from "lucide-react"
 import { Trans } from "react-i18next"
 import { buildDocLink } from "@src/utils/docLinks"
+import { Checkbox } from "@/components/ui/checkbox"
 
 import { SetCachedStateField } from "./types"
 import { SectionHeader } from "./SectionHeader"
@@ -27,13 +28,15 @@ export const CheckpointSettings = ({ enableCheckpoints, setCachedStateField, ...
 
 			<Section>
 				<div>
-					<VSCodeCheckbox
-						checked={enableCheckpoints}
-						onChange={(e: any) => {
-							setCachedStateField("enableCheckpoints", e.target.checked)
-						}}>
+					<div className="flex items-center space-x-2">
+						<Checkbox
+							checked={enableCheckpoints}
+							onCheckedChange={(checked) => {
+								setCachedStateField("enableCheckpoints", checked === true)
+							}}
+						/>
 						<span className="font-medium">{t("settings:checkpoints.enable.label")}</span>
-					</VSCodeCheckbox>
+					</div>
 					<div className="text-vscode-descriptionForeground text-sm mt-1">
 						<Trans i18nKey="settings:checkpoints.enable.description">
 							<VSCodeLink

--- a/webview-ui/src/components/settings/ContextManagementSettings.tsx
+++ b/webview-ui/src/components/settings/ContextManagementSettings.tsx
@@ -1,8 +1,8 @@
 import { HTMLAttributes } from "react"
 import React from "react"
 import { useAppTranslation } from "@/i18n/TranslationContext"
-import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
 import { Database, FoldVertical } from "lucide-react"
+import { Checkbox } from "@/components/ui/checkbox"
 
 import { cn } from "@/lib/utils"
 import { Input, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Slider, Button } from "@/components/ui"
@@ -163,14 +163,16 @@ export const ContextManagementSettings = ({
 				</div>
 
 				<div>
-					<VSCodeCheckbox
-						checked={showRooIgnoredFiles}
-						onChange={(e: any) => setCachedStateField("showRooIgnoredFiles", e.target.checked)}
-						data-testid="show-rooignored-files-checkbox">
+					<div className="flex items-center space-x-2">
+						<Checkbox
+							checked={showRooIgnoredFiles}
+							onCheckedChange={(checked) => setCachedStateField("showRooIgnoredFiles", checked === true)}
+							data-testid="show-rooignored-files-checkbox"
+						/>
 						<label className="block font-medium mb-1">
 							{t("settings:contextManagement.rooignore.label")}
 						</label>
-					</VSCodeCheckbox>
+					</div>
 					<div className="text-vscode-descriptionForeground text-sm mt-1 mb-3">
 						{t("settings:contextManagement.rooignore.description")}
 					</div>
@@ -197,14 +199,16 @@ export const ContextManagementSettings = ({
 								disabled={maxReadFileLine === -1}
 							/>
 							<span>{t("settings:contextManagement.maxReadFile.lines")}</span>
-							<VSCodeCheckbox
-								checked={maxReadFileLine === -1}
-								onChange={(e: any) =>
-									setCachedStateField("maxReadFileLine", e.target.checked ? -1 : 500)
-								}
-								data-testid="max-read-file-always-full-checkbox">
-								{t("settings:contextManagement.maxReadFile.always_full_read")}
-							</VSCodeCheckbox>
+							<div className="flex items-center space-x-2">
+								<Checkbox
+									checked={maxReadFileLine === -1}
+									onCheckedChange={(checked) =>
+										setCachedStateField("maxReadFileLine", checked === true ? -1 : 500)
+									}
+									data-testid="max-read-file-always-full-checkbox"
+								/>
+								<span>{t("settings:contextManagement.maxReadFile.always_full_read")}</span>
+							</div>
 						</div>
 					</div>
 					<div className="text-vscode-descriptionForeground text-sm mt-2">
@@ -269,14 +273,18 @@ export const ContextManagementSettings = ({
 				</div>
 
 				<div>
-					<VSCodeCheckbox
-						checked={includeDiagnosticMessages}
-						onChange={(e: any) => setCachedStateField("includeDiagnosticMessages", e.target.checked)}
-						data-testid="include-diagnostic-messages-checkbox">
+					<div className="flex items-center space-x-2">
+						<Checkbox
+							checked={includeDiagnosticMessages}
+							onCheckedChange={(checked) =>
+								setCachedStateField("includeDiagnosticMessages", checked === true)
+							}
+							data-testid="include-diagnostic-messages-checkbox"
+						/>
 						<label className="block font-medium mb-1">
 							{t("settings:contextManagement.diagnostics.includeMessages.label")}
 						</label>
-					</VSCodeCheckbox>
+					</div>
 					<div className="text-vscode-descriptionForeground text-sm mt-1 mb-3">
 						{t("settings:contextManagement.diagnostics.includeMessages.description")}
 					</div>
@@ -358,12 +366,14 @@ export const ContextManagementSettings = ({
 				</div>
 			</Section>
 			<Section className="pt-2">
-				<VSCodeCheckbox
-					checked={autoCondenseContext}
-					onChange={(e: any) => setCachedStateField("autoCondenseContext", e.target.checked)}
-					data-testid="auto-condense-context-checkbox">
+				<div className="flex items-center space-x-2">
+					<Checkbox
+						checked={autoCondenseContext}
+						onCheckedChange={(checked) => setCachedStateField("autoCondenseContext", checked === true)}
+						data-testid="auto-condense-context-checkbox"
+					/>
 					<span className="font-medium">{t("settings:contextManagement.autoCondenseContext.name")}</span>
-				</VSCodeCheckbox>
+				</div>
 				{autoCondenseContext && (
 					<div className="flex flex-col gap-3 pl-3 border-l-2 border-vscode-button-background">
 						<div className="flex items-center gap-4 font-bold">

--- a/webview-ui/src/components/settings/DiffSettingsControl.tsx
+++ b/webview-ui/src/components/settings/DiffSettingsControl.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react"
 import { Slider } from "@/components/ui"
 import { useAppTranslation } from "@/i18n/TranslationContext"
-import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
+import { Checkbox } from "@/components/ui/checkbox"
 
 interface DiffSettingsControlProps {
 	diffEnabled?: boolean
@@ -17,8 +17,8 @@ export const DiffSettingsControl: React.FC<DiffSettingsControlProps> = ({
 	const { t } = useAppTranslation()
 
 	const handleDiffEnabledChange = useCallback(
-		(e: any) => {
-			onChange("diffEnabled", e.target.checked)
+		(checked: boolean) => {
+			onChange("diffEnabled", checked)
 		},
 		[onChange],
 	)
@@ -33,9 +33,10 @@ export const DiffSettingsControl: React.FC<DiffSettingsControlProps> = ({
 	return (
 		<div className="flex flex-col gap-1">
 			<div>
-				<VSCodeCheckbox checked={diffEnabled} onChange={handleDiffEnabledChange}>
+				<div className="flex items-center space-x-2">
+					<Checkbox checked={diffEnabled} onCheckedChange={handleDiffEnabledChange} />
 					<span className="font-medium">{t("settings:advanced.diff.label")}</span>
-				</VSCodeCheckbox>
+				</div>
 				<div className="text-vscode-descriptionForeground text-sm">
 					{t("settings:advanced.diff.description")}
 				</div>

--- a/webview-ui/src/components/settings/ExperimentalFeature.tsx
+++ b/webview-ui/src/components/settings/ExperimentalFeature.tsx
@@ -1,5 +1,5 @@
-import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
 import { useAppTranslation } from "@/i18n/TranslationContext"
+import { Checkbox } from "@/components/ui/checkbox"
 
 interface ExperimentalFeatureProps {
 	enabled: boolean
@@ -18,9 +18,8 @@ export const ExperimentalFeature = ({ enabled, onChange, experimentKey }: Experi
 	return (
 		<div>
 			<div className="flex items-center gap-2">
-				<VSCodeCheckbox checked={enabled} onChange={(e: any) => onChange(e.target.checked)}>
-					<span className="font-medium">{t(nameKey)}</span>
-				</VSCodeCheckbox>
+				<Checkbox checked={enabled} onCheckedChange={onChange} />
+				<span className="font-medium">{t(nameKey)}</span>
 			</div>
 			<p className="text-vscode-descriptionForeground text-sm mt-0">{t(descriptionKey)}</p>
 		</div>

--- a/webview-ui/src/components/settings/ImageGenerationSettings.tsx
+++ b/webview-ui/src/components/settings/ImageGenerationSettings.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react"
-import { VSCodeCheckbox, VSCodeTextField, VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeTextField, VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react"
 import { useAppTranslation } from "@/i18n/TranslationContext"
+import { Checkbox } from "@/components/ui/checkbox"
 
 interface ImageGenerationSettingsProps {
 	enabled: boolean
@@ -54,9 +55,8 @@ export const ImageGenerationSettings = ({
 		<div className="space-y-4">
 			<div>
 				<div className="flex items-center gap-2">
-					<VSCodeCheckbox checked={enabled} onChange={(e: any) => onChange(e.target.checked)}>
-						<span className="font-medium">{t("settings:experimental.IMAGE_GENERATION.name")}</span>
-					</VSCodeCheckbox>
+					<Checkbox checked={enabled} onCheckedChange={onChange} />
+					<span className="font-medium">{t("settings:experimental.IMAGE_GENERATION.name")}</span>
 				</div>
 				<p className="text-vscode-descriptionForeground text-sm mt-0">
 					{t("settings:experimental.IMAGE_GENERATION.description")}

--- a/webview-ui/src/components/settings/NotificationSettings.tsx
+++ b/webview-ui/src/components/settings/NotificationSettings.tsx
@@ -1,7 +1,7 @@
 import { HTMLAttributes } from "react"
 import { useAppTranslation } from "@/i18n/TranslationContext"
-import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
 import { Bell } from "lucide-react"
+import { Checkbox } from "@/components/ui/checkbox"
 
 import { SetCachedStateField } from "./types"
 import { SectionHeader } from "./SectionHeader"
@@ -36,12 +36,14 @@ export const NotificationSettings = ({
 
 			<Section>
 				<div>
-					<VSCodeCheckbox
-						checked={ttsEnabled}
-						onChange={(e: any) => setCachedStateField("ttsEnabled", e.target.checked)}
-						data-testid="tts-enabled-checkbox">
+					<div className="flex items-center space-x-2">
+						<Checkbox
+							checked={ttsEnabled}
+							onCheckedChange={(checked) => setCachedStateField("ttsEnabled", checked === true)}
+							data-testid="tts-enabled-checkbox"
+						/>
 						<span className="font-medium">{t("settings:notifications.tts.label")}</span>
-					</VSCodeCheckbox>
+					</div>
 					<div className="text-vscode-descriptionForeground text-sm mt-1">
 						{t("settings:notifications.tts.description")}
 					</div>
@@ -69,12 +71,14 @@ export const NotificationSettings = ({
 				)}
 
 				<div>
-					<VSCodeCheckbox
-						checked={soundEnabled}
-						onChange={(e: any) => setCachedStateField("soundEnabled", e.target.checked)}
-						data-testid="sound-enabled-checkbox">
+					<div className="flex items-center space-x-2">
+						<Checkbox
+							checked={soundEnabled}
+							onCheckedChange={(checked) => setCachedStateField("soundEnabled", checked === true)}
+							data-testid="sound-enabled-checkbox"
+						/>
 						<span className="font-medium">{t("settings:notifications.sound.label")}</span>
-					</VSCodeCheckbox>
+					</div>
 					<div className="text-vscode-descriptionForeground text-sm mt-1">
 						{t("settings:notifications.sound.description")}
 					</div>

--- a/webview-ui/src/components/settings/PromptsSettings.tsx
+++ b/webview-ui/src/components/settings/PromptsSettings.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react"
-import { VSCodeTextArea, VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeTextArea } from "@vscode/webview-ui-toolkit/react"
+import { Checkbox } from "@/components/ui/checkbox"
 
 import { supportPrompt, SupportPromptType } from "@roo/support-prompt"
 
@@ -234,20 +235,22 @@ const PromptsSettings = ({
 							{activeSupportOption === "ENHANCE" && (
 								<>
 									<div>
-										<VSCodeCheckbox
-											checked={includeTaskHistoryInEnhance}
-											onChange={(e: any) => {
-												const value = e.target.checked
-												setIncludeTaskHistoryInEnhance(value)
-												vscode.postMessage({
-													type: "includeTaskHistoryInEnhance",
-													bool: value,
-												})
-											}}>
+										<div className="flex items-center space-x-2">
+											<Checkbox
+												checked={includeTaskHistoryInEnhance}
+												onCheckedChange={(checked) => {
+													const value = checked === true
+													setIncludeTaskHistoryInEnhance(value)
+													vscode.postMessage({
+														type: "includeTaskHistoryInEnhance",
+														bool: value,
+													})
+												}}
+											/>
 											<span className="font-medium">
 												{t("prompts:supportPrompts.enhance.includeTaskHistory")}
 											</span>
-										</VSCodeCheckbox>
+										</div>
 										<div className="text-vscode-descriptionForeground text-sm mt-1 mb-3">
 											{t("prompts:supportPrompts.enhance.includeTaskHistoryDescription")}
 										</div>

--- a/webview-ui/src/components/settings/TemperatureControl.tsx
+++ b/webview-ui/src/components/settings/TemperatureControl.tsx
@@ -1,9 +1,9 @@
-import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
 import { useEffect, useState } from "react"
 import { useAppTranslation } from "@/i18n/TranslationContext"
 import { useDebounce } from "react-use"
 
 import { Slider } from "@/components/ui"
+import { Checkbox } from "@/components/ui/checkbox"
 
 interface TemperatureControlProps {
 	value: number | undefined | null
@@ -28,20 +28,22 @@ export const TemperatureControl = ({ value, onChange, maxValue = 1 }: Temperatur
 	return (
 		<>
 			<div>
-				<VSCodeCheckbox
-					checked={isCustomTemperature}
-					onChange={(e: any) => {
-						const isChecked = e.target.checked
-						setIsCustomTemperature(isChecked)
+				<div className="flex items-center space-x-2">
+					<Checkbox
+						checked={isCustomTemperature}
+						onCheckedChange={(checked) => {
+							const isChecked = checked === true
+							setIsCustomTemperature(isChecked)
 
-						if (!isChecked) {
-							setInputValue(null) // Unset the temperature, note that undefined is unserializable.
-						} else {
-							setInputValue(value ?? 0) // Use the value from apiConfiguration, if set.
-						}
-					}}>
+							if (!isChecked) {
+								setInputValue(null) // Unset the temperature, note that undefined is unserializable.
+							} else {
+								setInputValue(value ?? 0) // Use the value from apiConfiguration, if set.
+							}
+						}}
+					/>
 					<label className="block font-medium mb-1">{t("settings:temperature.useCustom")}</label>
-				</VSCodeCheckbox>
+				</div>
 				<div className="text-sm text-vscode-descriptionForeground mt-1">
 					{t("settings:temperature.description")}
 				</div>

--- a/webview-ui/src/components/settings/TerminalSettings.tsx
+++ b/webview-ui/src/components/settings/TerminalSettings.tsx
@@ -2,10 +2,11 @@ import { HTMLAttributes, useState, useCallback } from "react"
 import { useAppTranslation } from "@/i18n/TranslationContext"
 import { vscode } from "@/utils/vscode"
 import { SquareTerminal } from "lucide-react"
-import { VSCodeCheckbox, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import { Trans } from "react-i18next"
 import { buildDocLink } from "@src/utils/docLinks"
 import { useEvent, useMount } from "react-use"
+import { Checkbox } from "@/components/ui/checkbox"
 
 import { ExtensionMessage } from "@roo/ExtensionMessage"
 
@@ -163,14 +164,16 @@ export const TerminalSettings = ({
 							</div>
 						</div>
 						<div>
-							<VSCodeCheckbox
-								checked={terminalCompressProgressBar ?? true}
-								onChange={(e: any) =>
-									setCachedStateField("terminalCompressProgressBar", e.target.checked)
-								}
-								data-testid="terminal-compress-progress-bar-checkbox">
+							<div className="flex items-center space-x-2">
+								<Checkbox
+									checked={terminalCompressProgressBar ?? true}
+									onCheckedChange={(checked) =>
+										setCachedStateField("terminalCompressProgressBar", checked === true)
+									}
+									data-testid="terminal-compress-progress-bar-checkbox"
+								/>
 								<span className="font-medium">{t("settings:terminal.compressProgressBar.label")}</span>
-							</VSCodeCheckbox>
+							</div>
 							<div className="text-vscode-descriptionForeground text-sm mt-1">
 								<Trans i18nKey="settings:terminal.compressProgressBar.description">
 									<VSCodeLink
@@ -200,19 +203,22 @@ export const TerminalSettings = ({
 					</div>
 					<div className="flex flex-col gap-3 pl-3 border-l-2 border-vscode-button-background">
 						<div>
-							<VSCodeCheckbox
-								checked={inheritEnv}
-								onChange={(e: any) => {
-									setInheritEnv(e.target.checked)
-									vscode.postMessage({
-										type: "updateVSCodeSetting",
-										setting: "terminal.integrated.inheritEnv",
-										value: e.target.checked,
-									})
-								}}
-								data-testid="terminal-inherit-env-checkbox">
+							<div className="flex items-center space-x-2">
+								<Checkbox
+									checked={inheritEnv}
+									onCheckedChange={(checked) => {
+										const isChecked = checked === true
+										setInheritEnv(isChecked)
+										vscode.postMessage({
+											type: "updateVSCodeSetting",
+											setting: "terminal.integrated.inheritEnv",
+											value: isChecked as any,
+										})
+									}}
+									data-testid="terminal-inherit-env-checkbox"
+								/>
 								<span className="font-medium">{t("settings:terminal.inheritEnv.label")}</span>
-							</VSCodeCheckbox>
+							</div>
 							<div className="text-vscode-descriptionForeground text-sm mt-1">
 								<Trans i18nKey="settings:terminal.inheritEnv.description">
 									<VSCodeLink
@@ -228,15 +234,17 @@ export const TerminalSettings = ({
 						</div>
 
 						<div>
-							<VSCodeCheckbox
-								checked={terminalShellIntegrationDisabled ?? false}
-								onChange={(e: any) =>
-									setCachedStateField("terminalShellIntegrationDisabled", e.target.checked)
-								}>
+							<div className="flex items-center space-x-2">
+								<Checkbox
+									checked={terminalShellIntegrationDisabled ?? false}
+									onCheckedChange={(checked) =>
+										setCachedStateField("terminalShellIntegrationDisabled", checked === true)
+									}
+								/>
 								<span className="font-medium">
 									{t("settings:terminal.shellIntegrationDisabled.label")}
 								</span>
-							</VSCodeCheckbox>
+							</div>
 							<div className="text-vscode-descriptionForeground text-sm mt-1">
 								<Trans i18nKey="settings:terminal.shellIntegrationDisabled.description">
 									<VSCodeLink
@@ -322,16 +330,18 @@ export const TerminalSettings = ({
 								</div>
 
 								<div>
-									<VSCodeCheckbox
-										checked={terminalPowershellCounter ?? false}
-										onChange={(e: any) =>
-											setCachedStateField("terminalPowershellCounter", e.target.checked)
-										}
-										data-testid="terminal-powershell-counter-checkbox">
+									<div className="flex items-center space-x-2">
+										<Checkbox
+											checked={terminalPowershellCounter ?? false}
+											onCheckedChange={(checked) =>
+												setCachedStateField("terminalPowershellCounter", checked === true)
+											}
+											data-testid="terminal-powershell-counter-checkbox"
+										/>
 										<span className="font-medium">
 											{t("settings:terminal.powershellCounter.label")}
 										</span>
-									</VSCodeCheckbox>
+									</div>
 									<div className="text-vscode-descriptionForeground text-sm mt-1">
 										<Trans i18nKey="settings:terminal.powershellCounter.description">
 											<VSCodeLink
@@ -347,16 +357,18 @@ export const TerminalSettings = ({
 								</div>
 
 								<div>
-									<VSCodeCheckbox
-										checked={terminalZshClearEolMark ?? true}
-										onChange={(e: any) =>
-											setCachedStateField("terminalZshClearEolMark", e.target.checked)
-										}
-										data-testid="terminal-zsh-clear-eol-mark-checkbox">
+									<div className="flex items-center space-x-2">
+										<Checkbox
+											checked={terminalZshClearEolMark ?? true}
+											onCheckedChange={(checked) =>
+												setCachedStateField("terminalZshClearEolMark", checked === true)
+											}
+											data-testid="terminal-zsh-clear-eol-mark-checkbox"
+										/>
 										<span className="font-medium">
 											{t("settings:terminal.zshClearEolMark.label")}
 										</span>
-									</VSCodeCheckbox>
+									</div>
 									<div className="text-vscode-descriptionForeground text-sm mt-1">
 										<Trans i18nKey="settings:terminal.zshClearEolMark.description">
 											<VSCodeLink
@@ -372,12 +384,16 @@ export const TerminalSettings = ({
 								</div>
 
 								<div>
-									<VSCodeCheckbox
-										checked={terminalZshOhMy ?? false}
-										onChange={(e: any) => setCachedStateField("terminalZshOhMy", e.target.checked)}
-										data-testid="terminal-zsh-oh-my-checkbox">
+									<div className="flex items-center space-x-2">
+										<Checkbox
+											checked={terminalZshOhMy ?? false}
+											onCheckedChange={(checked) =>
+												setCachedStateField("terminalZshOhMy", checked === true)
+											}
+											data-testid="terminal-zsh-oh-my-checkbox"
+										/>
 										<span className="font-medium">{t("settings:terminal.zshOhMy.label")}</span>
-									</VSCodeCheckbox>
+									</div>
 									<div className="text-vscode-descriptionForeground text-sm mt-1">
 										<Trans i18nKey="settings:terminal.zshOhMy.description">
 											<VSCodeLink
@@ -393,12 +409,16 @@ export const TerminalSettings = ({
 								</div>
 
 								<div>
-									<VSCodeCheckbox
-										checked={terminalZshP10k ?? false}
-										onChange={(e: any) => setCachedStateField("terminalZshP10k", e.target.checked)}
-										data-testid="terminal-zsh-p10k-checkbox">
+									<div className="flex items-center space-x-2">
+										<Checkbox
+											checked={terminalZshP10k ?? false}
+											onCheckedChange={(checked) =>
+												setCachedStateField("terminalZshP10k", checked === true)
+											}
+											data-testid="terminal-zsh-p10k-checkbox"
+										/>
 										<span className="font-medium">{t("settings:terminal.zshP10k.label")}</span>
-									</VSCodeCheckbox>
+									</div>
 									<div className="text-vscode-descriptionForeground text-sm mt-1">
 										<Trans i18nKey="settings:terminal.zshP10k.description">
 											<VSCodeLink
@@ -414,12 +434,16 @@ export const TerminalSettings = ({
 								</div>
 
 								<div>
-									<VSCodeCheckbox
-										checked={terminalZdotdir ?? false}
-										onChange={(e: any) => setCachedStateField("terminalZdotdir", e.target.checked)}
-										data-testid="terminal-zdotdir-checkbox">
+									<div className="flex items-center space-x-2">
+										<Checkbox
+											checked={terminalZdotdir ?? false}
+											onCheckedChange={(checked) =>
+												setCachedStateField("terminalZdotdir", checked === true)
+											}
+											data-testid="terminal-zdotdir-checkbox"
+										/>
 										<span className="font-medium">{t("settings:terminal.zdotdir.label")}</span>
-									</VSCodeCheckbox>
+									</div>
 									<div className="text-vscode-descriptionForeground text-sm mt-1">
 										<Trans i18nKey="settings:terminal.zdotdir.description">
 											<VSCodeLink

--- a/webview-ui/src/components/settings/TodoListSettingsControl.tsx
+++ b/webview-ui/src/components/settings/TodoListSettingsControl.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react"
 import { useAppTranslation } from "@/i18n/TranslationContext"
-import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
+import { Checkbox } from "@/components/ui/checkbox"
 
 interface TodoListSettingsControlProps {
 	todoListEnabled?: boolean
@@ -14,8 +14,8 @@ export const TodoListSettingsControl: React.FC<TodoListSettingsControlProps> = (
 	const { t } = useAppTranslation()
 
 	const handleTodoListEnabledChange = useCallback(
-		(e: any) => {
-			onChange("todoListEnabled", e.target.checked)
+		(checked: boolean) => {
+			onChange("todoListEnabled", checked)
 		},
 		[onChange],
 	)
@@ -23,9 +23,10 @@ export const TodoListSettingsControl: React.FC<TodoListSettingsControlProps> = (
 	return (
 		<div className="flex flex-col gap-1">
 			<div>
-				<VSCodeCheckbox checked={todoListEnabled} onChange={handleTodoListEnabledChange}>
+				<div className="flex items-center space-x-2">
+					<Checkbox checked={todoListEnabled} onCheckedChange={handleTodoListEnabledChange} />
 					<span className="font-medium">{t("settings:advanced.todoList.label")}</span>
-				</VSCodeCheckbox>
+				</div>
 				<div className="text-vscode-descriptionForeground text-sm">
 					{t("settings:advanced.todoList.description")}
 				</div>

--- a/webview-ui/src/components/settings/UISettings.tsx
+++ b/webview-ui/src/components/settings/UISettings.tsx
@@ -1,8 +1,8 @@
 import { HTMLAttributes } from "react"
 import { useAppTranslation } from "@/i18n/TranslationContext"
-import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
 import { Glasses } from "lucide-react"
 import { telemetryClient } from "@/utils/TelemetryClient"
+import { Checkbox } from "@/components/ui/checkbox"
 
 import { SetCachedStateField } from "./types"
 import { SectionHeader } from "./SectionHeader"
@@ -39,12 +39,14 @@ export const UISettings = ({ reasoningBlockCollapsed, setCachedStateField, ...pr
 				<div className="space-y-6">
 					{/* Collapse Thinking Messages Setting */}
 					<div className="flex flex-col gap-1">
-						<VSCodeCheckbox
-							checked={reasoningBlockCollapsed}
-							onChange={(e: any) => handleReasoningBlockCollapsedChange(e.target.checked)}
-							data-testid="collapse-thinking-checkbox">
+						<div className="flex items-center space-x-2">
+							<Checkbox
+								checked={reasoningBlockCollapsed}
+								onCheckedChange={handleReasoningBlockCollapsedChange}
+								data-testid="collapse-thinking-checkbox"
+							/>
 							<span className="font-medium">{t("settings:ui.collapseThinking.label")}</span>
-						</VSCodeCheckbox>
+						</div>
 						<div className="text-vscode-descriptionForeground text-sm ml-5 mt-1">
 							{t("settings:ui.collapseThinking.description")}
 						</div>

--- a/webview-ui/src/components/settings/providers/Bedrock.tsx
+++ b/webview-ui/src/components/settings/providers/Bedrock.tsx
@@ -153,7 +153,7 @@ export const Bedrock = ({ apiConfiguration, setApiConfigurationField, selectedMo
 							<StandardTooltip content={t("settings:providers.enablePromptCachingTitle")}>
 								<i
 									className="codicon codicon-info text-vscode-descriptionForeground"
-									style={{ fontSize: "12px" }}
+									style={{ fontSize: "calc(12px * var(--roo-font-size-multiplier, 1))" }}
 								/>
 							</StandardTooltip>
 						</div>

--- a/webview-ui/src/components/settings/providers/ClaudeCode.tsx
+++ b/webview-ui/src/components/settings/providers/ClaudeCode.tsx
@@ -33,7 +33,7 @@ export const ClaudeCode: React.FC<ClaudeCodeProps> = ({ apiConfiguration, setApi
 
 				<p
 					style={{
-						fontSize: "12px",
+						fontSize: "calc(12px * var(--roo-font-size-multiplier, 1))",
 						marginTop: 3,
 						color: "var(--vscode-descriptionForeground)",
 					}}>

--- a/webview-ui/src/components/settings/providers/LiteLLM.tsx
+++ b/webview-ui/src/components/settings/providers/LiteLLM.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState, useEffect, useRef } from "react"
-import { VSCodeTextField, VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
+import { Checkbox } from "@/components/ui/checkbox"
 
 import { type ProviderSettings, type OrganizationAllowList, litellmDefaultModelId } from "@roo-code/types"
 
@@ -160,13 +161,15 @@ export const LiteLLM = ({
 				if (selectedModel?.supportsPromptCache) {
 					return (
 						<div className="mt-4">
-							<VSCodeCheckbox
-								checked={apiConfiguration.litellmUsePromptCache || false}
-								onChange={(e: any) => {
-									setApiConfigurationField("litellmUsePromptCache", e.target.checked)
-								}}>
+							<div className="flex items-center space-x-2">
+								<Checkbox
+									checked={apiConfiguration.litellmUsePromptCache || false}
+									onCheckedChange={(checked) => {
+										setApiConfigurationField("litellmUsePromptCache", checked === true)
+									}}
+								/>
 								<span className="font-medium">{t("settings:providers.enablePromptCaching")}</span>
-							</VSCodeCheckbox>
+							</div>
 							<div className="text-sm text-vscode-descriptionForeground ml-6 mt-1">
 								{t("settings:providers.enablePromptCachingTitle")}
 							</div>

--- a/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
+++ b/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
@@ -384,7 +384,7 @@ export const OpenAICompatible = ({
 						<StandardTooltip content={t("settings:providers.customModel.imageSupport.description")}>
 							<i
 								className="codicon codicon-info text-vscode-descriptionForeground"
-								style={{ fontSize: "12px" }}
+								style={{ fontSize: "calc(12px * var(--roo-font-size-multiplier, 1))" }}
 							/>
 						</StandardTooltip>
 					</div>
@@ -408,7 +408,7 @@ export const OpenAICompatible = ({
 						<StandardTooltip content={t("settings:providers.customModel.computerUse.description")}>
 							<i
 								className="codicon codicon-info text-vscode-descriptionForeground"
-								style={{ fontSize: "12px" }}
+								style={{ fontSize: "calc(12px * var(--roo-font-size-multiplier, 1))" }}
 							/>
 						</StandardTooltip>
 					</div>
@@ -432,7 +432,7 @@ export const OpenAICompatible = ({
 						<StandardTooltip content={t("settings:providers.customModel.promptCache.description")}>
 							<i
 								className="codicon codicon-info text-vscode-descriptionForeground"
-								style={{ fontSize: "12px" }}
+								style={{ fontSize: "calc(12px * var(--roo-font-size-multiplier, 1))" }}
 							/>
 						</StandardTooltip>
 					</div>
@@ -478,7 +478,7 @@ export const OpenAICompatible = ({
 							<StandardTooltip content={t("settings:providers.customModel.pricing.input.description")}>
 								<i
 									className="codicon codicon-info text-vscode-descriptionForeground"
-									style={{ fontSize: "12px" }}
+									style={{ fontSize: "calc(12px * var(--roo-font-size-multiplier, 1))" }}
 								/>
 							</StandardTooltip>
 						</div>
@@ -522,7 +522,7 @@ export const OpenAICompatible = ({
 							<StandardTooltip content={t("settings:providers.customModel.pricing.output.description")}>
 								<i
 									className="codicon codicon-info text-vscode-descriptionForeground"
-									style={{ fontSize: "12px" }}
+									style={{ fontSize: "calc(12px * var(--roo-font-size-multiplier, 1))" }}
 								/>
 							</StandardTooltip>
 						</div>
@@ -567,7 +567,7 @@ export const OpenAICompatible = ({
 										content={t("settings:providers.customModel.pricing.cacheReads.description")}>
 										<i
 											className="codicon codicon-info text-vscode-descriptionForeground"
-											style={{ fontSize: "12px" }}
+											style={{ fontSize: "calc(12px * var(--roo-font-size-multiplier, 1))" }}
 										/>
 									</StandardTooltip>
 								</div>
@@ -609,7 +609,7 @@ export const OpenAICompatible = ({
 										content={t("settings:providers.customModel.pricing.cacheWrites.description")}>
 										<i
 											className="codicon codicon-info text-vscode-descriptionForeground"
-											style={{ fontSize: "12px" }}
+											style={{ fontSize: "calc(12px * var(--roo-font-size-multiplier, 1))" }}
 										/>
 									</StandardTooltip>
 								</div>

--- a/webview-ui/src/components/settings/providers/Requesty.tsx
+++ b/webview-ui/src/components/settings/providers/Requesty.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react"
-import { VSCodeCheckbox, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
+import { Checkbox } from "@/components/ui/checkbox"
 
 import { type ProviderSettings, type OrganizationAllowList, requestyDefaultModelId } from "@roo-code/types"
 
@@ -100,18 +101,20 @@ export const Requesty = ({
 				</a>
 			)}
 
-			<VSCodeCheckbox
-				checked={requestyEndpointSelected}
-				onChange={(e: any) => {
-					const isChecked = e.target.checked === true
-					if (!isChecked) {
-						setApiConfigurationField("requestyBaseUrl", undefined)
-					}
+			<div className="flex items-center space-x-2">
+				<Checkbox
+					checked={requestyEndpointSelected}
+					onCheckedChange={(checked) => {
+						const isChecked = checked === true
+						if (!isChecked) {
+							setApiConfigurationField("requestyBaseUrl", undefined)
+						}
 
-					setRequestyEndpointSelected(isChecked)
-				}}>
-				{t("settings:providers.requestyUseCustomBaseUrl")}
-			</VSCodeCheckbox>
+						setRequestyEndpointSelected(isChecked)
+					}}
+				/>
+				<span>{t("settings:providers.requestyUseCustomBaseUrl")}</span>
+			</div>
 			{requestyEndpointSelected && (
 				<VSCodeTextField
 					value={apiConfiguration?.requestyBaseUrl || ""}

--- a/webview-ui/src/components/settings/styles.ts
+++ b/webview-ui/src/components/settings/styles.ts
@@ -15,7 +15,7 @@ export const StyledMarkdown = styled.div`
 		"Open Sans",
 		"Helvetica Neue",
 		sans-serif;
-	font-size: 12px;
+	font-size: calc(12px * var(--roo-font-size-multiplier, 1));
 	color: var(--vscode-descriptionForeground);
 
 	p,

--- a/webview-ui/src/components/ui/button.tsx
+++ b/webview-ui/src/components/ui/button.tsx
@@ -13,8 +13,7 @@ const buttonVariants = cva(
 				destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
 				outline:
 					"border border-vscode-input-border bg-transparent hover:bg-accent hover:text-accent-foreground",
-				secondary:
-					"border border-vscode-input-border bg-secondary text-secondary-foreground hover:bg-secondary/80",
+				secondary: "border border-secondary bg-secondary text-secondary-foreground hover:bg-secondary/80",
 				ghost: "hover:bg-accent hover:text-accent-foreground",
 				link: "text-primary underline-offset-4 hover:underline",
 				combobox:

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -266,6 +266,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		maxDiagnosticMessages: 50,
 		openRouterImageApiKey: "",
 		openRouterImageGenerationSelectedModel: "",
+		fontSizeMultiplier: 1.0,
 	})
 
 	const [didHydrateState, setDidHydrateState] = useState(false)

--- a/webview-ui/src/context/__tests__/ExtensionStateContext.spec.tsx
+++ b/webview-ui/src/context/__tests__/ExtensionStateContext.spec.tsx
@@ -214,12 +214,14 @@ describe("mergeExtensionState", () => {
 			remoteControlEnabled: false,
 			taskSyncEnabled: false,
 			featureRoomoteControlEnabled: false,
+			fontSizeMultiplier: 1.0,
 		}
 
 		const prevState: ExtensionState = {
 			...baseState,
 			apiConfiguration: { modelMaxTokens: 1234, modelMaxThinkingTokens: 123 },
 			experiments: {} as Record<ExperimentId, boolean>,
+			fontSizeMultiplier: 1.0,
 		}
 
 		const newState: ExtensionState = {
@@ -236,6 +238,7 @@ describe("mergeExtensionState", () => {
 				imageGeneration: false,
 				runSlashCommand: false,
 			} as Record<ExperimentId, boolean>,
+			fontSizeMultiplier: 1.0,
 		}
 
 		const result = mergeExtensionState(prevState, newState)

--- a/webview-ui/src/index.css
+++ b/webview-ui/src/index.css
@@ -23,12 +23,12 @@
 @plugin "tailwindcss-animate";
 
 @theme {
-	--font-display: var(--vscode-font-family);
-
-	--text-xs: calc(var(--vscode-font-size) * 0.85);
-	--text-sm: calc(var(--vscode-font-size) * 0.9);
-	--text-base: var(--vscode-font-size);
-	--text-lg: calc(var(--vscode-font-size) * 1.1);
+	--text-xs: calc(var(--vscode-font-size) * 0.85 * var(--roo-font-size-multiplier, 1));
+	--text-sm: calc(var(--vscode-font-size) * 0.9 * var(--roo-font-size-multiplier, 1));
+	--text-base: calc(var(--vscode-font-size) * var(--roo-font-size-multiplier, 1));
+	--text-lg: calc(var(--vscode-font-size) * 1.1 * var(--roo-font-size-multiplier, 1));
+	--text-xl: calc(var(--vscode-font-size) * 1.2 * var(--roo-font-size-multiplier, 1));
+	--text-2xl: calc(var(--vscode-font-size) * 1.4 * var(--roo-font-size-multiplier, 1));
 
 	--color-background: var(--background);
 	--color-foreground: var(--foreground);
@@ -147,6 +147,9 @@
 
 @layer base {
 	:root {
+		--roo-font-size-multiplier: 1;
+		--type-ramp-base-font-size: calc(var(--vscode-font-size) * var(--roo-font-size-multiplier, 1)) !important;
+
 		--background: var(--vscode-editor-background);
 		--foreground: var(--vscode-editor-foreground);
 		--card: var(--vscode-editor-background);
@@ -230,6 +233,7 @@ html {
 body {
 	margin: 0;
 	line-height: 1.25;
+	font-size: calc(var(--vscode-font-size) * var(--roo-font-size-multiplier, 1));
 }
 
 body.scrollable,
@@ -339,7 +343,7 @@ body:focus-within .code-block-scrollable {
 	display: block;
 	color: var(--vscode-foreground);
 	cursor: pointer;
-	font-size: var(--vscode-font-size);
+	font-size: calc(var(--vscode-font-size) * var(--roo-font-size-multiplier, 1));
 	line-height: normal;
 	margin-bottom: 2px;
 }

--- a/webview-ui/src/preflight.css
+++ b/webview-ui/src/preflight.css
@@ -131,7 +131,7 @@ pre {
 	); /* 4 */
 	font-feature-settings: var(--default-mono-font-feature-settings, normal); /* 5 */
 	font-variation-settings: var(--default-mono-font-variation-settings, normal); /* 6 */
-	font-size: 1em; /* 4 */
+	font-size: calc(1em * var(--roo-font-size-multiplier, 1)); /* 4 */
 }
 
 /*
@@ -139,7 +139,7 @@ pre {
 */
 
 small {
-	font-size: 80%;
+	font-size: calc(80% * var(--roo-font-size-multiplier, 1));
 }
 
 /*
@@ -148,7 +148,7 @@ small {
 
 sub,
 sup {
-	font-size: 75%;
+	font-size: calc(75% * var(--roo-font-size-multiplier, 1));
 	line-height: 0;
 	position: relative;
 	vertical-align: baseline;


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #8100

### Roo Code Task Context (Optional)

<!--
If you used Roo Code to help create this PR, you can share public task links here.
This helps reviewers understand your development process and provides additional context.
Example: https://app.roocode.com/share/task-id
-->

### Description

This PR adds the ability to scale the font size inside Roo's window. I didn't go with small, medium, large and instead went with multiplier because it gives the user more flexibility.
I didn't add mouse wheel binding or keyboard binding by default because it's already used by the editor and I prefer to leave that choice to the users.

We now have these two new commands:

<img width="598" height="98" alt="image" src="https://github.com/user-attachments/assets/2ee96c59-9da9-4594-81ca-3657fc5427f4" />

Along with a configurable setting using `roo-cline.fontSizeMultiplier` that the users can configure themselves.

As a side effect, I've also replaced a few components due to them being a web components, which prevents me from updating the font-size because they're using shadow DOM. This change shouldn't matter that much, it only adds consistency to the UI.

### Test Procedure

Change the settings or use the provided command from the command palette and observe the change. The only part that changes is the font size.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

Normal size: 

<img width="363" height="968" alt="image" src="https://github.com/user-attachments/assets/62ebf62a-c82d-4946-b2e8-01954a78f554" />

Smol size:

<img width="361" height="963" alt="image" src="https://github.com/user-attachments/assets/f595ec2c-6361-4599-973a-54a13617b5ff" />

Comically large size:

<img width="357" height="955" alt="image" src="https://github.com/user-attachments/assets/96c117a2-beaa-4d39-89bb-aeddf2c8b69a" />


### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

### Additional Notes

While working on this I also found that we used different ways of stylings. Might worth to revisit that in the future for consistencies.

Also, the issue didn't explain the scope on which section should have the size changed. I'm not sure if we only want to change the font in the chat? I *think* that's what we want because the rest can be changed using vscode settings, but for now I went with changing everything for consistency.

Let me know which one is the correct one and I'll update this PR :)

### Get in Touch

@elianiva
