### PR TITLE
Clamp GPT-5 max output tokens to 20% of context window

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -116,17 +116,7 @@ export const getModelMaxOutputTokens = ({
 	}
 
 	// If model has explicit maxTokens, clamp it to 20% of the context window
-	// Exception: GPT-5 models should use their exact configured max output tokens
 	if (model.maxTokens) {
-		// Check if this is a GPT-5 model (case-insensitive)
-		const isGpt5Model = modelId.toLowerCase().includes("gpt-5")
-
-		// GPT-5 models bypass the 20% cap and use their full configured max tokens
-		if (isGpt5Model) {
-			return model.maxTokens
-		}
-
-		// All other models are clamped to 20% of context window
 		return Math.min(model.maxTokens, Math.ceil(model.contextWindow * 0.2))
 	}
 


### PR DESCRIPTION
This PR standardizes GPT-5 output token limits with all other models:\n\n- Remove GPT-5 exception in [getModelMaxOutputTokens()](src/shared/api.ts:83) so max output = min(model.maxTokens, ceil(0.2 * contextWindow)).\n- Update tests accordingly: [src/shared/__tests__/api.spec.ts](src/shared/__tests__/api.spec.ts:197), [src/shared/__tests__/api.spec.ts](src/shared/__tests__/api.spec.ts:249).\n- Verified locally: all tests passing (298 files, 3906 tests).\n\nExample: 400k context → 80k max output tokens.\n\nRationale: Aligns GPT-5 behavior (including OpenRouter) with other models and avoids oversized completions when providers report very high max_completion_tokens.