### PR TITLE
feat(openai-codex): profile-scoped oauth + email/limits

### DIFF
--- a/packages/types/src/vscode-extension-host.ts
+++ b/packages/types/src/vscode-extension-host.ts
@@ -403,6 +403,7 @@ export type ExtensionState = Pick<
 	taskSyncEnabled: boolean
 	featureRoomoteControlEnabled: boolean
 	openAiCodexIsAuthenticated?: boolean
+	openAiCodexAccountEmail?: string | null
 	debug?: boolean
 }
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2105,6 +2105,21 @@ export class ClineProvider
 		const currentMode = mode ?? defaultModeSlug
 		const hasSystemPromptOverride = await this.hasFileBasedSystemPromptOverride(currentMode)
 
+		const openAiCodexProfileId = Array.isArray(listApiConfigMeta)
+			? listApiConfigMeta.find((profile) => profile.name === currentApiConfigName)?.id
+			: undefined
+		let openAiCodexIsAuthenticated = false
+		let openAiCodexAccountEmail: string | null = null
+
+		try {
+			const { openAiCodexOAuthManager } = await import("../../integrations/openai-codex/oauth")
+			openAiCodexIsAuthenticated = await openAiCodexOAuthManager.isAuthenticated(openAiCodexProfileId)
+			openAiCodexAccountEmail = await openAiCodexOAuthManager.getEmail(openAiCodexProfileId)
+		} catch {
+			openAiCodexIsAuthenticated = false
+			openAiCodexAccountEmail = null
+		}
+
 		return {
 			version: this.context.extension?.packageJSON?.version ?? "",
 			apiConfiguration,
@@ -2232,14 +2247,8 @@ export class ClineProvider
 			openRouterImageApiKey,
 			openRouterImageGenerationSelectedModel,
 			featureRoomoteControlEnabled,
-			openAiCodexIsAuthenticated: await (async () => {
-				try {
-					const { openAiCodexOAuthManager } = await import("../../integrations/openai-codex/oauth")
-					return await openAiCodexOAuthManager.isAuthenticated()
-				} catch {
-					return false
-				}
-			})(),
+			openAiCodexIsAuthenticated,
+			openAiCodexAccountEmail,
 			debug: vscode.workspace.getConfiguration(Package.name).get<boolean>("debug", false),
 		}
 	}

