### PR TITLE
fix(claude-code): workaround reserved tool name collision (read_file)

### DIFF
--- a/src/api/providers/claude-code.ts
+++ b/src/api/providers/claude-code.ts
@@ -32,10 +32,10 @@ import { convertOpenAIToolsToAnthropic } from "../../core/prompts/tools/native-t
  * Workaround: namespace reserved tool names before sending the request, and map tool call names back
  * so the rest of Roo’s tool routing remains unchanged.
  */
-const RESERVED_ANTHROPIC_TOOL_NAMES = new Set(["read_file"])
-const RESERVED_ANTHROPIC_TOOL_PREFIX = "_"
+export const RESERVED_ANTHROPIC_TOOL_NAMES = new Set(["read_file"])
+export const RESERVED_ANTHROPIC_TOOL_PREFIX = "_"
 
-function patchReservedAnthropicToolNames<T extends { name: string }>(
+export function patchReservedAnthropicToolNames<T extends { name: string }>(
 	tools: T[],
 ): {
 	tools: T[]
@@ -58,7 +58,10 @@ function patchReservedAnthropicToolNames<T extends { name: string }>(
 	return { tools: patchedTools, reverseNameMap }
 }
 
-function unpatchToolName(name: string, reverseNameMap: Map<string, string>): string {
+export function unpatchToolName(name: string | undefined, reverseNameMap: Map<string, string>): string | undefined {
+	if (name === undefined) {
+		return undefined
+	}
 	return reverseNameMap.get(name) ?? name
 }
 
@@ -278,8 +281,7 @@ export class ClaudeCodeHandler implements ApiHandler, SingleCompletionHandler {
 							type: "tool_call_partial",
 							index: chunk.index,
 							id: chunk.id,
-							// chunk.name is expected to always exist for tool calls
-							name: unpatchToolName(chunk.name as string, reverseNameMap),
+							name: unpatchToolName(chunk.name, reverseNameMap),
 							arguments: chunk.arguments,
 						}
 						break


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #10867

### Roo Code Task Context (Optional)

<!--
If you used Roo Code to help create this PR, you can share public task links here.
This helps reviewers understand your development process and provides additional context.
Example: https://app.roocode.com/share/task-id
-->

### Description

<!--
Briefly summarize the changes in this PR and how they address the linked issue.
The issue should cover the "what" and "why"; this section should focus on:
- The "how": key implementation details, design choices, or trade-offs made.
- Anything specific reviewers should pay attention to in this PR.
-->

Claude Code OAuth API requests fail when a tool is named `read_file`.
This PR adds a small workaround by renaming the tool before sending it to Claude Code (e.g. `read_file` → `_read_file`).

Notes for reviewers:
- This appears to be a reserved-name collision / backend validation issue on the Claude Code side.
- The change is intentionally minimal and only affects the tool name used in the outgoing request, keeping the tool schema unchanged otherwise.

### Test Procedure

<!--
Detail the steps to test your changes. This helps reviewers verify your work.
- How did you test this specific implementation? (e.g., unit tests, manual testing steps)
- How can reviewers reproduce your tests or verify the fix/feature?
- Include relevant testing environment details if applicable.
-->

1. Open Roo Code and sign in via Claude Code OAuth.
2. Trigger any request that includes the `read_file` tool (e.g. ask Roo Code to read a file from the workspace).
3. Verify the request succeeds (previously failed before this change).
4. Optionally confirm that tool calls still work as expected after the rename workaround.


### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [ ] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->

If the Claude Code OAuth gateway treats `read_file` as a reserved/system tool name, this workaround prevents collisions while keeping Roo Code behavior unchanged for users.

### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->
Discord: loject
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes tool name collision in Claude Code OAuth by renaming `read_file` to `_read_file` in `claude-code.ts`.
> 
>   - **Behavior**:
>     - Adds `patchReservedAnthropicToolNames()` and `unpatchToolName()` functions in `claude-code.ts` to rename `read_file` tool to `_read_file` before sending requests.
>     - Updates `createMessage()` in `ClaudeCodeHandler` to apply the renaming workaround for reserved tool names.
>   - **Misc**:
>     - Adds constants `RESERVED_ANTHROPIC_TOOL_NAMES` and `RESERVED_ANTHROPIC_TOOL_PREFIX` in `claude-code.ts` for managing reserved tool names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 9abd22764287833bbe1f6e37f2f11f8199a2cf09. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->