--- a/src/core/webview/__tests__/webviewMessageHandler.spec.ts
+++ b/src/core/webview/__tests__/webviewMessageHandler.spec.ts
@@ -599,6 +599,10 @@ describe("webviewMessageHandler - requestRouterModels", () => {
 describe("webviewMessageHandler - requestOpenAiCodexRateLimits", () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
+		mockClineProvider.getState = vi.fn().mockResolvedValue({
+			currentApiConfigName: "test-profile",
+			listApiConfigMeta: [{ id: "test-profile-id", name: "test-profile" }],
+		})
 		mockGetAccessToken.mockResolvedValue(null)
 		mockGetAccountId.mockResolvedValue(null)
 	})

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -2385,14 +2385,16 @@ export const webviewMessageHandler = async (
 		case "openAiCodexSignIn": {
 			try {
 				const { openAiCodexOAuthManager } = await import("../../integrations/openai-codex/oauth")
-				const authUrl = openAiCodexOAuthManager.startAuthorizationFlow()
+				const { currentApiConfigName, listApiConfigMeta } = await provider.getState()
+				const profileId = listApiConfigMeta?.find((profile) => profile.name === currentApiConfigName)?.id
+				const authUrl = openAiCodexOAuthManager.startAuthorizationFlow(profileId)
 
 				// Open the authorization URL in the browser
 				await vscode.env.openExternal(vscode.Uri.parse(authUrl))
 
 				// Wait for the callback in a separate promise (non-blocking)
 				openAiCodexOAuthManager
-					.waitForCallback()
+					.waitForCallback(profileId)
 					.then(async () => {
 						vscode.window.showInformationMessage("Successfully signed in to OpenAI Codex")
 						await provider.postStateToWebview()
@@ -2412,7 +2414,9 @@ export const webviewMessageHandler = async (
 		case "openAiCodexSignOut": {
 			try {
 				const { openAiCodexOAuthManager } = await import("../../integrations/openai-codex/oauth")
-				await openAiCodexOAuthManager.clearCredentials()
+				const { currentApiConfigName, listApiConfigMeta } = await provider.getState()
+				const profileId = listApiConfigMeta?.find((profile) => profile.name === currentApiConfigName)?.id
+				await openAiCodexOAuthManager.clearCredentials(profileId)
 				vscode.window.showInformationMessage("Signed out from OpenAI Codex")
 				await provider.postStateToWebview()
 			} catch (error) {
@@ -3244,7 +3248,9 @@ export const webviewMessageHandler = async (
 		case "requestOpenAiCodexRateLimits": {
 			try {
 				const { openAiCodexOAuthManager } = await import("../../integrations/openai-codex/oauth")
-				const accessToken = await openAiCodexOAuthManager.getAccessToken()
+				const { currentApiConfigName, listApiConfigMeta } = await provider.getState()
+				const profileId = listApiConfigMeta?.find((profile) => profile.name === currentApiConfigName)?.id
+				const accessToken = await openAiCodexOAuthManager.getAccessToken(profileId)
 
 				if (!accessToken) {
 					provider.postMessageToWebview({
@@ -3254,7 +3260,7 @@ export const webviewMessageHandler = async (
 					break
 				}
 
-				const accountId = await openAiCodexOAuthManager.getAccountId()
+				const accountId = await openAiCodexOAuthManager.getAccountId(profileId)
 				const { fetchOpenAiCodexRateLimitInfo } = await import("../../integrations/openai-codex/rate-limits")
 				const rateLimits = await fetchOpenAiCodexRateLimitInfo(accessToken, { accountId })
 

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -145,7 +145,13 @@ const ApiOptions = ({
 	setErrorMessage,
 }: ApiOptionsProps) => {
 	const { t } = useAppTranslation()
-	const { organizationAllowList, cloudIsAuthenticated, openAiCodexIsAuthenticated } = useExtensionState()
+	const {
+		organizationAllowList,
+		cloudIsAuthenticated,
+		openAiCodexIsAuthenticated,
+		openAiCodexAccountEmail,
+		currentApiConfigName,
+	} = useExtensionState()
 
 	const [customHeaders, setCustomHeaders] = useState<[string, string][]>(() => {
 		const headers = apiConfiguration?.openAiHeaders || {}
@@ -563,6 +569,8 @@ const ApiOptions = ({
 					setApiConfigurationField={setApiConfigurationField}
 					simplifySettings={fromWelcomeView}
 					openAiCodexIsAuthenticated={openAiCodexIsAuthenticated}
+					openAiCodexAccountEmail={openAiCodexAccountEmail}
+					currentApiConfigName={currentApiConfigName}
 				/>
 			)}
 

--- a/webview-ui/src/components/settings/providers/OpenAICodex.tsx
+++ b/webview-ui/src/components/settings/providers/OpenAICodex.tsx
@@ -14,6 +14,8 @@ interface OpenAICodexProps {
 	setApiConfigurationField: (field: keyof ProviderSettings, value: ProviderSettings[keyof ProviderSettings]) => void
 	simplifySettings?: boolean
 	openAiCodexIsAuthenticated?: boolean
+	openAiCodexAccountEmail?: string | null
+	currentApiConfigName?: string
 }
 
 export const OpenAICodex: React.FC<OpenAICodexProps> = ({
@@ -21,6 +23,8 @@ export const OpenAICodex: React.FC<OpenAICodexProps> = ({
 	setApiConfigurationField,
 	simplifySettings,
 	openAiCodexIsAuthenticated = false,
+	openAiCodexAccountEmail,
+	currentApiConfigName,
 }) => {
 	const { t } = useAppTranslation()
 
@@ -29,15 +33,39 @@ export const OpenAICodex: React.FC<OpenAICodexProps> = ({
 			{/* Authentication Section */}
 			<div className="flex flex-col gap-2">
 				{openAiCodexIsAuthenticated ? (
-					<div className="flex justify-end">
-						<Button
-							variant="secondary"
-							size="sm"
-							onClick={() => vscode.postMessage({ type: "openAiCodexSignOut" })}>
-							{t("settings:providers.openAiCodex.signOutButton", {
-								defaultValue: "Sign Out",
-							})}
-						</Button>
+					<div className="flex flex-col gap-2">
+						<div className="flex flex-wrap items-center justify-between gap-2">
+							<div className="flex flex-col gap-1">
+								<div className="text-sm font-medium text-vscode-foreground">
+									{t("settings:providers.openAiCodex.connectedLabel", {
+										defaultValue: "Connected",
+									})}
+								</div>
+								{openAiCodexAccountEmail ? (
+									<div className="text-sm text-vscode-descriptionForeground">
+										{openAiCodexAccountEmail}
+									</div>
+								) : null}
+							</div>
+							<div className="flex items-center gap-2">
+								<Button
+									variant="secondary"
+									size="sm"
+									onClick={() => vscode.postMessage({ type: "openAiCodexSignIn" })}>
+									{t("settings:providers.openAiCodex.reauthButton", {
+										defaultValue: "Reconnect account",
+									})}
+								</Button>
+								<Button
+									variant="secondary"
+									size="sm"
+									onClick={() => vscode.postMessage({ type: "openAiCodexSignOut" })}>
+									{t("settings:providers.openAiCodex.signOutButton", {
+										defaultValue: "Sign Out",
+									})}
+								</Button>
+							</div>
+						</div>
 					</div>
 				) : (
 					<Button
@@ -52,7 +80,10 @@ export const OpenAICodex: React.FC<OpenAICodexProps> = ({
 			</div>
 
 			{/* Rate Limit Dashboard - only shown when authenticated */}
-			<OpenAICodexRateLimitDashboard isAuthenticated={openAiCodexIsAuthenticated} />
+			<OpenAICodexRateLimitDashboard
+				isAuthenticated={openAiCodexIsAuthenticated}
+				currentApiConfigName={currentApiConfigName}
+			/>
 
 			{/* Model Picker */}
 			<ModelPicker

--- a/webview-ui/src/components/settings/providers/OpenAICodexRateLimitDashboard.tsx
+++ b/webview-ui/src/components/settings/providers/OpenAICodexRateLimitDashboard.tsx
@@ -6,6 +6,7 @@ import { vscode } from "@src/utils/vscode"
 
 interface OpenAICodexRateLimitDashboardProps {
 	isAuthenticated: boolean
+	currentApiConfigName?: string
 }
 
 type Translate = (key: string, options?: Record<string, any>) => string
@@ -84,7 +85,10 @@ const UsageProgressBar: React.FC<{ usedPercent: number; label?: string }> = ({ u
 	)
 }
 
-export const OpenAICodexRateLimitDashboard: React.FC<OpenAICodexRateLimitDashboardProps> = ({ isAuthenticated }) => {
+export const OpenAICodexRateLimitDashboard: React.FC<OpenAICodexRateLimitDashboardProps> = ({
+	isAuthenticated,
+	currentApiConfigName,
+}) => {
 	const { t } = useAppTranslation()
 	const [rateLimits, setRateLimits] = useState<OpenAiCodexRateLimitInfo | null>(null)
 	const [isLoading, setIsLoading] = useState(false)
@@ -120,10 +124,13 @@ export const OpenAICodexRateLimitDashboard: React.FC<OpenAICodexRateLimitDashboa
 	}, [])
 
 	useEffect(() => {
+		setRateLimits(null)
+		setError(null)
+		setIsLoading(false)
 		if (isAuthenticated) {
 			fetchRateLimits()
 		}
-	}, [isAuthenticated, fetchRateLimits])
+	}, [isAuthenticated, currentApiConfigName, fetchRateLimits])
 
 	if (!isAuthenticated) return null
 


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #11094 <!-- Replace with the issue number, e.g., Closes: #123 -->

### Roo Code Task Context (Optional)

<!--
If you used Roo Code to help create this PR, you can share public task links here.
This helps reviewers understand your development process and provides additional context.
Example: https://app.roocode.com/share/task-id
-->
https://app.roocode.com/share/d6d78501-039a-4118-a346-6349944ad9dd

### Description

<!--
Briefly summarize the changes in this PR and how they address the linked issue.
The issue should cover the "what" and "why"; this section should focus on:
- The "how": key implementation details, design choices, or trade-offs made.
- Anything specific reviewers should pay attention to in this PR.
-->

- Scoped OpenAI Codex OAuth credentials to provider profiles so each profile maintains its own session and tokens.
- Added account email extraction from id_token to surface the connected account in the UI.
- Refreshed Codex usage limits when switching profiles to avoid stale rate‑limit data.
- Updated webview state/types and UI wiring to pass and display the account email and ensure limits refresh on profile changes.



### Test Procedure

<!--
Detail the steps to test your changes. This helps reviewers verify your work.
- How did you test this specific implementation? (e.g., unit tests, manual testing steps)
- How can reviewers reproduce your tests or verify the fix/feature?
- Include relevant testing environment details if applicable.
-->

1. Install dependencies (workspace root): pnpm install --frozen-lockfile
2. Backend tests: cd src && npx vitest run api/providers/__tests__/openai-codex-native-tool-calls.spec.ts core/webview/__tests__/webviewMessageHandler.spec.ts
3. UI tests: cd webview-ui && npx vitest run src/components/settings/__tests__/ApiOptions.spec.tsx
4. Manual: create multiple OpenAI Codex profiles, authenticate each with different accounts, verify email and usage limits update when switching profiles.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->
<img width="1059" height="898" alt="image" src="https://github.com/user-attachments/assets/360984c4-87ce-4e1b-bc25-45dc76777f41" />

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->
None.


### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->
loject
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces profile-scoped OAuth for OpenAI Codex, adding account email display and refreshing usage limits on profile switch.
> 
>   - **Behavior**:
>     - Scoped OpenAI Codex OAuth credentials to provider profiles in `openai-codex.ts`.
>     - Added account email extraction from `id_token` in `openai-codex.ts`.
>     - Refreshed Codex usage limits on profile switch in `ClineProvider.ts`.
>   - **UI Components**:
>     - Updated `ApiOptions.tsx` to pass `openAiCodexAccountEmail` and `currentApiConfigName`.
>     - Modified `OpenAICodex.tsx` to display account email and handle sign-in/out.
>     - Enhanced `OpenAICodexRateLimitDashboard.tsx` to refresh limits on profile change.
>   - **Misc**:
>     - Added `openAiCodexAccountEmail` to `ExtensionState` in `vscode-extension-host.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 11cddf8bd2573b525c6eda61c6f37523dae5b9ea. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->